### PR TITLE
Add circuit breaker to prevent remediation loops

### DIFF
--- a/oasisagent/config.py
+++ b/oasisagent/config.py
@@ -372,7 +372,7 @@ class CircuitBreakerConfig(BaseModel):
 
     max_attempts_per_entity: Annotated[int, Field(ge=1)] = 3
     window_minutes: Annotated[int, Field(ge=1)] = 60
-    cooldown_minutes: Annotated[int, Field(ge=1)] = 15
+    cooldown_minutes: Annotated[int, Field(ge=0)] = 15
     global_failure_rate_threshold: Annotated[float, Field(gt=0.0, le=1.0)] = 0.3
     global_pause_minutes: Annotated[int, Field(ge=1)] = 30
 

--- a/oasisagent/engine/__init__.py
+++ b/oasisagent/engine/__init__.py
@@ -1,5 +1,6 @@
 """Decision engine — event classification, guardrails, and handler dispatch."""
 
+from oasisagent.engine.circuit_breaker import CircuitBreaker, CircuitBreakerResult
 from oasisagent.engine.decision import (
     DecisionDisposition,
     DecisionEngine,
@@ -10,6 +11,8 @@ from oasisagent.engine.guardrails import GuardrailResult, GuardrailsEngine
 from oasisagent.engine.known_fixes import KnownFixRegistry
 
 __all__ = [
+    "CircuitBreaker",
+    "CircuitBreakerResult",
     "DecisionDisposition",
     "DecisionEngine",
     "DecisionResult",

--- a/oasisagent/engine/circuit_breaker.py
+++ b/oasisagent/engine/circuit_breaker.py
@@ -1,0 +1,220 @@
+"""Circuit breaker — prevents remediation loops.
+
+Tracks action attempts per entity and globally. Trips when:
+- Per-entity: max attempts exceeded in rolling window, or cooldown active
+- Global: failure rate exceeds threshold (with minimum sample size)
+
+When tripped:
+- Entity trip: AUTO_FIX → RECOMMEND (notify human instead)
+- Entity cooldown: defer action (too soon since last attempt)
+- Global trip: AUTO_FIX → ESCALATE (global pause)
+
+ARCHITECTURE.md §7 describes the circuit breaker behavior.
+"""
+
+from __future__ import annotations
+
+import logging
+import time
+from typing import TYPE_CHECKING, NamedTuple
+
+from pydantic import BaseModel, ConfigDict
+
+if TYPE_CHECKING:
+    from oasisagent.config import CircuitBreakerConfig
+
+logger = logging.getLogger(__name__)
+
+
+# ---------------------------------------------------------------------------
+# Internal bookkeeping
+# ---------------------------------------------------------------------------
+
+
+class AttemptRecord(NamedTuple):
+    """A single recorded action attempt."""
+
+    entity_id: str
+    timestamp: float  # time.monotonic()
+    success: bool
+
+
+# ---------------------------------------------------------------------------
+# Result model
+# ---------------------------------------------------------------------------
+
+
+class CircuitBreakerResult(BaseModel):
+    """Outcome of a circuit breaker check."""
+
+    model_config = ConfigDict(extra="forbid")
+
+    allowed: bool
+    reason: str
+    entity_tripped: bool = False
+    entity_cooldown: bool = False
+    global_tripped: bool = False
+
+
+# ---------------------------------------------------------------------------
+# Circuit breaker
+# ---------------------------------------------------------------------------
+
+
+class CircuitBreaker:
+    """Tracks action outcomes and prevents remediation loops.
+
+    Maintains a single list of attempt records. Per-entity and global
+    state are both derived from this list, ensuring a single source
+    of truth.
+
+    Uses ``time.monotonic()`` for timestamps — immune to clock skew
+    and NTP jumps.
+    """
+
+    def __init__(self, config: CircuitBreakerConfig) -> None:
+        self._config = config
+        self._attempts: list[AttemptRecord] = []
+        self._global_tripped_at: float | None = None
+
+    def record_attempt(
+        self, entity_id: str, *, success: bool
+    ) -> CircuitBreakerResult:
+        """Record an action outcome and return the current circuit state.
+
+        The caller gets immediate feedback on whether this attempt
+        tripped the circuit, without needing a separate check() call.
+        """
+        self._attempts.append(AttemptRecord(
+            entity_id=entity_id,
+            timestamp=time.monotonic(),
+            success=success,
+        ))
+        return self.check(entity_id)
+
+    def check(self, entity_id: str) -> CircuitBreakerResult:
+        """Check if the circuit breaker allows an action for this entity.
+
+        Evaluates in order:
+        1. Global trip (failure rate above threshold)
+        2. Per-entity max attempts exceeded
+        3. Per-entity cooldown active
+        """
+        self._prune()
+
+        # 1. Global trip check
+        if self._is_global_tripped():
+            return CircuitBreakerResult(
+                allowed=False,
+                reason="Global circuit breaker tripped — failure rate exceeded threshold",
+                global_tripped=True,
+            )
+
+        # 2. Per-entity max attempts
+        entity_attempts = [a for a in self._attempts if a.entity_id == entity_id]
+        if len(entity_attempts) >= self._config.max_attempts_per_entity:
+            logger.info(
+                "Circuit breaker: entity %s has %d attempts (max %d) in window",
+                entity_id,
+                len(entity_attempts),
+                self._config.max_attempts_per_entity,
+            )
+            return CircuitBreakerResult(
+                allowed=False,
+                reason=(
+                    f"Entity '{entity_id}' has {len(entity_attempts)} attempts "
+                    f"in the last {self._config.window_minutes} minutes "
+                    f"(max {self._config.max_attempts_per_entity})"
+                ),
+                entity_tripped=True,
+            )
+
+        # 3. Per-entity cooldown
+        if entity_attempts:
+            last_attempt = entity_attempts[-1]
+            cooldown_seconds = self._config.cooldown_minutes * 60
+            elapsed = time.monotonic() - last_attempt.timestamp
+            if elapsed < cooldown_seconds:
+                remaining = cooldown_seconds - elapsed
+                logger.debug(
+                    "Circuit breaker: entity %s in cooldown (%.0fs remaining)",
+                    entity_id,
+                    remaining,
+                )
+                return CircuitBreakerResult(
+                    allowed=False,
+                    reason=(
+                        f"Entity '{entity_id}' is in cooldown "
+                        f"({remaining:.0f}s remaining of {self._config.cooldown_minutes}m)"
+                    ),
+                    entity_cooldown=True,
+                )
+
+        # All checks passed
+        return CircuitBreakerResult(
+            allowed=True,
+            reason="Circuit breaker allows action",
+        )
+
+    def reset(self, entity_id: str | None = None) -> None:
+        """Reset circuit breaker state.
+
+        If entity_id is given, only that entity's attempts are cleared.
+        If None, all state is reset (including global trip).
+        """
+        if entity_id is None:
+            self._attempts.clear()
+            self._global_tripped_at = None
+            logger.info("Circuit breaker: full reset")
+        else:
+            self._attempts = [a for a in self._attempts if a.entity_id != entity_id]
+            logger.info("Circuit breaker: reset for entity %s", entity_id)
+
+    def _is_global_tripped(self) -> bool:
+        """Check if the global circuit breaker is active."""
+        now = time.monotonic()
+
+        # If currently in global pause, check if it has expired
+        if self._global_tripped_at is not None:
+            pause_seconds = self._config.global_pause_minutes * 60
+            if (now - self._global_tripped_at) < pause_seconds:
+                return True
+            # Pause expired — reset
+            self._global_tripped_at = None
+            logger.info("Circuit breaker: global pause expired, resuming")
+
+        # Check failure rate (with minimum sample size)
+        total = len(self._attempts)
+        if total < self._min_global_attempts:
+            return False
+
+        failures = sum(1 for a in self._attempts if not a.success)
+        rate = failures / total
+
+        if rate >= self._config.global_failure_rate_threshold:
+            self._global_tripped_at = now
+            logger.warning(
+                "Circuit breaker: GLOBAL TRIP — failure rate %.1f%% "
+                "(%d/%d) exceeds threshold %.1f%%",
+                rate * 100,
+                failures,
+                total,
+                self._config.global_failure_rate_threshold * 100,
+            )
+            return True
+
+        return False
+
+    @property
+    def _min_global_attempts(self) -> int:
+        """Minimum attempts before global failure rate is evaluated.
+
+        Prevents false trips on cold start (e.g., 1 failure out of
+        1 attempt = 100% rate, but shouldn't trip globally).
+        """
+        return 5
+
+    def _prune(self) -> None:
+        """Remove attempts outside the rolling window."""
+        cutoff = time.monotonic() - (self._config.window_minutes * 60)
+        self._attempts = [a for a in self._attempts if a.timestamp >= cutoff]

--- a/tests/test_circuit_breaker.py
+++ b/tests/test_circuit_breaker.py
@@ -1,1 +1,391 @@
 """Tests for circuit breaker logic."""
+
+from __future__ import annotations
+
+import time
+from typing import Any
+
+from oasisagent.config import CircuitBreakerConfig
+from oasisagent.engine.circuit_breaker import CircuitBreaker
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _make_config(**overrides: Any) -> CircuitBreakerConfig:
+    defaults: dict[str, Any] = {
+        "max_attempts_per_entity": 3,
+        "window_minutes": 60,
+        "cooldown_minutes": 15,
+        "global_failure_rate_threshold": 0.3,
+        "global_pause_minutes": 30,
+    }
+    defaults.update(overrides)
+    return CircuitBreakerConfig(**defaults)
+
+
+def _breaker(**overrides: Any) -> CircuitBreaker:
+    return CircuitBreaker(_make_config(**overrides))
+
+
+def _age_attempts(breaker: CircuitBreaker, seconds: float) -> None:
+    """Shift all attempt timestamps back by the given seconds."""
+    breaker._attempts = [
+        a._replace(timestamp=a.timestamp - seconds)
+        for a in breaker._attempts
+    ]
+
+
+# ---------------------------------------------------------------------------
+# Per-entity: max attempts
+# ---------------------------------------------------------------------------
+
+
+class TestEntityMaxAttempts:
+    """Per-entity circuit trips when max attempts exceeded in window."""
+
+    def test_below_threshold_allowed(self) -> None:
+        cb = _breaker(max_attempts_per_entity=3)
+        cb.record_attempt("light.kitchen", success=False)
+        cb.record_attempt("light.kitchen", success=False)
+
+        result = cb.check("light.kitchen")
+        # 2 attempts < 3 max, but cooldown may be active
+        # Check that entity_tripped is False
+        assert result.entity_tripped is False
+
+    def test_at_threshold_tripped(self) -> None:
+        cb = _breaker(max_attempts_per_entity=3, cooldown_minutes=0)
+        cb.record_attempt("light.kitchen", success=False)
+        cb.record_attempt("light.kitchen", success=False)
+        cb.record_attempt("light.kitchen", success=False)
+
+        result = cb.check("light.kitchen")
+        assert result.allowed is False
+        assert result.entity_tripped is True
+        assert result.entity_cooldown is False
+        assert "3 attempts" in result.reason
+
+    def test_success_counts_toward_max(self) -> None:
+        """All attempts count, not just failures."""
+        cb = _breaker(max_attempts_per_entity=3, cooldown_minutes=0)
+        cb.record_attempt("light.kitchen", success=True)
+        cb.record_attempt("light.kitchen", success=True)
+        cb.record_attempt("light.kitchen", success=True)
+
+        result = cb.check("light.kitchen")
+        assert result.entity_tripped is True
+
+    def test_expired_attempts_dont_count(self) -> None:
+        cb = _breaker(max_attempts_per_entity=3, cooldown_minutes=0, window_minutes=60)
+        cb.record_attempt("light.kitchen", success=False)
+        cb.record_attempt("light.kitchen", success=False)
+        cb.record_attempt("light.kitchen", success=False)
+
+        # Age attempts past the window
+        _age_attempts(cb, 61 * 60)
+
+        result = cb.check("light.kitchen")
+        assert result.allowed is True
+        assert result.entity_tripped is False
+
+
+# ---------------------------------------------------------------------------
+# Per-entity: cooldown
+# ---------------------------------------------------------------------------
+
+
+class TestEntityCooldown:
+    """Per-entity cooldown blocks attempts too soon after the last one."""
+
+    def test_within_cooldown_blocked(self) -> None:
+        cb = _breaker(cooldown_minutes=15, max_attempts_per_entity=10)
+        cb.record_attempt("light.kitchen", success=False)
+
+        result = cb.check("light.kitchen")
+        assert result.allowed is False
+        assert result.entity_cooldown is True
+        assert result.entity_tripped is False
+        assert "cooldown" in result.reason.lower()
+
+    def test_after_cooldown_allowed(self) -> None:
+        cb = _breaker(cooldown_minutes=15, max_attempts_per_entity=10)
+        cb.record_attempt("light.kitchen", success=False)
+
+        # Age past cooldown
+        _age_attempts(cb, 16 * 60)
+
+        result = cb.check("light.kitchen")
+        assert result.allowed is True
+
+    def test_zero_cooldown_allows_immediately(self) -> None:
+        cb = _breaker(cooldown_minutes=0, max_attempts_per_entity=10)
+        cb.record_attempt("light.kitchen", success=False)
+
+        # With 0 cooldown, the elapsed time (however small) >= 0
+        # But monotonic time is > 0 so this should pass
+        result = cb.check("light.kitchen")
+        assert result.entity_cooldown is False
+
+
+# ---------------------------------------------------------------------------
+# Global trip
+# ---------------------------------------------------------------------------
+
+
+class TestGlobalTrip:
+    """Global circuit trips when failure rate exceeds threshold."""
+
+    def test_high_failure_rate_trips(self) -> None:
+        cb = _breaker(
+            global_failure_rate_threshold=0.3,
+            max_attempts_per_entity=100,
+            cooldown_minutes=0,
+        )
+        # 4 failures out of 6 = 66% > 30%
+        for i in range(4):
+            cb.record_attempt(f"entity.{i}", success=False)
+        for i in range(2):
+            cb.record_attempt(f"entity.ok_{i}", success=True)
+
+        result = cb.check("entity.new")
+        assert result.allowed is False
+        assert result.global_tripped is True
+
+    def test_low_failure_rate_allowed(self) -> None:
+        cb = _breaker(
+            global_failure_rate_threshold=0.3,
+            max_attempts_per_entity=100,
+            cooldown_minutes=0,
+        )
+        # 1 failure out of 6 = 16% < 30%
+        cb.record_attempt("entity.bad", success=False)
+        for i in range(5):
+            cb.record_attempt(f"entity.ok_{i}", success=True)
+
+        result = cb.check("entity.new")
+        assert result.global_tripped is False
+
+    def test_below_min_sample_size_not_tripped(self) -> None:
+        """1 failure out of 1 attempt = 100%, but below min sample (5)."""
+        cb = _breaker(global_failure_rate_threshold=0.3, cooldown_minutes=0)
+        cb.record_attempt("entity.bad", success=False)
+
+        result = cb.check("entity.other")
+        assert result.global_tripped is False
+        assert result.allowed is True
+
+    def test_exactly_at_min_sample_size(self) -> None:
+        """5 attempts, all failures = 100% → trips."""
+        cb = _breaker(
+            global_failure_rate_threshold=0.3,
+            max_attempts_per_entity=100,
+            cooldown_minutes=0,
+        )
+        for i in range(5):
+            cb.record_attempt(f"entity.bad_{i}", success=False)
+
+        result = cb.check("entity.new")
+        assert result.global_tripped is True
+
+    def test_global_pause_expires(self) -> None:
+        cb = _breaker(
+            global_failure_rate_threshold=0.3,
+            global_pause_minutes=30,
+            max_attempts_per_entity=100,
+            cooldown_minutes=0,
+        )
+        # Trip the global breaker
+        for i in range(5):
+            cb.record_attempt(f"entity.bad_{i}", success=False)
+
+        result = cb.check("entity.new")
+        assert result.global_tripped is True
+
+        # Age attempts past the window AND simulate pause expiry
+        _age_attempts(cb, 61 * 60)
+        cb._global_tripped_at = time.monotonic() - (31 * 60)
+
+        result = cb.check("entity.new")
+        assert result.global_tripped is False
+        assert result.allowed is True
+
+    def test_global_pause_still_active(self) -> None:
+        cb = _breaker(
+            global_failure_rate_threshold=0.3,
+            global_pause_minutes=30,
+            max_attempts_per_entity=100,
+            cooldown_minutes=0,
+        )
+        for i in range(5):
+            cb.record_attempt(f"entity.bad_{i}", success=False)
+
+        # Trip it
+        cb.check("entity.new")
+
+        # Only 10 minutes have passed (pause is 30)
+        cb._global_tripped_at = time.monotonic() - (10 * 60)
+
+        result = cb.check("entity.new")
+        assert result.global_tripped is True
+        assert result.allowed is False
+
+
+# ---------------------------------------------------------------------------
+# Entity isolation
+# ---------------------------------------------------------------------------
+
+
+class TestEntityIsolation:
+    """Failures for one entity don't affect another entity's per-entity check."""
+
+    def test_entity_a_tripped_entity_b_allowed(self) -> None:
+        cb = _breaker(max_attempts_per_entity=3, cooldown_minutes=0)
+        cb.record_attempt("entity.a", success=False)
+        cb.record_attempt("entity.a", success=False)
+        cb.record_attempt("entity.a", success=False)
+
+        result_a = cb.check("entity.a")
+        result_b = cb.check("entity.b")
+
+        assert result_a.entity_tripped is True
+        assert result_b.allowed is True
+        assert result_b.entity_tripped is False
+
+    def test_independent_cooldowns(self) -> None:
+        cb = _breaker(cooldown_minutes=15, max_attempts_per_entity=10)
+        cb.record_attempt("entity.a", success=False)
+
+        result_a = cb.check("entity.a")
+        result_b = cb.check("entity.b")
+
+        assert result_a.entity_cooldown is True
+        assert result_b.allowed is True
+
+
+# ---------------------------------------------------------------------------
+# Combined states
+# ---------------------------------------------------------------------------
+
+
+class TestCombinedStates:
+    """Entity tripped + global ok, entity ok + global tripped."""
+
+    def test_entity_tripped_global_ok(self) -> None:
+        cb = _breaker(
+            max_attempts_per_entity=2,
+            cooldown_minutes=0,
+            global_failure_rate_threshold=0.9,
+        )
+        cb.record_attempt("entity.a", success=False)
+        cb.record_attempt("entity.a", success=False)
+        # Add successes to keep global rate low
+        for i in range(10):
+            cb.record_attempt(f"entity.ok_{i}", success=True)
+
+        result = cb.check("entity.a")
+        assert result.entity_tripped is True
+        assert result.global_tripped is False
+
+    def test_entity_ok_global_tripped(self) -> None:
+        cb = _breaker(
+            max_attempts_per_entity=100,
+            cooldown_minutes=0,
+            global_failure_rate_threshold=0.3,
+        )
+        for i in range(5):
+            cb.record_attempt(f"entity.bad_{i}", success=False)
+
+        # entity.clean has no attempts, but global is tripped
+        result = cb.check("entity.clean")
+        assert result.global_tripped is True
+        assert result.entity_tripped is False
+
+
+# ---------------------------------------------------------------------------
+# record_attempt returns result
+# ---------------------------------------------------------------------------
+
+
+class TestRecordAttempt:
+    """record_attempt returns CircuitBreakerResult for immediate feedback."""
+
+    def test_returns_result(self) -> None:
+        cb = _breaker(max_attempts_per_entity=2, cooldown_minutes=0)
+        result = cb.record_attempt("light.kitchen", success=False)
+
+        assert result.allowed is True  # 1 attempt < 2 max
+
+    def test_tripping_attempt_returns_tripped(self) -> None:
+        cb = _breaker(max_attempts_per_entity=2, cooldown_minutes=0)
+        cb.record_attempt("light.kitchen", success=False)
+        result = cb.record_attempt("light.kitchen", success=False)
+
+        assert result.entity_tripped is True
+        assert result.allowed is False
+
+
+# ---------------------------------------------------------------------------
+# Reset
+# ---------------------------------------------------------------------------
+
+
+class TestReset:
+    """Reset clears circuit breaker state."""
+
+    def test_reset_entity(self) -> None:
+        cb = _breaker(max_attempts_per_entity=2, cooldown_minutes=0)
+        cb.record_attempt("entity.a", success=False)
+        cb.record_attempt("entity.a", success=False)
+
+        assert cb.check("entity.a").entity_tripped is True
+
+        cb.reset("entity.a")
+
+        assert cb.check("entity.a").allowed is True
+
+    def test_reset_entity_preserves_others(self) -> None:
+        cb = _breaker(max_attempts_per_entity=2, cooldown_minutes=0)
+        cb.record_attempt("entity.a", success=False)
+        cb.record_attempt("entity.a", success=False)
+        cb.record_attempt("entity.b", success=False)
+        cb.record_attempt("entity.b", success=False)
+
+        cb.reset("entity.a")
+
+        assert cb.check("entity.a").allowed is True
+        assert cb.check("entity.b").entity_tripped is True
+
+    def test_reset_all(self) -> None:
+        cb = _breaker(
+            max_attempts_per_entity=2,
+            cooldown_minutes=0,
+            global_failure_rate_threshold=0.3,
+        )
+        for i in range(5):
+            cb.record_attempt(f"entity.bad_{i}", success=False)
+
+        assert cb.check("entity.new").global_tripped is True
+
+        cb.reset()
+
+        assert cb.check("entity.new").allowed is True
+
+
+# ---------------------------------------------------------------------------
+# Empty state
+# ---------------------------------------------------------------------------
+
+
+class TestEmptyState:
+    """No attempts recorded — everything allowed."""
+
+    def test_no_attempts_allowed(self) -> None:
+        cb = _breaker()
+        result = cb.check("any.entity")
+
+        assert result.allowed is True
+        assert result.entity_tripped is False
+        assert result.entity_cooldown is False
+        assert result.global_tripped is False


### PR DESCRIPTION
## Summary
- Adds `CircuitBreaker` class that tracks action attempts per entity and globally to prevent remediation loops
- **Per-entity**: trips when max attempts exceeded in rolling window, enforces cooldown between attempts (entity_tripped vs entity_cooldown as separate signals)
- **Global**: trips when failure rate exceeds threshold, with min sample size of 5 to avoid false trips on cold start
- Single `_attempts` list as source of truth with lazy pruning via `time.monotonic()`
- `record_attempt()` returns `CircuitBreakerResult` for immediate caller feedback
- Changed `cooldown_minutes` config constraint from `ge=1` to `ge=0` to allow disabling cooldown

## Test plan
- [x] 23 unit tests covering all circuit breaker behavior
- [x] Entity max attempts: below/at threshold, success counting, window expiry
- [x] Entity cooldown: within/after cooldown, zero-cooldown bypass
- [x] Global trip: high/low failure rate, min sample size, pause expiry/active
- [x] Entity isolation: independent tripping and cooldown per entity
- [x] Combined states: entity tripped + global ok, entity ok + global tripped
- [x] record_attempt returns result, reset (entity/all), empty state
- [x] Full suite: 254 tests pass, ruff clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)