### PR TITLE
Config loading with Pydantic validation

### DIFF
--- a/oasisagent/config.py
+++ b/oasisagent/config.py
@@ -1,0 +1,485 @@
+"""Configuration loading and validation for OasisAgent.
+
+Loads config.yaml, interpolates ${VAR} environment variable references,
+and validates against Pydantic models matching ARCHITECTURE.md §11.
+"""
+
+from __future__ import annotations
+
+import os
+import re
+from enum import StrEnum
+from typing import TYPE_CHECKING, Annotated
+
+import yaml
+from pydantic import BaseModel, ConfigDict, Field
+
+if TYPE_CHECKING:
+    from pathlib import Path
+
+
+# ---------------------------------------------------------------------------
+# Environment variable interpolation
+# ---------------------------------------------------------------------------
+
+_ENV_VAR_PATTERN = re.compile(
+    r"\$\{(?P<name>[A-Za-z_][A-Za-z0-9_]*)(?::-(?P<default>[^}]*))?\}"
+)
+
+
+class ConfigError(Exception):
+    """Raised when configuration loading or validation fails."""
+
+
+def _interpolate_env_vars(raw: str) -> str:
+    """Replace ${VAR} and ${VAR:-default} in a raw YAML string.
+
+    Operates on the raw string *before* yaml.safe_load() so that env var
+    references work in any value position, including inside URLs like
+    ``mqtt://${MQTT_HOST}:1883``.
+
+    Raises:
+        ConfigError: If a referenced env var is not set and has no default.
+    """
+    missing: list[str] = []
+
+    def _replace(match: re.Match[str]) -> str:
+        name = match.group("name")
+        default = match.group("default")
+        value = os.environ.get(name)
+        if value is not None:
+            return value
+        if default is not None:
+            return default
+        missing.append(name)
+        return match.group(0)
+
+    result = _ENV_VAR_PATTERN.sub(_replace, raw)
+
+    if missing:
+        names = ", ".join(sorted(set(missing)))
+        raise ConfigError(
+            f"Missing required environment variables: {names}. "
+            f"Set them in your environment or .env file."
+        )
+
+    return result
+
+
+# ---------------------------------------------------------------------------
+# Config loader
+# ---------------------------------------------------------------------------
+
+
+def load_config(path: Path) -> OasisAgentConfig:
+    """Load and validate configuration from a YAML file.
+
+    Args:
+        path: Path to the config.yaml file.
+
+    Returns:
+        Validated OasisAgentConfig instance.
+
+    Raises:
+        ConfigError: If the file is not found, env vars are missing,
+            or validation fails.
+    """
+    if not path.exists():
+        raise ConfigError(
+            f"Config file not found at {path}. "
+            f"Copy config.example.yaml to config.yaml and customize it."
+        )
+
+    raw = path.read_text()
+    interpolated = _interpolate_env_vars(raw)
+
+    try:
+        data = yaml.safe_load(interpolated)
+    except yaml.YAMLError as exc:
+        raise ConfigError(f"Invalid YAML in {path}: {exc}") from exc
+
+    if not isinstance(data, dict):
+        raise ConfigError(f"Config file at {path} must contain a YAML mapping, got {type(data)}.")
+
+    try:
+        return OasisAgentConfig.model_validate(data)
+    except Exception as exc:
+        raise ConfigError(f"Config validation failed: {exc}") from exc
+
+
+# ---------------------------------------------------------------------------
+# Pydantic models — organized bottom-up (leaf models first)
+# ---------------------------------------------------------------------------
+
+
+class LogLevel(StrEnum):
+    """Valid log levels."""
+
+    DEBUG = "debug"
+    INFO = "info"
+    WARNING = "warning"
+    ERROR = "error"
+
+
+# -- Agent ------------------------------------------------------------------
+
+
+class AgentConfig(BaseModel):
+    """Global agent settings."""
+
+    model_config = ConfigDict(extra="forbid")
+
+    name: str = "oasis-agent"
+    log_level: LogLevel = LogLevel.INFO
+    event_queue_size: Annotated[int, Field(ge=1)] = 1000
+    shutdown_timeout: Annotated[int, Field(ge=1)] = 30
+
+
+# -- Ingestion: MQTT --------------------------------------------------------
+
+
+class MqttTopicMapping(BaseModel):
+    """Maps an MQTT topic pattern to event fields."""
+
+    model_config = ConfigDict(extra="forbid")
+
+    pattern: str
+    system: str = "auto"
+    event_type: str = "auto"
+    severity: str = "auto"
+
+
+class MqttIngestionConfig(BaseModel):
+    """MQTT subscriber configuration."""
+
+    model_config = ConfigDict(extra="forbid")
+
+    enabled: bool = True
+    broker: str = "mqtt://localhost:1883"
+    username: str = ""
+    password: str = ""
+    client_id: str = "oasis-agent"
+    qos: Annotated[int, Field(ge=0, le=2)] = 1
+    topics: list[MqttTopicMapping] = Field(default_factory=list)
+
+
+# -- Ingestion: HA WebSocket ------------------------------------------------
+
+
+class StateChangesSubscription(BaseModel):
+    """Config for HA state_changed event filtering."""
+
+    model_config = ConfigDict(extra="forbid")
+
+    enabled: bool = True
+    trigger_states: list[str] = Field(default_factory=lambda: ["unavailable", "unknown"])
+    ignore_entities: list[str] = Field(default_factory=list)
+    min_duration: Annotated[int, Field(ge=0)] = 60
+
+
+class AutomationFailuresSubscription(BaseModel):
+    """Config for HA automation failure tracking."""
+
+    model_config = ConfigDict(extra="forbid")
+
+    enabled: bool = True
+
+
+class ServiceCallErrorsSubscription(BaseModel):
+    """Config for HA service call error tracking."""
+
+    model_config = ConfigDict(extra="forbid")
+
+    enabled: bool = True
+
+
+class HaWebSocketSubscriptions(BaseModel):
+    """HA WebSocket subscription configuration."""
+
+    model_config = ConfigDict(extra="forbid")
+
+    state_changes: StateChangesSubscription = Field(default_factory=StateChangesSubscription)
+    automation_failures: AutomationFailuresSubscription = Field(
+        default_factory=AutomationFailuresSubscription
+    )
+    service_call_errors: ServiceCallErrorsSubscription = Field(
+        default_factory=ServiceCallErrorsSubscription
+    )
+
+
+class HaWebSocketConfig(BaseModel):
+    """Home Assistant WebSocket ingestion configuration."""
+
+    model_config = ConfigDict(extra="forbid")
+
+    enabled: bool = True
+    url: str = "ws://localhost:8123/api/websocket"
+    token: str = ""
+    subscriptions: HaWebSocketSubscriptions = Field(default_factory=HaWebSocketSubscriptions)
+
+
+# -- Ingestion: HA Log Poller -----------------------------------------------
+
+
+class LogPattern(BaseModel):
+    """Pattern for matching HA log entries."""
+
+    model_config = ConfigDict(extra="forbid")
+
+    regex: str
+    event_type: str
+    severity: str = "warning"
+
+
+class HaLogPollerConfig(BaseModel):
+    """Home Assistant log poller configuration."""
+
+    model_config = ConfigDict(extra="forbid")
+
+    enabled: bool = True
+    url: str = "http://localhost:8123"
+    token: str = ""
+    poll_interval: Annotated[int, Field(ge=1)] = 30
+    patterns: list[LogPattern] = Field(default_factory=list)
+    dedup_window: Annotated[int, Field(ge=0)] = 300
+
+
+# -- Ingestion (top-level) --------------------------------------------------
+
+
+class IngestionConfig(BaseModel):
+    """All ingestion adapter configurations."""
+
+    model_config = ConfigDict(extra="forbid")
+
+    mqtt: MqttIngestionConfig = Field(default_factory=MqttIngestionConfig)
+    ha_websocket: HaWebSocketConfig = Field(default_factory=HaWebSocketConfig)
+    ha_log_poller: HaLogPollerConfig = Field(default_factory=HaLogPollerConfig)
+
+
+# -- LLM -------------------------------------------------------------------
+
+
+class LlmEndpointConfig(BaseModel):
+    """Configuration for a single LLM endpoint (triage or reasoning)."""
+
+    model_config = ConfigDict(extra="forbid")
+
+    base_url: str
+    model: str
+    api_key: str = ""
+    timeout: Annotated[int, Field(ge=1)] = 30
+    max_tokens: Annotated[int, Field(ge=1)] = 2048
+    temperature: Annotated[float, Field(ge=0.0, le=2.0)] = 0.1
+
+
+class LlmOptionsConfig(BaseModel):
+    """Shared LLM client options."""
+
+    model_config = ConfigDict(extra="forbid")
+
+    cost_tracking: bool = True
+    retry_attempts: Annotated[int, Field(ge=0)] = 2
+    fallback_to_triage: bool = True
+    log_prompts: bool = False
+
+
+class LlmConfig(BaseModel):
+    """LLM configuration — triage (T1) and reasoning (T2) endpoints."""
+
+    model_config = ConfigDict(extra="forbid")
+
+    triage: LlmEndpointConfig = Field(
+        default_factory=lambda: LlmEndpointConfig(
+            base_url="http://localhost:11434/v1",
+            model="qwen2.5:7b",
+            api_key="not-needed",
+            timeout=5,
+            max_tokens=1024,
+            temperature=0.1,
+        )
+    )
+    reasoning: LlmEndpointConfig = Field(
+        default_factory=lambda: LlmEndpointConfig(
+            base_url="https://api.anthropic.com",
+            model="claude-sonnet-4-5-20250929",
+            api_key="",
+            timeout=45,
+            max_tokens=4096,
+            temperature=0.2,
+        )
+    )
+    options: LlmOptionsConfig = Field(default_factory=LlmOptionsConfig)
+
+
+# -- Handlers ---------------------------------------------------------------
+
+
+class HaHandlerConfig(BaseModel):
+    """Home Assistant handler configuration."""
+
+    model_config = ConfigDict(extra="forbid")
+
+    enabled: bool = True
+    url: str = "http://localhost:8123"
+    token: str = ""
+    verify_timeout: Annotated[int, Field(ge=1)] = 30
+
+
+class DockerHandlerConfig(BaseModel):
+    """Docker handler configuration."""
+
+    model_config = ConfigDict(extra="forbid")
+
+    enabled: bool = False
+    socket: str = "unix:///var/run/docker.sock"
+    url: str | None = None
+    tls_verify: bool = True
+
+
+class ProxmoxHandlerConfig(BaseModel):
+    """Proxmox handler configuration."""
+
+    model_config = ConfigDict(extra="forbid")
+
+    enabled: bool = False
+    url: str = "https://localhost:8006"
+    user: str = ""
+    token_name: str = ""
+    token_value: str = ""
+    verify_ssl: bool = False
+
+
+class HandlersConfig(BaseModel):
+    """All handler configurations."""
+
+    model_config = ConfigDict(extra="forbid")
+
+    homeassistant: HaHandlerConfig = Field(default_factory=HaHandlerConfig)
+    docker: DockerHandlerConfig = Field(default_factory=DockerHandlerConfig)
+    proxmox: ProxmoxHandlerConfig = Field(default_factory=ProxmoxHandlerConfig)
+
+
+# -- Guardrails -------------------------------------------------------------
+
+
+class CircuitBreakerConfig(BaseModel):
+    """Circuit breaker settings to prevent remediation loops."""
+
+    model_config = ConfigDict(extra="forbid")
+
+    max_attempts_per_entity: Annotated[int, Field(ge=1)] = 3
+    window_minutes: Annotated[int, Field(ge=1)] = 60
+    cooldown_minutes: Annotated[int, Field(ge=1)] = 15
+    global_failure_rate_threshold: Annotated[float, Field(gt=0.0, le=1.0)] = 0.3
+    global_pause_minutes: Annotated[int, Field(ge=1)] = 30
+
+
+class GuardrailsConfig(BaseModel):
+    """Safety guardrails — enforced in code, not model prompts."""
+
+    model_config = ConfigDict(extra="forbid")
+
+    blocked_domains: list[str] = Field(
+        default_factory=lambda: [
+            "lock.*",
+            "alarm_control_panel.*",
+            "camera.*",
+            "cover.*",
+        ]
+    )
+    blocked_entities: list[str] = Field(default_factory=list)
+    kill_switch: bool = False
+    dry_run: bool = False
+    circuit_breaker: CircuitBreakerConfig = Field(default_factory=CircuitBreakerConfig)
+
+
+# -- Audit ------------------------------------------------------------------
+
+
+class InfluxDbConfig(BaseModel):
+    """InfluxDB v2 connection configuration."""
+
+    model_config = ConfigDict(extra="forbid")
+
+    enabled: bool = True
+    url: str = "http://localhost:8086"
+    token: str = ""
+    org: str = "myorg"
+    bucket: str = "oasisagent"
+
+
+class AuditConfig(BaseModel):
+    """Audit logging configuration."""
+
+    model_config = ConfigDict(extra="forbid")
+
+    influxdb: InfluxDbConfig = Field(default_factory=InfluxDbConfig)
+    retention_days: Annotated[int, Field(ge=1)] = 90
+
+
+# -- Notifications ----------------------------------------------------------
+
+
+class MqttNotificationConfig(BaseModel):
+    """MQTT notification channel configuration."""
+
+    model_config = ConfigDict(extra="forbid")
+
+    enabled: bool = True
+    broker: str = "mqtt://localhost:1883"
+    topic_prefix: str = "oasis/notifications"
+    username: str = ""
+    password: str = ""
+
+
+class EmailNotificationConfig(BaseModel):
+    """Email (SMTP) notification channel configuration."""
+
+    model_config = ConfigDict(extra="forbid")
+
+    enabled: bool = False
+    smtp_host: str = "localhost"
+    smtp_port: Annotated[int, Field(ge=1, le=65535)] = 587
+    from_address: str = Field(default="oasis-agent@example.com", alias="from")
+    to: list[str] = Field(default_factory=list)
+
+
+class WebhookNotificationConfig(BaseModel):
+    """Webhook notification channel configuration."""
+
+    model_config = ConfigDict(extra="forbid")
+
+    enabled: bool = False
+    urls: list[str] = Field(default_factory=list)
+
+
+class NotificationsConfig(BaseModel):
+    """All notification channel configurations."""
+
+    model_config = ConfigDict(extra="forbid")
+
+    mqtt: MqttNotificationConfig = Field(default_factory=MqttNotificationConfig)
+    email: EmailNotificationConfig = Field(default_factory=EmailNotificationConfig)
+    webhook: WebhookNotificationConfig = Field(default_factory=WebhookNotificationConfig)
+
+
+# -- Top-level config -------------------------------------------------------
+
+
+class OasisAgentConfig(BaseModel):
+    """Top-level OasisAgent configuration.
+
+    Represents the complete config.yaml schema as defined in
+    ARCHITECTURE.md §11.
+    """
+
+    model_config = ConfigDict(extra="forbid")
+
+    agent: AgentConfig = Field(default_factory=AgentConfig)
+    ingestion: IngestionConfig = Field(default_factory=IngestionConfig)
+    llm: LlmConfig = Field(default_factory=LlmConfig)
+    handlers: HandlersConfig = Field(default_factory=HandlersConfig)
+    guardrails: GuardrailsConfig = Field(default_factory=GuardrailsConfig)
+    audit: AuditConfig = Field(default_factory=AuditConfig)
+    notifications: NotificationsConfig = Field(default_factory=NotificationsConfig)

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -1,0 +1,508 @@
+"""Tests for configuration loading and validation."""
+
+from __future__ import annotations
+
+from textwrap import dedent
+from typing import TYPE_CHECKING
+
+import pytest
+
+if TYPE_CHECKING:
+    from pathlib import Path
+
+from oasisagent.config import (
+    ConfigError,
+    LogLevel,
+    OasisAgentConfig,
+    _interpolate_env_vars,
+    load_config,
+)
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _write_config(tmp_path: Path, content: str) -> Path:
+    """Write a config YAML string to a temp file and return its path."""
+    config_file = tmp_path / "config.yaml"
+    config_file.write_text(dedent(content))
+    return config_file
+
+
+def _minimal_config() -> str:
+    """Return a minimal valid config YAML string (all sections use defaults)."""
+    return """\
+        agent:
+          name: test-agent
+    """
+
+
+def _full_config() -> str:
+    """Return a full config YAML with all sections populated."""
+    return """\
+        agent:
+          name: test-agent
+          log_level: debug
+          event_queue_size: 500
+          shutdown_timeout: 10
+
+        ingestion:
+          mqtt:
+            enabled: true
+            broker: mqtt://broker:1883
+            username: user
+            password: pass
+            client_id: test
+            qos: 1
+            topics:
+              - pattern: "ha/error/#"
+                system: homeassistant
+                event_type: automation_error
+                severity: error
+              - pattern: "oasis/alerts/#"
+                system: auto
+                event_type: auto
+                severity: auto
+          ha_websocket:
+            enabled: true
+            url: ws://ha:8123/api/websocket
+            token: test-token
+            subscriptions:
+              state_changes:
+                enabled: true
+                trigger_states: ["unavailable"]
+                ignore_entities: ["sensor.flaky"]
+                min_duration: 120
+              automation_failures:
+                enabled: false
+              service_call_errors:
+                enabled: true
+          ha_log_poller:
+            enabled: true
+            url: http://ha:8123
+            token: test-token
+            poll_interval: 15
+            dedup_window: 600
+            patterns:
+              - regex: "Error setting up integration '(.+)'"
+                event_type: integration_failure
+                severity: error
+
+        llm:
+          triage:
+            base_url: http://ollama:11434/v1
+            model: qwen2.5:7b
+            api_key: not-needed
+            timeout: 5
+            max_tokens: 1024
+            temperature: 0.1
+          reasoning:
+            base_url: https://api.anthropic.com
+            model: claude-sonnet-4-5-20250929
+            api_key: sk-test
+            timeout: 45
+            max_tokens: 4096
+            temperature: 0.2
+          options:
+            cost_tracking: true
+            retry_attempts: 3
+            fallback_to_triage: false
+            log_prompts: true
+
+        handlers:
+          homeassistant:
+            enabled: true
+            url: http://ha:8123
+            token: test-token
+            verify_timeout: 60
+          docker:
+            enabled: false
+            socket: unix:///var/run/docker.sock
+          proxmox:
+            enabled: false
+            url: https://pve:8006
+            user: root@pam
+            token_name: agent
+            token_value: secret
+            verify_ssl: false
+
+        guardrails:
+          blocked_domains:
+            - "lock.*"
+            - "alarm_control_panel.*"
+          blocked_entities:
+            - "switch.dangerous"
+          kill_switch: false
+          dry_run: true
+          circuit_breaker:
+            max_attempts_per_entity: 5
+            window_minutes: 30
+            cooldown_minutes: 10
+            global_failure_rate_threshold: 0.5
+            global_pause_minutes: 60
+
+        audit:
+          influxdb:
+            enabled: true
+            url: http://influx:8086
+            token: influx-token
+            org: myorg
+            bucket: oasisagent
+          retention_days: 30
+
+        notifications:
+          mqtt:
+            enabled: true
+            broker: mqtt://broker:1883
+            topic_prefix: oasis/notify
+            username: user
+            password: pass
+          email:
+            enabled: false
+          webhook:
+            enabled: false
+    """
+
+
+# ---------------------------------------------------------------------------
+# Environment variable interpolation
+# ---------------------------------------------------------------------------
+
+
+class TestEnvVarInterpolation:
+    """Tests for ${VAR} and ${VAR:-default} interpolation."""
+
+    def test_simple_substitution(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.setenv("MY_VAR", "hello")
+        assert _interpolate_env_vars("value: ${MY_VAR}") == "value: hello"
+
+    def test_default_value_when_unset(self) -> None:
+        result = _interpolate_env_vars("key: ${UNSET_VAR:-fallback}")
+        assert result == "key: fallback"
+
+    def test_default_value_empty_string(self) -> None:
+        result = _interpolate_env_vars("key: ${UNSET_VAR:-}")
+        assert result == "key: "
+
+    def test_env_var_overrides_default(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.setenv("MY_VAR", "real")
+        result = _interpolate_env_vars("key: ${MY_VAR:-fallback}")
+        assert result == "key: real"
+
+    def test_missing_required_var_raises(self) -> None:
+        with pytest.raises(ConfigError, match="MISSING_VAR"):
+            _interpolate_env_vars("key: ${MISSING_VAR}")
+
+    def test_multiple_missing_vars_reported(self) -> None:
+        with pytest.raises(ConfigError, match="ALPHA") as exc_info:
+            _interpolate_env_vars("a: ${ALPHA}\nb: ${BETA}")
+        assert "BETA" in str(exc_info.value)
+
+    def test_embedded_in_url(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.setenv("HOST", "192.168.1.100")
+        monkeypatch.setenv("PORT", "1883")
+        result = _interpolate_env_vars("broker: mqtt://${HOST}:${PORT}")
+        assert result == "broker: mqtt://192.168.1.100:1883"
+
+    def test_no_interpolation_needed(self) -> None:
+        raw = "key: plain_value"
+        assert _interpolate_env_vars(raw) == raw
+
+    def test_multiple_on_same_line(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.setenv("A", "1")
+        monkeypatch.setenv("B", "2")
+        result = _interpolate_env_vars("${A} and ${B}")
+        assert result == "1 and 2"
+
+
+# ---------------------------------------------------------------------------
+# Config loading
+# ---------------------------------------------------------------------------
+
+
+class TestLoadConfig:
+    """Tests for the load_config() function."""
+
+    def test_file_not_found(self, tmp_path: Path) -> None:
+        with pytest.raises(ConfigError, match="Config file not found"):
+            load_config(tmp_path / "nonexistent.yaml")
+
+    def test_file_not_found_message_suggests_example(self, tmp_path: Path) -> None:
+        with pytest.raises(ConfigError, match=r"config\.example\.yaml"):
+            load_config(tmp_path / "config.yaml")
+
+    def test_minimal_config_loads(self, tmp_path: Path) -> None:
+        path = _write_config(tmp_path, _minimal_config())
+        config = load_config(path)
+        assert isinstance(config, OasisAgentConfig)
+        assert config.agent.name == "test-agent"
+
+    def test_full_config_loads(self, tmp_path: Path) -> None:
+        path = _write_config(tmp_path, _full_config())
+        config = load_config(path)
+        assert config.agent.name == "test-agent"
+        assert config.agent.log_level == LogLevel.DEBUG
+        assert config.agent.event_queue_size == 500
+
+    def test_env_var_in_config(self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.setenv("TEST_TOKEN", "my-secret-token")
+        content = """\
+            handlers:
+              homeassistant:
+                token: ${TEST_TOKEN}
+        """
+        path = _write_config(tmp_path, content)
+        config = load_config(path)
+        assert config.handlers.homeassistant.token == "my-secret-token"
+
+    def test_missing_env_var_raises(self, tmp_path: Path) -> None:
+        content = """\
+            handlers:
+              homeassistant:
+                token: ${MISSING_TOKEN}
+        """
+        path = _write_config(tmp_path, content)
+        with pytest.raises(ConfigError, match="MISSING_TOKEN"):
+            load_config(path)
+
+    def test_env_var_with_default(self, tmp_path: Path) -> None:
+        content = """\
+            llm:
+              triage:
+                base_url: http://localhost:11434/v1
+                model: qwen2.5:7b
+                api_key: ${LLM_KEY:-not-needed}
+        """
+        path = _write_config(tmp_path, content)
+        config = load_config(path)
+        assert config.llm.triage.api_key == "not-needed"
+
+    def test_invalid_yaml(self, tmp_path: Path) -> None:
+        path = _write_config(tmp_path, "not: valid: yaml: [")
+        with pytest.raises(ConfigError):
+            load_config(path)
+
+    def test_non_mapping_yaml(self, tmp_path: Path) -> None:
+        path = _write_config(tmp_path, "- a list\n- not a mapping")
+        with pytest.raises(ConfigError, match="YAML mapping"):
+            load_config(path)
+
+
+# ---------------------------------------------------------------------------
+# Defaults
+# ---------------------------------------------------------------------------
+
+
+class TestDefaults:
+    """Verify defaults match ARCHITECTURE.md §11."""
+
+    def test_agent_defaults(self, tmp_path: Path) -> None:
+        path = _write_config(tmp_path, "agent: {}")
+        config = load_config(path)
+        assert config.agent.name == "oasis-agent"
+        assert config.agent.log_level == LogLevel.INFO
+        assert config.agent.event_queue_size == 1000
+        assert config.agent.shutdown_timeout == 30
+
+    def test_guardrails_defaults(self, tmp_path: Path) -> None:
+        path = _write_config(tmp_path, "guardrails: {}")
+        config = load_config(path)
+        assert config.guardrails.kill_switch is False
+        assert config.guardrails.dry_run is False
+        assert "lock.*" in config.guardrails.blocked_domains
+        assert "camera.*" in config.guardrails.blocked_domains
+
+    def test_circuit_breaker_defaults(self, tmp_path: Path) -> None:
+        path = _write_config(tmp_path, "guardrails: {}")
+        config = load_config(path)
+        cb = config.guardrails.circuit_breaker
+        assert cb.max_attempts_per_entity == 3
+        assert cb.window_minutes == 60
+        assert cb.cooldown_minutes == 15
+        assert cb.global_failure_rate_threshold == 0.3
+        assert cb.global_pause_minutes == 30
+
+    def test_audit_defaults(self, tmp_path: Path) -> None:
+        path = _write_config(tmp_path, "audit: {}")
+        config = load_config(path)
+        assert config.audit.influxdb.enabled is True
+        assert config.audit.influxdb.bucket == "oasisagent"
+        assert config.audit.retention_days == 90
+
+    def test_ha_websocket_subscription_defaults(self, tmp_path: Path) -> None:
+        path = _write_config(tmp_path, "ingestion:\n  ha_websocket: {}")
+        config = load_config(path)
+        subs = config.ingestion.ha_websocket.subscriptions
+        assert subs.state_changes.enabled is True
+        assert subs.state_changes.trigger_states == ["unavailable", "unknown"]
+        assert subs.state_changes.min_duration == 60
+        assert subs.automation_failures.enabled is True
+        assert subs.service_call_errors.enabled is True
+
+
+# ---------------------------------------------------------------------------
+# Validation
+# ---------------------------------------------------------------------------
+
+
+class TestValidation:
+    """Tests for Pydantic validation catching invalid config."""
+
+    def test_extra_field_rejected(self, tmp_path: Path) -> None:
+        """extra='forbid' catches typos in config keys."""
+        content = """\
+            agent:
+              name: test
+              typo_field: true
+        """
+        path = _write_config(tmp_path, content)
+        with pytest.raises(ConfigError, match="typo_field"):
+            load_config(path)
+
+    def test_nested_extra_field_rejected(self, tmp_path: Path) -> None:
+        content = """\
+            guardrails:
+              circuit_breaker:
+                max_attempts_per_entity: 3
+                bogus_setting: 42
+        """
+        path = _write_config(tmp_path, content)
+        with pytest.raises(ConfigError, match="bogus_setting"):
+            load_config(path)
+
+    def test_invalid_log_level(self, tmp_path: Path) -> None:
+        content = """\
+            agent:
+              log_level: verbose
+        """
+        path = _write_config(tmp_path, content)
+        with pytest.raises(ConfigError):
+            load_config(path)
+
+    def test_negative_queue_size(self, tmp_path: Path) -> None:
+        content = """\
+            agent:
+              event_queue_size: -1
+        """
+        path = _write_config(tmp_path, content)
+        with pytest.raises(ConfigError):
+            load_config(path)
+
+    def test_qos_out_of_range(self, tmp_path: Path) -> None:
+        content = """\
+            ingestion:
+              mqtt:
+                qos: 5
+        """
+        path = _write_config(tmp_path, content)
+        with pytest.raises(ConfigError):
+            load_config(path)
+
+    def test_temperature_out_of_range(self, tmp_path: Path) -> None:
+        content = """\
+            llm:
+              triage:
+                base_url: http://localhost:11434/v1
+                model: test
+                temperature: 3.0
+        """
+        path = _write_config(tmp_path, content)
+        with pytest.raises(ConfigError):
+            load_config(path)
+
+    def test_failure_rate_threshold_out_of_range(self, tmp_path: Path) -> None:
+        content = """\
+            guardrails:
+              circuit_breaker:
+                global_failure_rate_threshold: 1.5
+        """
+        path = _write_config(tmp_path, content)
+        with pytest.raises(ConfigError):
+            load_config(path)
+
+
+# ---------------------------------------------------------------------------
+# Nested model structure
+# ---------------------------------------------------------------------------
+
+
+class TestNestedModels:
+    """Verify nested models parse correctly from YAML."""
+
+    def test_mqtt_topic_mappings(self, tmp_path: Path) -> None:
+        content = """\
+            ingestion:
+              mqtt:
+                topics:
+                  - pattern: "ha/error/#"
+                    system: homeassistant
+                    event_type: automation_error
+                    severity: error
+                  - pattern: "oasis/#"
+        """
+        path = _write_config(tmp_path, content)
+        config = load_config(path)
+        topics = config.ingestion.mqtt.topics
+        assert len(topics) == 2
+        assert topics[0].pattern == "ha/error/#"
+        assert topics[0].system == "homeassistant"
+        assert topics[1].system == "auto"
+        assert topics[1].severity == "auto"
+
+    def test_log_patterns(self, tmp_path: Path) -> None:
+        content = """\
+            ingestion:
+              ha_log_poller:
+                patterns:
+                  - regex: "Error setting up integration '(.+)'"
+                    event_type: integration_failure
+                    severity: error
+                  - regex: "(.+) is unavailable"
+                    event_type: state_unavailable
+        """
+        path = _write_config(tmp_path, content)
+        config = load_config(path)
+        patterns = config.ingestion.ha_log_poller.patterns
+        assert len(patterns) == 2
+        assert patterns[0].event_type == "integration_failure"
+        assert patterns[0].severity == "error"
+        assert patterns[1].severity == "warning"  # default
+
+    def test_ha_websocket_subscriptions(self, tmp_path: Path) -> None:
+        content = """\
+            ingestion:
+              ha_websocket:
+                subscriptions:
+                  state_changes:
+                    enabled: false
+                    trigger_states: ["unavailable"]
+                    ignore_entities: ["sensor.flaky"]
+                    min_duration: 300
+                  automation_failures:
+                    enabled: false
+        """
+        path = _write_config(tmp_path, content)
+        config = load_config(path)
+        subs = config.ingestion.ha_websocket.subscriptions
+        assert subs.state_changes.enabled is False
+        assert subs.state_changes.trigger_states == ["unavailable"]
+        assert subs.state_changes.ignore_entities == ["sensor.flaky"]
+        assert subs.state_changes.min_duration == 300
+        assert subs.automation_failures.enabled is False
+        assert subs.service_call_errors.enabled is True  # default
+
+    def test_email_from_alias(self, tmp_path: Path) -> None:
+        """The 'from' YAML key maps to from_address via alias."""
+        content = """\
+            notifications:
+              email:
+                enabled: true
+                from: agent@test.com
+                to:
+                  - admin@test.com
+        """
+        path = _write_config(tmp_path, content)
+        config = load_config(path)
+        assert config.notifications.email.from_address == "agent@test.com"
+        assert config.notifications.email.to == ["admin@test.com"]


### PR DESCRIPTION
## Summary

- **`oasisagent/config.py`** — Full Pydantic model hierarchy matching ARCHITECTURE.md §11, with `extra="forbid"` on every model to catch config typos at startup.
- **`${VAR}` interpolation** operates on the raw YAML string before `yaml.safe_load()`, so env var references work in any value position (including `mqtt://${HOST}:1883`). Supports `${VAR:-default}` fallback syntax.
- **Nested models** for all complex structures: `MqttTopicMapping`, `LogPattern`, `HaWebSocketSubscriptions` (with `StateChangesSubscription`, `AutomationFailuresSubscription`, `ServiceCallErrorsSubscription`). No loose dicts.
- **`ConfigError`** with actionable messages: file-not-found suggests copying `config.example.yaml`, missing env vars listed by name.
- **`load_config(path) -> OasisAgentConfig`** — no global singleton, config passed explicitly.
- **Email `from` field** handled via Pydantic alias (`from` → `from_address`) since `from` is a Python keyword.

## Key design decisions

- Env var interpolation is a pre-processing step, not Pydantic validators — keeps testing simple and avoids hidden `os.environ` coupling
- `extra="forbid"` on all models — typos in YAML keys fail at startup, not silently
- `StrEnum` for `LogLevel` (ruff UP042 compliance)
- No config path resolution logic yet — that belongs in `__main__.py` (noted for later: `OASIS_CONFIG` env var → `./config.yaml` → `/app/config.yaml`)

## Test plan

34 tests covering:
- [ ] `${VAR}` and `${VAR:-default}` interpolation (9 tests)
- [ ] Config loading: file not found, minimal, full, env vars, invalid YAML, non-mapping (8 tests)
- [ ] Defaults match §11 for all sections (5 tests)
- [ ] Validation: `extra="forbid"` catches typos, invalid values rejected (7 tests)
- [ ] Nested models: topic mappings, log patterns, WS subscriptions, email alias (4 tests)
- [ ] `ruff check` passes

```
$ pytest tests/test_config.py -v
34 passed in 0.13s

$ ruff check oasisagent/config.py tests/test_config.py
All checks passed!
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)