### PR TITLE
Event queue with dedup and backpressure

### DIFF
--- a/config.example.yaml
+++ b/config.example.yaml
@@ -16,6 +16,7 @@ agent:
   name: oasis-agent             # Instance name (for logging and multi-agent setups)
   log_level: info               # debug, info, warning, error
   event_queue_size: 1000        # Internal event queue buffer size
+  dedup_window_seconds: 300     # Events with same dedup key within this window are dropped
   shutdown_timeout: 30          # Seconds to wait for graceful shutdown
 
 # -----------------------------------------------------------------------------

--- a/oasisagent/config.py
+++ b/oasisagent/config.py
@@ -132,6 +132,7 @@ class AgentConfig(BaseModel):
     name: str = "oasis-agent"
     log_level: LogLevel = LogLevel.INFO
     event_queue_size: Annotated[int, Field(ge=1)] = 1000
+    dedup_window_seconds: Annotated[int, Field(ge=0)] = 300
     shutdown_timeout: Annotated[int, Field(ge=1)] = 30
 
 

--- a/oasisagent/engine/queue.py
+++ b/oasisagent/engine/queue.py
@@ -1,0 +1,223 @@
+"""Event queue with deduplication and backpressure.
+
+This module lives in ``engine/`` because the queue is part of the processing
+pipeline: ingestion adapters push events in, the decision engine consumes them.
+ARCHITECTURE.md §2 shows the Event Queue sitting between Ingestion Adapters and
+the Decision Engine — it's infrastructure for the engine, not a standalone
+component.
+
+Backpressure: when the queue is full, ``put()`` blocks the calling adapter,
+naturally slowing ingestion. ``put_nowait()`` raises ``QueueFullError`` for
+adapters that can't afford to block.
+
+Deduplication: events with the same ``metadata.dedup_key`` within a
+configurable window are silently dropped. This is enforced at the queue
+level so individual adapters don't need to coordinate.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import logging
+import time
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from oasisagent.models import Event
+
+logger = logging.getLogger(__name__)
+
+
+class QueueFullError(Exception):
+    """Raised when ``put_nowait()`` is called on a full queue."""
+
+
+class EventQueue:
+    """Async event queue with deduplication and backpressure.
+
+    Args:
+        max_size: Maximum number of events in the queue. When full,
+            ``put()`` blocks and ``put_nowait()`` raises ``QueueFullError``.
+        dedup_window_seconds: Events with the same ``metadata.dedup_key``
+            within this window are silently dropped. Set to 0 to disable.
+    """
+
+    # Warn once when queue crosses this threshold; reset when it drops below
+    # the recovery threshold. Classic hysteresis to avoid log spam.
+    _WARN_THRESHOLD = 0.8
+    _RECOVER_THRESHOLD = 0.5
+    _PRUNE_INTERVAL_SECONDS = 60.0
+
+    def __init__(self, max_size: int = 1000, dedup_window_seconds: int = 300) -> None:
+        self._queue: asyncio.Queue[Event] = asyncio.Queue(maxsize=max_size)
+        self._max_size = max_size
+        self._dedup_window = dedup_window_seconds
+        self._seen: dict[str, float] = {}  # dedup_key -> timestamp
+        self._last_prune: float = time.monotonic()
+        self._capacity_warning_active = False
+
+    # -- Public interface ---------------------------------------------------
+
+    async def put(self, event: Event) -> bool:
+        """Enqueue an event. Blocks if the queue is full (backpressure).
+
+        Returns:
+            True if the event was enqueued, False if it was deduplicated.
+        """
+        if self._is_duplicate(event):
+            logger.debug("Dedup: dropping event %s (key=%s)", event.id, event.metadata.dedup_key)
+            return False
+
+        await self._queue.put(event)
+        self._record_seen(event)
+        self._check_capacity()
+        return True
+
+    def put_nowait(self, event: Event) -> bool:
+        """Enqueue an event without blocking.
+
+        Returns:
+            True if the event was enqueued, False if it was deduplicated.
+
+        Raises:
+            QueueFullError: If the queue is at capacity.
+        """
+        if self._is_duplicate(event):
+            logger.debug("Dedup: dropping event %s (key=%s)", event.id, event.metadata.dedup_key)
+            return False
+
+        try:
+            self._queue.put_nowait(event)
+        except asyncio.QueueFull as exc:
+            raise QueueFullError(
+                f"Event queue is full ({self._max_size} events). "
+                f"The decision engine may be falling behind."
+            ) from exc
+
+        self._record_seen(event)
+        self._check_capacity()
+        return True
+
+    async def get(self) -> Event:
+        """Dequeue the next event. Blocks until one is available."""
+        event = await self._queue.get()
+        self._check_capacity_recovery()
+        return event
+
+    def task_done(self) -> None:
+        """Mark a dequeued event as fully processed."""
+        self._queue.task_done()
+
+    def drain(self) -> list[Event]:
+        """Remove and return all queued events without blocking.
+
+        Call after all producers have stopped. Not safe for concurrent
+        use with ``put()``.
+        """
+        events: list[Event] = []
+        while not self._queue.empty():
+            try:
+                events.append(self._queue.get_nowait())
+            except asyncio.QueueEmpty:
+                break
+        return events
+
+    @property
+    def size(self) -> int:
+        """Number of events currently in the queue."""
+        return self._queue.qsize()
+
+    @property
+    def is_full(self) -> bool:
+        """Whether the queue is at capacity."""
+        return self._queue.full()
+
+    @property
+    def is_empty(self) -> bool:
+        """Whether the queue has no events."""
+        return self._queue.empty()
+
+    @property
+    def dedup_cache_size(self) -> int:
+        """Number of entries in the dedup cache (for monitoring/testing)."""
+        return len(self._seen)
+
+    # -- Deduplication ------------------------------------------------------
+
+    def _is_duplicate(self, event: Event) -> bool:
+        """Check if this event's dedup_key was seen within the window."""
+        if self._dedup_window <= 0:
+            return False
+
+        key = event.metadata.dedup_key
+        if not key:
+            return False
+
+        self._maybe_prune()
+
+        seen_at = self._seen.get(key)
+        if seen_at is None:
+            return False
+
+        return (time.monotonic() - seen_at) < self._dedup_window
+
+    def _record_seen(self, event: Event) -> None:
+        """Record a dedup key with the current timestamp."""
+        if self._dedup_window <= 0:
+            return
+
+        key = event.metadata.dedup_key
+        if key:
+            self._seen[key] = time.monotonic()
+
+    def _maybe_prune(self) -> None:
+        """Prune expired dedup entries if enough time has passed.
+
+        Uses a time gate to avoid pruning on every put(). Only prunes
+        if >60s since last prune.
+        """
+        now = time.monotonic()
+        if (now - self._last_prune) < self._PRUNE_INTERVAL_SECONDS:
+            return
+
+        self._last_prune = now
+        cutoff = now - self._dedup_window
+        expired = [k for k, ts in self._seen.items() if ts < cutoff]
+        for k in expired:
+            del self._seen[k]
+
+        if expired:
+            logger.debug("Dedup: pruned %d expired entries", len(expired))
+
+    # -- Capacity monitoring ------------------------------------------------
+
+    def _check_capacity(self) -> None:
+        """Warn once when queue crosses the high-water mark."""
+        if self._capacity_warning_active:
+            return
+
+        fill_ratio = self._queue.qsize() / self._max_size
+        if fill_ratio >= self._WARN_THRESHOLD:
+            self._capacity_warning_active = True
+            logger.warning(
+                "Event queue at %.0f%% capacity (%d/%d). "
+                "Decision engine may be falling behind.",
+                fill_ratio * 100,
+                self._queue.qsize(),
+                self._max_size,
+            )
+
+    def _check_capacity_recovery(self) -> None:
+        """Reset the capacity warning when the queue drops below recovery threshold."""
+        if not self._capacity_warning_active:
+            return
+
+        fill_ratio = self._queue.qsize() / self._max_size
+        if fill_ratio <= self._RECOVER_THRESHOLD:
+            self._capacity_warning_active = False
+            logger.info(
+                "Event queue recovered to %.0f%% capacity (%d/%d).",
+                fill_ratio * 100,
+                self._queue.qsize(),
+                self._max_size,
+            )

--- a/tests/test_event_queue.py
+++ b/tests/test_event_queue.py
@@ -1,0 +1,355 @@
+"""Tests for the event queue with deduplication and backpressure."""
+
+from __future__ import annotations
+
+import asyncio
+import logging
+import time
+from datetime import UTC, datetime
+
+import pytest
+
+from oasisagent.engine.queue import EventQueue, QueueFullError
+from oasisagent.models import Event, EventMetadata, Severity
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _make_event(
+    entity_id: str = "automation.test",
+    dedup_key: str = "",
+    event_type: str = "automation_error",
+) -> Event:
+    """Create an Event with sensible defaults."""
+    return Event(
+        source="mqtt",
+        system="homeassistant",
+        event_type=event_type,
+        entity_id=entity_id,
+        severity=Severity.ERROR,
+        timestamp=datetime(2026, 3, 7, 12, 0, 0, tzinfo=UTC),
+        metadata=EventMetadata(dedup_key=dedup_key),
+    )
+
+
+# ---------------------------------------------------------------------------
+# Basic put/get
+# ---------------------------------------------------------------------------
+
+
+class TestBasicOperations:
+    """Tests for basic queue operations."""
+
+    async def test_put_and_get(self) -> None:
+        q = EventQueue(max_size=10)
+        event = _make_event()
+        result = await q.put(event)
+        assert result is True
+        assert q.size == 1
+
+        got = await q.get()
+        assert got.id == event.id
+        assert q.size == 0
+
+    async def test_fifo_order(self) -> None:
+        q = EventQueue(max_size=10)
+        e1 = _make_event(entity_id="first")
+        e2 = _make_event(entity_id="second")
+        e3 = _make_event(entity_id="third")
+
+        await q.put(e1)
+        await q.put(e2)
+        await q.put(e3)
+
+        assert (await q.get()).entity_id == "first"
+        assert (await q.get()).entity_id == "second"
+        assert (await q.get()).entity_id == "third"
+
+    async def test_put_nowait(self) -> None:
+        q = EventQueue(max_size=10)
+        event = _make_event()
+        result = q.put_nowait(event)
+        assert result is True
+        assert q.size == 1
+
+    async def test_task_done(self) -> None:
+        q = EventQueue(max_size=10)
+        await q.put(_make_event())
+        await q.get()
+        q.task_done()  # Should not raise
+
+
+# ---------------------------------------------------------------------------
+# Properties
+# ---------------------------------------------------------------------------
+
+
+class TestProperties:
+    """Tests for size, is_full, is_empty."""
+
+    async def test_is_empty(self) -> None:
+        q = EventQueue(max_size=5)
+        assert q.is_empty is True
+        await q.put(_make_event())
+        assert q.is_empty is False
+
+    async def test_is_full(self) -> None:
+        q = EventQueue(max_size=2)
+        assert q.is_full is False
+        q.put_nowait(_make_event(entity_id="a"))
+        q.put_nowait(_make_event(entity_id="b"))
+        assert q.is_full is True
+
+    async def test_size(self) -> None:
+        q = EventQueue(max_size=10)
+        assert q.size == 0
+        await q.put(_make_event())
+        assert q.size == 1
+        await q.get()
+        assert q.size == 0
+
+
+# ---------------------------------------------------------------------------
+# Backpressure
+# ---------------------------------------------------------------------------
+
+
+class TestBackpressure:
+    """Tests for backpressure behavior."""
+
+    async def test_put_nowait_raises_when_full(self) -> None:
+        q = EventQueue(max_size=1)
+        q.put_nowait(_make_event(entity_id="a"))
+
+        with pytest.raises(QueueFullError, match="Event queue is full"):
+            q.put_nowait(_make_event(entity_id="b"))
+
+    async def test_queue_full_error_has_cause(self) -> None:
+        q = EventQueue(max_size=1)
+        q.put_nowait(_make_event())
+
+        with pytest.raises(QueueFullError) as exc_info:
+            q.put_nowait(_make_event(entity_id="b"))
+        assert isinstance(exc_info.value.__cause__, asyncio.QueueFull)
+
+    async def test_put_blocks_when_full_then_unblocks(self) -> None:
+        q = EventQueue(max_size=1)
+        await q.put(_make_event(entity_id="a"))
+        assert q.is_full
+
+        unblocked = asyncio.Event()
+
+        async def _delayed_consume() -> None:
+            await asyncio.sleep(0.05)
+            await q.get()
+
+        async def _blocked_put() -> None:
+            await q.put(_make_event(entity_id="b"))
+            unblocked.set()
+
+        consumer = asyncio.create_task(_delayed_consume())
+        producer = asyncio.create_task(_blocked_put())
+
+        await asyncio.wait_for(unblocked.wait(), timeout=2.0)
+        assert q.size == 1
+
+        await consumer
+        await producer
+
+
+# ---------------------------------------------------------------------------
+# Deduplication
+# ---------------------------------------------------------------------------
+
+
+class TestDeduplication:
+    """Tests for dedup behavior."""
+
+    async def test_duplicate_within_window_dropped(self) -> None:
+        q = EventQueue(max_size=10, dedup_window_seconds=300)
+        e1 = _make_event(dedup_key="mqtt:automation.test:error")
+        e2 = _make_event(dedup_key="mqtt:automation.test:error")
+
+        result1 = await q.put(e1)
+        result2 = await q.put(e2)
+
+        assert result1 is True
+        assert result2 is False
+        assert q.size == 1
+
+    async def test_duplicate_put_nowait_dropped(self) -> None:
+        q = EventQueue(max_size=10, dedup_window_seconds=300)
+        e1 = _make_event(dedup_key="key1")
+        e2 = _make_event(dedup_key="key1")
+
+        result1 = q.put_nowait(e1)
+        result2 = q.put_nowait(e2)
+
+        assert result1 is True
+        assert result2 is False
+        assert q.size == 1
+
+    async def test_different_keys_not_deduped(self) -> None:
+        q = EventQueue(max_size=10, dedup_window_seconds=300)
+        e1 = _make_event(dedup_key="key1")
+        e2 = _make_event(dedup_key="key2")
+
+        assert await q.put(e1) is True
+        assert await q.put(e2) is True
+        assert q.size == 2
+
+    async def test_empty_dedup_key_not_deduped(self) -> None:
+        q = EventQueue(max_size=10, dedup_window_seconds=300)
+        e1 = _make_event(dedup_key="")
+        e2 = _make_event(dedup_key="")
+
+        assert await q.put(e1) is True
+        assert await q.put(e2) is True
+        assert q.size == 2
+
+    async def test_dedup_disabled_when_window_zero(self) -> None:
+        q = EventQueue(max_size=10, dedup_window_seconds=0)
+        e1 = _make_event(dedup_key="same-key")
+        e2 = _make_event(dedup_key="same-key")
+
+        assert await q.put(e1) is True
+        assert await q.put(e2) is True
+        assert q.size == 2
+
+    async def test_duplicate_after_window_expires_allowed(self) -> None:
+        q = EventQueue(max_size=10, dedup_window_seconds=1)
+        e1 = _make_event(dedup_key="key1")
+
+        assert await q.put(e1) is True
+
+        # Fake time advancement by manipulating the seen timestamp
+        q._seen["key1"] = time.monotonic() - 2  # 2 seconds ago, past the 1s window
+
+        e2 = _make_event(dedup_key="key1")
+        assert await q.put(e2) is True
+        assert q.size == 2
+
+    async def test_dedup_cache_pruning(self) -> None:
+        """Verify expired dedup entries are actually cleaned up."""
+        q = EventQueue(max_size=10, dedup_window_seconds=1)
+        q._PRUNE_INTERVAL_SECONDS = 0  # Force prune on every check
+
+        e1 = _make_event(dedup_key="prune-me")
+        await q.put(e1)
+        assert q.dedup_cache_size == 1
+
+        # Age the entry past the window
+        q._seen["prune-me"] = time.monotonic() - 2
+        q._last_prune = 0  # Force prune on next put
+
+        # Put a different event to trigger pruning
+        e2 = _make_event(dedup_key="trigger-prune")
+        await q.put(e2)
+
+        assert "prune-me" not in q._seen
+        assert q.dedup_cache_size == 1  # Only "trigger-prune" remains
+
+    async def test_dedup_logs_debug(self, caplog: pytest.LogCaptureFixture) -> None:
+        q = EventQueue(max_size=10, dedup_window_seconds=300)
+        e1 = _make_event(dedup_key="logged-key")
+        e2 = _make_event(dedup_key="logged-key")
+
+        with caplog.at_level(logging.DEBUG):
+            await q.put(e1)
+            await q.put(e2)
+
+        assert any("Dedup: dropping" in r.message for r in caplog.records)
+
+
+# ---------------------------------------------------------------------------
+# Drain
+# ---------------------------------------------------------------------------
+
+
+class TestDrain:
+    """Tests for drain() during shutdown."""
+
+    async def test_drain_returns_all_events(self) -> None:
+        q = EventQueue(max_size=10)
+        await q.put(_make_event(entity_id="a"))
+        await q.put(_make_event(entity_id="b"))
+        await q.put(_make_event(entity_id="c"))
+
+        drained = q.drain()
+        assert len(drained) == 3
+        assert q.is_empty
+
+    async def test_drain_empty_queue(self) -> None:
+        q = EventQueue(max_size=10)
+        assert q.drain() == []
+
+    async def test_drain_preserves_order(self) -> None:
+        q = EventQueue(max_size=10)
+        await q.put(_make_event(entity_id="first"))
+        await q.put(_make_event(entity_id="second"))
+
+        drained = q.drain()
+        assert drained[0].entity_id == "first"
+        assert drained[1].entity_id == "second"
+
+
+# ---------------------------------------------------------------------------
+# Capacity warnings (hysteresis)
+# ---------------------------------------------------------------------------
+
+
+class TestCapacityWarnings:
+    """Tests for the 80% warning with hysteresis."""
+
+    async def test_warning_at_80_percent(self, caplog: pytest.LogCaptureFixture) -> None:
+        q = EventQueue(max_size=5)
+
+        with caplog.at_level(logging.WARNING):
+            for i in range(4):
+                q.put_nowait(_make_event(entity_id=f"e{i}"))
+
+        assert any("capacity" in r.message.lower() for r in caplog.records)
+
+    async def test_warning_fires_only_once(self, caplog: pytest.LogCaptureFixture) -> None:
+        q = EventQueue(max_size=5)
+
+        with caplog.at_level(logging.WARNING):
+            for i in range(5):
+                q.put_nowait(_make_event(entity_id=f"e{i}"))
+
+        warning_count = sum(1 for r in caplog.records if "capacity" in r.message.lower())
+        assert warning_count == 1
+
+    async def test_warning_resets_after_recovery(
+        self, caplog: pytest.LogCaptureFixture
+    ) -> None:
+        q = EventQueue(max_size=10)
+
+        # Fill to 80%
+        with caplog.at_level(logging.WARNING):
+            for i in range(8):
+                q.put_nowait(_make_event(entity_id=f"e{i}"))
+
+        first_warnings = sum(1 for r in caplog.records if "capacity" in r.message.lower())
+        assert first_warnings == 1
+        assert q._capacity_warning_active is True
+
+        # Drain to below 50%
+        caplog.clear()
+        with caplog.at_level(logging.INFO):
+            for _ in range(5):
+                await q.get()
+
+        assert q._capacity_warning_active is False
+        assert any("recovered" in r.message.lower() for r in caplog.records)
+
+        # Fill again — should warn again
+        caplog.clear()
+        with caplog.at_level(logging.WARNING):
+            for i in range(5):
+                q.put_nowait(_make_event(entity_id=f"refill{i}"))
+
+        second_warnings = sum(1 for r in caplog.records if "capacity" in r.message.lower())
+        assert second_warnings == 1


### PR DESCRIPTION
## Summary

- **`oasisagent/engine/queue.py`** — `EventQueue` class, thin wrapper over `asyncio.Queue`:
  - **Backpressure**: `put()` blocks when full; `put_nowait()` raises custom `QueueFullError` (wraps `asyncio.QueueFull` as `__cause__`, not raw asyncio exception)
  - **Deduplication**: Same `metadata.dedup_key` within `dedup_window_seconds` silently dropped. Lazy pruning with 60s time gate (no background task)
  - **Capacity hysteresis**: Warns once at 80% fill, resets at 50%. No log spam when hovering near threshold
  - **`put()`/`put_nowait()` return `bool`**: True=enqueued, False=deduped — callers know if their event was accepted
  - **`drain()`**: Returns all events for graceful shutdown. Docstring documents concurrency contract ("call after producers stopped")
  - Lives in `engine/` because §2 diagram shows Event Queue between ingestion and decision engine — it's pipeline infrastructure

- **`AgentConfig`**: Added `dedup_window_seconds: int = 300` — single knob for queue-level dedup, independent of per-event TTL and adapter-specific dedup windows (review Option A)

- **`config.example.yaml`**: Added `dedup_window_seconds` with description

## Test plan

24 tests in `tests/test_event_queue.py`:
- [ ] Basic ops: put/get, FIFO order, put_nowait, task_done (4 tests)
- [ ] Properties: is_empty, is_full, size (3 tests)
- [ ] Backpressure: put_nowait raises QueueFullError with cause, put blocks then unblocks (3 tests)
- [ ] Dedup: within window dropped, different keys pass, empty key passes, disabled when 0, after expiry allowed, cache pruning verified, debug logging (8 tests)
- [ ] Drain: returns all, empty queue, preserves order (3 tests)
- [ ] Capacity warnings: fires at 80%, fires only once, resets after recovery and re-fires (3 tests)

```
$ pytest -v
101 passed in 0.27s  (34 config + 43 models + 24 queue)

$ ruff check oasisagent/ tests/
All checks passed!
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)