### PR TITLE
Add T1 triage service and async decision engine

### DIFF
--- a/oasisagent/engine/decision.py
+++ b/oasisagent/engine/decision.py
@@ -1,8 +1,8 @@
 """Decision engine — core orchestrator for the event pipeline.
 
 Receives events from the queue, runs them through T0 known fixes lookup,
-applies guardrails, and produces DecisionResults. T1/T2 triage and
-handler dispatch are added in later Phase 1 items.
+then T1 triage (if no T0 match), applies guardrails, and produces
+DecisionResults.
 
 ARCHITECTURE.md §6 describes the decision flow.
 """
@@ -19,7 +19,8 @@ from oasisagent.engine.guardrails import GuardrailResult  # noqa: TC001 — Pyda
 
 if TYPE_CHECKING:
     from oasisagent.engine.guardrails import GuardrailsEngine
-    from oasisagent.engine.known_fixes import KnownFixRegistry
+    from oasisagent.engine.known_fixes import KnownFix, KnownFixRegistry
+    from oasisagent.llm.triage import TriageService
     from oasisagent.models import Event
 
 logger = logging.getLogger(__name__)
@@ -45,6 +46,8 @@ class DecisionDisposition(StrEnum):
     BLOCKED = "blocked"
     DRY_RUN = "dry_run"
     UNMATCHED = "unmatched"
+    DROPPED = "dropped"
+    ESCALATED = "escalated"
 
 
 class DecisionResult(BaseModel):
@@ -67,26 +70,28 @@ class DecisionResult(BaseModel):
 
 
 class DecisionEngine:
-    """Orchestrates event processing through T0 lookup and guardrails.
+    """Orchestrates event processing through T0 lookup, T1 triage, and guardrails.
 
     For Phase 1, the engine:
     1. Looks up events against the T0 known fixes registry
-    2. Applies guardrails to matched fixes
-    3. Returns a DecisionResult for every event (matched or unmatched)
+    2. If no T0 match and triage_service is available, calls T1 SLM
+    3. Applies guardrails to matched/classified fixes
+    4. Returns a DecisionResult for every event (matched, dropped, or escalated)
 
-    T1/T2 triage, handler dispatch, and circuit breaker integration
-    are added in subsequent Phase 1 items.
+    T2 deep reasoning and handler dispatch are added in later items.
     """
 
     def __init__(
         self,
         registry: KnownFixRegistry,
         guardrails: GuardrailsEngine,
+        triage_service: TriageService | None = None,
     ) -> None:
         self._registry = registry
         self._guardrails = guardrails
+        self._triage = triage_service
 
-    def process_event(self, event: Event) -> DecisionResult:
+    async def process_event(self, event: Event) -> DecisionResult:
         """Process a single event through the decision pipeline.
 
         Returns a DecisionResult regardless of outcome — every event
@@ -95,21 +100,27 @@ class DecisionEngine:
         # T0: Known fixes lookup
         fix = self._registry.match(event)
 
-        if fix is None:
-            logger.debug(
-                "No T0 match for event %s (system=%s, type=%s, entity=%s)",
-                event.id,
-                event.system,
-                event.event_type,
-                event.entity_id,
-            )
-            return DecisionResult(
-                event_id=event.id,
-                tier=DecisionTier.T0,
-                disposition=DecisionDisposition.UNMATCHED,
-                diagnosis="No known fix matched — pending T1/T2 processing",
-            )
+        if fix is not None:
+            return self._apply_t0_fix(event, fix)
 
+        # T1: Triage via local SLM (if available)
+        if self._triage is not None:
+            return await self._apply_t1_triage(event)
+
+        # No T0 match, no T1 available
+        logger.debug(
+            "No T0 match for event %s and no T1 triage available",
+            event.id,
+        )
+        return DecisionResult(
+            event_id=event.id,
+            tier=DecisionTier.T0,
+            disposition=DecisionDisposition.UNMATCHED,
+            diagnosis="No known fix matched and T1 triage is not configured",
+        )
+
+    def _apply_t0_fix(self, event: Event, fix: KnownFix) -> DecisionResult:
+        """Apply guardrails to a T0-matched fix and return a result."""
         logger.info(
             "T0 match: event %s → fix '%s' (risk_tier=%s)",
             event.id,
@@ -117,7 +128,6 @@ class DecisionEngine:
             fix.risk_tier,
         )
 
-        # Apply guardrails
         guardrail_result = self._guardrails.check(
             entity_id=event.entity_id,
             risk_tier=fix.risk_tier,
@@ -167,4 +177,81 @@ class DecisionEngine:
             matched_fix_id=fix.id,
             diagnosis=fix.diagnosis,
             guardrail_result=guardrail_result,
+        )
+
+    async def _apply_t1_triage(self, event: Event) -> DecisionResult:
+        """Classify an unmatched event via T1 SLM and return a result."""
+        from oasisagent.models import Disposition
+
+        triage_result = await self._triage.classify(event)
+
+        logger.info(
+            "T1 triage: event %s → disposition=%s, confidence=%.2f",
+            event.id,
+            triage_result.disposition,
+            triage_result.confidence,
+        )
+
+        if triage_result.disposition == Disposition.DROP:
+            return DecisionResult(
+                event_id=event.id,
+                tier=DecisionTier.T1,
+                disposition=DecisionDisposition.DROPPED,
+                diagnosis=triage_result.summary,
+                details={
+                    "classification": triage_result.classification,
+                    "confidence": triage_result.confidence,
+                    "reasoning": triage_result.reasoning,
+                },
+            )
+
+        if triage_result.disposition == Disposition.ESCALATE_T2:
+            return DecisionResult(
+                event_id=event.id,
+                tier=DecisionTier.T1,
+                disposition=DecisionDisposition.ESCALATED,
+                diagnosis=triage_result.summary,
+                details={
+                    "classification": triage_result.classification,
+                    "confidence": triage_result.confidence,
+                    "reasoning": triage_result.reasoning,
+                    "escalate_to": "t2",
+                },
+            )
+
+        if triage_result.disposition == Disposition.ESCALATE_HUMAN:
+            return DecisionResult(
+                event_id=event.id,
+                tier=DecisionTier.T1,
+                disposition=DecisionDisposition.ESCALATED,
+                diagnosis=triage_result.summary,
+                details={
+                    "classification": triage_result.classification,
+                    "confidence": triage_result.confidence,
+                    "reasoning": triage_result.reasoning,
+                    "escalate_to": "human",
+                },
+            )
+
+        # KNOWN_PATTERN — T1 found a pattern but guardrails still apply
+        if triage_result.disposition == Disposition.KNOWN_PATTERN:
+            return DecisionResult(
+                event_id=event.id,
+                tier=DecisionTier.T1,
+                disposition=DecisionDisposition.MATCHED,
+                diagnosis=triage_result.summary,
+                details={
+                    "classification": triage_result.classification,
+                    "confidence": triage_result.confidence,
+                    "reasoning": triage_result.reasoning,
+                    "suggested_fix": triage_result.suggested_fix,
+                },
+            )
+
+        # Fallback — shouldn't happen but be safe
+        return DecisionResult(
+            event_id=event.id,
+            tier=DecisionTier.T1,
+            disposition=DecisionDisposition.ESCALATED,
+            diagnosis=f"Unexpected T1 disposition: {triage_result.disposition}",
         )

--- a/oasisagent/llm/__init__.py
+++ b/oasisagent/llm/__init__.py
@@ -8,6 +8,7 @@ from oasisagent.llm.client import (
     TokenUsage,
     UsageStats,
 )
+from oasisagent.llm.triage import TriageService
 
 __all__ = [
     "LLMClient",
@@ -15,5 +16,6 @@ __all__ = [
     "LLMResponse",
     "LLMRole",
     "TokenUsage",
+    "TriageService",
     "UsageStats",
 ]

--- a/oasisagent/llm/prompts/classify_event.py
+++ b/oasisagent/llm/prompts/classify_event.py
@@ -1,1 +1,92 @@
-"""T1 prompt: Classify an event and determine disposition."""
+"""T1 prompt: Classify an event and determine disposition.
+
+The system prompt instructs the local SLM to classify infrastructure events
+and return a structured JSON response. The output schema (T1ClassifyOutput)
+is deliberately simpler than the canonical TriageResult — flat fields and
+string-typed enums give local models the best chance of producing valid JSON.
+
+TriageService maps T1ClassifyOutput → TriageResult.
+"""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING, Any
+
+from pydantic import BaseModel, ConfigDict
+
+if TYPE_CHECKING:
+    from oasisagent.models import Event
+
+SYSTEM_PROMPT = """\
+You are an infrastructure triage agent for a home lab. Your job is to classify \
+events from Home Assistant, Docker, and Proxmox and determine what action to take.
+
+For each event, respond with a JSON object containing these fields:
+
+- "disposition": One of these exact values:
+  - "drop" — The event is noise and should be ignored (e.g., transient sensor \
+blips, expected state changes)
+  - "known_pattern" — The issue has a recognizable pattern with a clear fix
+  - "escalate_t2" — The issue is complex and requires deeper analysis by a \
+more capable model
+  - "escalate_human" — The issue requires immediate human attention
+
+- "confidence": A float between 0.0 and 1.0 indicating how confident you are \
+in your classification
+
+- "classification": A short category label for the event (e.g., \
+"sensor_flap", "integration_failure", "automation_error", "network_issue")
+
+- "summary": A one-sentence human-readable summary of what happened and why \
+you classified it this way
+
+- "suggested_fix": If disposition is "known_pattern", describe the fix. \
+Otherwise set to null.
+
+- "reasoning": Brief explanation of your classification logic (1-2 sentences)
+
+Respond with ONLY the JSON object, no markdown fences or extra text.\
+"""
+
+
+class T1ClassifyOutput(BaseModel):
+    """Schema the SLM actually produces.
+
+    Deliberately flat and string-typed for maximum compatibility with
+    local models. TriageService maps this to the canonical TriageResult.
+    """
+
+    model_config = ConfigDict(extra="forbid")
+
+    disposition: str
+    confidence: float
+    classification: str
+    summary: str
+    suggested_fix: str | None = None
+    reasoning: str = ""
+
+
+def build_classify_messages(event: Event) -> list[dict[str, Any]]:
+    """Build chat messages for T1 event classification.
+
+    Returns messages in OpenAI chat format with the system prompt
+    and a user message containing the serialized event.
+    """
+    event_data = event.model_dump(mode="json")
+
+    # Remove fields the SLM doesn't need
+    event_data.pop("context", None)
+    event_data.pop("metadata", None)
+    event_data.pop("ingested_at", None)
+
+    import json
+
+    user_content = (
+        "Classify this infrastructure event:\n\n"
+        f"{json.dumps(event_data, indent=2, default=str)}"
+    )
+
+    return [
+        {"role": "system", "content": SYSTEM_PROMPT},
+        {"role": "user", "content": user_content},
+    ]

--- a/oasisagent/llm/prompts/summarize_context.py
+++ b/oasisagent/llm/prompts/summarize_context.py
@@ -1,1 +1,54 @@
-"""T1 prompt: Summarize context for T2 escalation or human notification."""
+"""T1 prompt: Summarize context for T2 escalation or human notification.
+
+When T1 classifies an event as escalate_t2, this prompt asks the SLM to
+prepare a structured context package that T2 can use for deep diagnosis.
+"""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING, Any
+
+if TYPE_CHECKING:
+    from oasisagent.models import Event, TriageResult
+
+SYSTEM_PROMPT = """\
+You are preparing a context summary for a senior infrastructure analyst. \
+An event has been classified as requiring deeper analysis.
+
+Summarize the event and its context into a structured JSON object with \
+these fields:
+
+- "event_summary": A clear, concise description of what happened (2-3 sentences)
+- "system_context": What system is affected and its role in the infrastructure
+- "failure_indicators": List of specific symptoms or error indicators observed
+- "potential_causes": List of possible root causes to investigate
+- "urgency": One of "low", "medium", "high", "critical"
+- "related_entities": List of entity IDs that may be related to this issue
+
+Respond with ONLY the JSON object, no markdown fences or extra text.\
+"""
+
+
+def build_summarize_messages(
+    event: Event, triage: TriageResult
+) -> list[dict[str, Any]]:
+    """Build chat messages for context summarization.
+
+    Combines the original event with T1's classification to give the
+    SLM full context for preparing the T2 escalation package.
+    """
+    import json
+
+    event_data = event.model_dump(mode="json")
+    triage_data = triage.model_dump(mode="json")
+
+    user_content = (
+        "Prepare a context summary for deeper analysis.\n\n"
+        f"Event:\n{json.dumps(event_data, indent=2, default=str)}\n\n"
+        f"T1 Classification:\n{json.dumps(triage_data, indent=2, default=str)}"
+    )
+
+    return [
+        {"role": "system", "content": SYSTEM_PROMPT},
+        {"role": "user", "content": user_content},
+    ]

--- a/oasisagent/llm/triage.py
+++ b/oasisagent/llm/triage.py
@@ -1,0 +1,131 @@
+"""T1 triage service — classifies events using the local SLM.
+
+Connects the LLMClient to the decision engine by converting events into
+prompt messages, calling the triage endpoint, and parsing the structured
+response into a canonical TriageResult.
+
+ARCHITECTURE.md §5 describes T1's role: classify and package, never
+decide to take action.
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+from typing import TYPE_CHECKING
+
+from oasisagent.llm.client import LLMError, LLMRole
+from oasisagent.llm.prompts.classify_event import T1ClassifyOutput, build_classify_messages
+from oasisagent.models import Disposition, TriageResult
+
+if TYPE_CHECKING:
+    from oasisagent.llm.client import LLMClient
+    from oasisagent.models import Event
+
+logger = logging.getLogger(__name__)
+
+# Map raw SLM output strings to canonical Disposition values.
+# Handles common variations local models may produce.
+_DISPOSITION_MAP: dict[str, Disposition] = {
+    "drop": Disposition.DROP,
+    "known_pattern": Disposition.KNOWN_PATTERN,
+    "escalate_t2": Disposition.ESCALATE_T2,
+    "escalate_human": Disposition.ESCALATE_HUMAN,
+    # Common SLM variations
+    "ignore": Disposition.DROP,
+    "noise": Disposition.DROP,
+    "escalate": Disposition.ESCALATE_HUMAN,
+    "notify_human": Disposition.ESCALATE_HUMAN,
+    "notify": Disposition.ESCALATE_HUMAN,
+}
+
+
+def _parse_disposition(raw: str) -> Disposition:
+    """Convert a raw SLM disposition string to the canonical enum.
+
+    Raises:
+        ValueError: If the string doesn't map to any known disposition.
+    """
+    normalized = raw.strip().lower()
+    disposition = _DISPOSITION_MAP.get(normalized)
+    if disposition is None:
+        raise ValueError(
+            f"Unknown disposition '{raw}'. "
+            f"Expected one of: {', '.join(sorted(_DISPOSITION_MAP))}"
+        )
+    return disposition
+
+
+class TriageService:
+    """Classifies events using the T1 local SLM.
+
+    Handles LLM call failures and JSON parse errors gracefully,
+    returning a conservative ESCALATE_HUMAN disposition rather than
+    dropping events silently.
+    """
+
+    def __init__(self, llm_client: LLMClient) -> None:
+        self._llm = llm_client
+
+    async def classify(self, event: Event) -> TriageResult:
+        """Classify an event and return a TriageResult.
+
+        On failure (LLM unavailable, bad JSON, invalid disposition),
+        returns a safe ESCALATE_HUMAN result so the event isn't lost.
+        """
+        messages = build_classify_messages(event)
+
+        try:
+            response = await self._llm.complete(
+                role=LLMRole.TRIAGE,
+                messages=messages,
+            )
+        except LLMError:
+            logger.error(
+                "T1 classify failed for event %s: LLM unavailable",
+                event.id,
+            )
+            return self._safe_fallback(event, reason="llm_unavailable")
+
+        try:
+            raw_output = T1ClassifyOutput.model_validate_json(response.content)
+        except (json.JSONDecodeError, ValueError) as exc:
+            logger.warning(
+                "T1 classify parse failure for event %s: %s. Raw: %.200s",
+                event.id,
+                exc,
+                response.content,
+            )
+            return self._safe_fallback(event, reason="parse_failure")
+
+        try:
+            disposition = _parse_disposition(raw_output.disposition)
+        except ValueError as exc:
+            logger.warning(
+                "T1 classify invalid disposition for event %s: %s",
+                event.id,
+                exc,
+            )
+            return self._safe_fallback(event, reason="parse_failure")
+
+        confidence = max(0.0, min(1.0, raw_output.confidence))
+
+        return TriageResult(
+            disposition=disposition,
+            confidence=confidence,
+            classification=raw_output.classification,
+            summary=raw_output.summary,
+            suggested_fix=raw_output.suggested_fix,
+            reasoning=raw_output.reasoning,
+        )
+
+    @staticmethod
+    def _safe_fallback(event: Event, *, reason: str) -> TriageResult:
+        """Return a conservative ESCALATE_HUMAN result on failure."""
+        return TriageResult(
+            disposition=Disposition.ESCALATE_HUMAN,
+            confidence=0.0,
+            classification="triage_failure",
+            summary=f"T1 triage failed ({reason}) — escalating to human",
+            reasoning=f"Automatic escalation due to {reason}",
+        )

--- a/tests/test_decision_engine.py
+++ b/tests/test_decision_engine.py
@@ -90,12 +90,12 @@ def _make_engine(
 class TestT0Matched:
     """Events that match a T0 fix and pass guardrails."""
 
-    def test_matched_event_returns_matched(self) -> None:
+    async def test_matched_event_returns_matched(self) -> None:
         fix = _make_fix(risk_tier=RiskTier.RECOMMEND)
         engine = _make_engine(fixes=[fix])
         event = _make_event()
 
-        result = engine.process_event(event)
+        result = await engine.process_event(event)
 
         assert result.event_id == event.id
         assert result.tier == DecisionTier.T0
@@ -105,11 +105,11 @@ class TestT0Matched:
         assert result.guardrail_result is not None
         assert result.guardrail_result.allowed is True
 
-    def test_auto_fix_tier_allowed(self) -> None:
+    async def test_auto_fix_tier_allowed(self) -> None:
         fix = _make_fix(risk_tier=RiskTier.AUTO_FIX)
         engine = _make_engine(fixes=[fix])
 
-        result = engine.process_event(_make_event())
+        result = await engine.process_event(_make_event())
 
         assert result.disposition == DecisionDisposition.MATCHED
         assert result.guardrail_result.risk_tier == RiskTier.AUTO_FIX
@@ -123,42 +123,42 @@ class TestT0Matched:
 class TestT0Blocked:
     """Events that match a T0 fix but are blocked by guardrails."""
 
-    def test_blocked_domain_returns_blocked(self) -> None:
+    async def test_blocked_domain_returns_blocked(self) -> None:
         fix = _make_fix(risk_tier=RiskTier.AUTO_FIX)
         engine = _make_engine(fixes=[fix])
         event = _make_event(entity_id="lock.front_door")
 
-        result = engine.process_event(event)
+        result = await engine.process_event(event)
 
         assert result.disposition == DecisionDisposition.BLOCKED
         assert result.matched_fix_id == "test-fix"
         assert result.guardrail_result is not None
         assert result.guardrail_result.allowed is False
 
-    def test_kill_switch_blocks(self) -> None:
+    async def test_kill_switch_blocks(self) -> None:
         fix = _make_fix(risk_tier=RiskTier.RECOMMEND)
         config = _make_guardrails(kill_switch=True)
         engine = _make_engine(fixes=[fix], guardrails_config=config)
 
-        result = engine.process_event(_make_event())
+        result = await engine.process_event(_make_event())
 
         assert result.disposition == DecisionDisposition.BLOCKED
         assert "kill switch" in result.guardrail_result.reason.lower()
 
-    def test_escalate_tier_blocked(self) -> None:
+    async def test_escalate_tier_blocked(self) -> None:
         fix = _make_fix(risk_tier=RiskTier.ESCALATE)
         engine = _make_engine(fixes=[fix])
 
-        result = engine.process_event(_make_event())
+        result = await engine.process_event(_make_event())
 
         assert result.disposition == DecisionDisposition.BLOCKED
         assert result.guardrail_result.risk_tier == RiskTier.ESCALATE
 
-    def test_block_tier_blocked(self) -> None:
+    async def test_block_tier_blocked(self) -> None:
         fix = _make_fix(risk_tier=RiskTier.BLOCK)
         engine = _make_engine(fixes=[fix])
 
-        result = engine.process_event(_make_event())
+        result = await engine.process_event(_make_event())
 
         assert result.disposition == DecisionDisposition.BLOCKED
 
@@ -171,12 +171,12 @@ class TestT0Blocked:
 class TestT0DryRun:
     """Events matched in dry run mode."""
 
-    def test_dry_run_returns_dry_run_disposition(self) -> None:
+    async def test_dry_run_returns_dry_run_disposition(self) -> None:
         fix = _make_fix(risk_tier=RiskTier.RECOMMEND)
         config = _make_guardrails(dry_run=True)
         engine = _make_engine(fixes=[fix], guardrails_config=config)
 
-        result = engine.process_event(_make_event())
+        result = await engine.process_event(_make_event())
 
         assert result.disposition == DecisionDisposition.DRY_RUN
         assert result.matched_fix_id == "test-fix"
@@ -185,32 +185,31 @@ class TestT0DryRun:
 
 
 # ---------------------------------------------------------------------------
-# No T0 match
+# No T0 match, no T1 available
 # ---------------------------------------------------------------------------
 
 
 class TestUnmatched:
-    """Events with no T0 match produce an UNMATCHED result."""
+    """Events with no T0 match and no T1 produce an UNMATCHED result."""
 
-    def test_no_match_returns_unmatched(self) -> None:
+    async def test_no_match_returns_unmatched(self) -> None:
         engine = _make_engine(fixes=[])
         event = _make_event()
 
-        result = engine.process_event(event)
+        result = await engine.process_event(event)
 
         assert result.event_id == event.id
         assert result.tier == DecisionTier.T0
         assert result.disposition == DecisionDisposition.UNMATCHED
         assert result.matched_fix_id is None
         assert result.guardrail_result is None
-        assert "T1/T2" in result.diagnosis
 
-    def test_unmatched_when_system_differs(self) -> None:
+    async def test_unmatched_when_system_differs(self) -> None:
         fix = _make_fix(match=FixMatch(system="docker"))
         engine = _make_engine(fixes=[fix])
         event = _make_event(system="homeassistant")
 
-        result = engine.process_event(event)
+        result = await engine.process_event(event)
 
         assert result.disposition == DecisionDisposition.UNMATCHED
 
@@ -223,7 +222,7 @@ class TestUnmatched:
 class TestMultipleEvents:
     """Process multiple events through the engine."""
 
-    def test_process_batch_in_order(self) -> None:
+    async def test_process_batch_in_order(self) -> None:
         fix = _make_fix(
             match=FixMatch(system="homeassistant", payload_contains="kelvin"),
         )
@@ -235,21 +234,21 @@ class TestMultipleEvents:
             _make_event(payload={"error": "kelvin in config"}),
         ]
 
-        results = [engine.process_event(e) for e in events]
+        results = [await engine.process_event(e) for e in events]
 
         assert results[0].disposition == DecisionDisposition.MATCHED
         assert results[1].disposition == DecisionDisposition.UNMATCHED
         assert results[2].disposition == DecisionDisposition.MATCHED
 
-    def test_different_entities_different_outcomes(self) -> None:
+    async def test_different_entities_different_outcomes(self) -> None:
         fix = _make_fix(risk_tier=RiskTier.AUTO_FIX)
         engine = _make_engine(fixes=[fix])
 
         safe = _make_event(entity_id="light.kitchen")
         blocked = _make_event(entity_id="lock.front_door")
 
-        safe_result = engine.process_event(safe)
-        blocked_result = engine.process_event(blocked)
+        safe_result = await engine.process_event(safe)
+        blocked_result = await engine.process_event(blocked)
 
         assert safe_result.disposition == DecisionDisposition.MATCHED
         assert blocked_result.disposition == DecisionDisposition.BLOCKED
@@ -273,11 +272,13 @@ class TestDecisionResultModel:
         assert DecisionDisposition.BLOCKED == "blocked"
         assert DecisionDisposition.DRY_RUN == "dry_run"
         assert DecisionDisposition.UNMATCHED == "unmatched"
+        assert DecisionDisposition.DROPPED == "dropped"
+        assert DecisionDisposition.ESCALATED == "escalated"
 
-    def test_result_serialization(self) -> None:
+    async def test_result_serialization(self) -> None:
         fix = _make_fix(risk_tier=RiskTier.RECOMMEND)
         engine = _make_engine(fixes=[fix])
-        result = engine.process_event(_make_event())
+        result = await engine.process_event(_make_event())
 
         data = result.model_dump()
         assert data["tier"] == "t0"
@@ -293,7 +294,7 @@ class TestDecisionResultModel:
 class TestIntegration:
     """End-to-end: load real YAML fixes, run events through engine."""
 
-    def test_kelvin_event_matched_and_allowed(self) -> None:
+    async def test_kelvin_event_matched_and_allowed(self) -> None:
         registry = KnownFixRegistry()
         registry.load(Path("known_fixes"))
         guardrails = GuardrailsEngine(_make_guardrails())
@@ -306,14 +307,14 @@ class TestIntegration:
             payload={"error": "kelvin deprecated"},
         )
 
-        result = engine.process_event(event)
+        result = await engine.process_event(event)
 
         assert result.disposition == DecisionDisposition.MATCHED
         assert result.matched_fix_id == "ha-deprecated-kelvin"
         assert result.tier == DecisionTier.T0
         assert result.guardrail_result.allowed is True
 
-    def test_unrelated_event_unmatched(self) -> None:
+    async def test_unrelated_event_unmatched(self) -> None:
         registry = KnownFixRegistry()
         registry.load(Path("known_fixes"))
         guardrails = GuardrailsEngine(_make_guardrails())
@@ -325,6 +326,6 @@ class TestIntegration:
             payload={"container": "nginx"},
         )
 
-        result = engine.process_event(event)
+        result = await engine.process_event(event)
 
         assert result.disposition == DecisionDisposition.UNMATCHED

--- a/tests/test_triage.py
+++ b/tests/test_triage.py
@@ -1,0 +1,407 @@
+"""Tests for T1 triage service and prompt templates."""
+
+from __future__ import annotations
+
+import json
+from datetime import UTC, datetime
+from typing import Any
+from unittest.mock import AsyncMock
+
+import pytest
+
+from oasisagent.config import (
+    CircuitBreakerConfig,
+    GuardrailsConfig,
+)
+from oasisagent.engine.decision import (
+    DecisionDisposition,
+    DecisionEngine,
+    DecisionTier,
+)
+from oasisagent.engine.guardrails import GuardrailsEngine
+from oasisagent.engine.known_fixes import KnownFixRegistry
+from oasisagent.llm.client import LLMClient, LLMError, LLMResponse, LLMRole
+from oasisagent.llm.prompts.classify_event import (
+    T1ClassifyOutput,
+    build_classify_messages,
+)
+from oasisagent.llm.triage import TriageService, _parse_disposition
+from oasisagent.models import Disposition, Event, EventMetadata, Severity
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _make_event(**overrides: Any) -> Event:
+    defaults: dict[str, Any] = {
+        "source": "test",
+        "system": "homeassistant",
+        "event_type": "state_unavailable",
+        "entity_id": "sensor.temperature",
+        "severity": Severity.WARNING,
+        "timestamp": datetime.now(UTC),
+        "payload": {"old_state": "23.5", "new_state": "unavailable"},
+        "metadata": EventMetadata(),
+    }
+    defaults.update(overrides)
+    return Event(**defaults)
+
+
+def _t1_json(
+    disposition: str = "drop",
+    confidence: float = 0.9,
+    classification: str = "sensor_flap",
+    summary: str = "Transient sensor blip",
+    suggested_fix: str | None = None,
+    reasoning: str = "Normal behavior",
+) -> str:
+    """Build a JSON string matching T1ClassifyOutput schema."""
+    return json.dumps({
+        "disposition": disposition,
+        "confidence": confidence,
+        "classification": classification,
+        "summary": summary,
+        "suggested_fix": suggested_fix,
+        "reasoning": reasoning,
+    })
+
+
+def _mock_llm_response(content: str) -> LLMResponse:
+    return LLMResponse(
+        content=content,
+        role=LLMRole.TRIAGE,
+        model="qwen2.5:7b",
+        usage=None,
+        latency_ms=100.0,
+    )
+
+
+def _mock_triage_service(content: str) -> TriageService:
+    """Create a TriageService with a mocked LLMClient returning given content."""
+    mock_client = AsyncMock(spec=LLMClient)
+    mock_client.complete.return_value = _mock_llm_response(content)
+    return TriageService(mock_client)
+
+
+# ---------------------------------------------------------------------------
+# T1ClassifyOutput schema
+# ---------------------------------------------------------------------------
+
+
+class TestT1ClassifyOutput:
+    """The SLM output schema parses correctly."""
+
+    def test_valid_output(self) -> None:
+        raw = _t1_json()
+        output = T1ClassifyOutput.model_validate_json(raw)
+
+        assert output.disposition == "drop"
+        assert output.confidence == 0.9
+        assert output.classification == "sensor_flap"
+
+    def test_with_suggested_fix(self) -> None:
+        raw = _t1_json(disposition="known_pattern", suggested_fix="Restart integration")
+        output = T1ClassifyOutput.model_validate_json(raw)
+
+        assert output.suggested_fix == "Restart integration"
+
+    def test_missing_optional_fields_ok(self) -> None:
+        raw = json.dumps({
+            "disposition": "drop",
+            "confidence": 0.5,
+            "classification": "noise",
+            "summary": "Noise event",
+        })
+        output = T1ClassifyOutput.model_validate_json(raw)
+
+        assert output.suggested_fix is None
+        assert output.reasoning == ""
+
+
+# ---------------------------------------------------------------------------
+# Disposition parsing
+# ---------------------------------------------------------------------------
+
+
+class TestDispositionParsing:
+    """Raw SLM strings map to canonical Disposition values."""
+
+    def test_canonical_values(self) -> None:
+        assert _parse_disposition("drop") == Disposition.DROP
+        assert _parse_disposition("known_pattern") == Disposition.KNOWN_PATTERN
+        assert _parse_disposition("escalate_t2") == Disposition.ESCALATE_T2
+        assert _parse_disposition("escalate_human") == Disposition.ESCALATE_HUMAN
+
+    def test_common_variations(self) -> None:
+        assert _parse_disposition("ignore") == Disposition.DROP
+        assert _parse_disposition("noise") == Disposition.DROP
+        assert _parse_disposition("escalate") == Disposition.ESCALATE_HUMAN
+        assert _parse_disposition("notify_human") == Disposition.ESCALATE_HUMAN
+        assert _parse_disposition("notify") == Disposition.ESCALATE_HUMAN
+
+    def test_case_insensitive(self) -> None:
+        assert _parse_disposition("DROP") == Disposition.DROP
+        assert _parse_disposition("Escalate_T2") == Disposition.ESCALATE_T2
+
+    def test_whitespace_stripped(self) -> None:
+        assert _parse_disposition("  drop  ") == Disposition.DROP
+
+    def test_unknown_raises(self) -> None:
+        with pytest.raises(ValueError, match="Unknown disposition"):
+            _parse_disposition("investigate")
+
+
+# ---------------------------------------------------------------------------
+# Prompt building
+# ---------------------------------------------------------------------------
+
+
+class TestBuildClassifyMessages:
+    """build_classify_messages produces valid chat messages."""
+
+    def test_returns_system_and_user(self) -> None:
+        messages = build_classify_messages(_make_event())
+
+        assert len(messages) == 2
+        assert messages[0]["role"] == "system"
+        assert messages[1]["role"] == "user"
+
+    def test_user_message_contains_event_data(self) -> None:
+        event = _make_event(entity_id="sensor.special")
+        messages = build_classify_messages(event)
+
+        assert "sensor.special" in messages[1]["content"]
+
+    def test_strips_context_and_metadata(self) -> None:
+        event = _make_event()
+        messages = build_classify_messages(event)
+        user_content = messages[1]["content"]
+
+        assert "context" not in json.loads(
+            user_content.split("Classify this infrastructure event:\n\n")[1]
+        )
+
+    def test_system_prompt_lists_dispositions(self) -> None:
+        messages = build_classify_messages(_make_event())
+        system = messages[0]["content"]
+
+        assert "drop" in system
+        assert "known_pattern" in system
+        assert "escalate_t2" in system
+        assert "escalate_human" in system
+
+
+# ---------------------------------------------------------------------------
+# TriageService.classify
+# ---------------------------------------------------------------------------
+
+
+class TestTriageServiceClassify:
+    """TriageService.classify calls LLM and parses response."""
+
+    async def test_valid_drop_response(self) -> None:
+        service = _mock_triage_service(_t1_json(disposition="drop"))
+        result = await service.classify(_make_event())
+
+        assert result.disposition == Disposition.DROP
+        assert result.confidence == 0.9
+        assert result.classification == "sensor_flap"
+
+    async def test_valid_known_pattern_response(self) -> None:
+        service = _mock_triage_service(
+            _t1_json(
+                disposition="known_pattern",
+                suggested_fix="Restart the Z-Wave integration",
+            )
+        )
+        result = await service.classify(_make_event())
+
+        assert result.disposition == Disposition.KNOWN_PATTERN
+        assert result.suggested_fix == "Restart the Z-Wave integration"
+
+    async def test_valid_escalate_t2_response(self) -> None:
+        service = _mock_triage_service(
+            _t1_json(disposition="escalate_t2", confidence=0.6)
+        )
+        result = await service.classify(_make_event())
+
+        assert result.disposition == Disposition.ESCALATE_T2
+        assert result.confidence == 0.6
+
+    async def test_confidence_clamped(self) -> None:
+        service = _mock_triage_service(
+            _t1_json(confidence=1.5)
+        )
+        result = await service.classify(_make_event())
+
+        assert result.confidence == 1.0
+
+    async def test_negative_confidence_clamped(self) -> None:
+        service = _mock_triage_service(
+            _t1_json(confidence=-0.5)
+        )
+        result = await service.classify(_make_event())
+
+        assert result.confidence == 0.0
+
+
+# ---------------------------------------------------------------------------
+# TriageService error handling
+# ---------------------------------------------------------------------------
+
+
+class TestTriageServiceErrors:
+    """Error paths return safe ESCALATE_HUMAN fallback."""
+
+    async def test_llm_unavailable_returns_escalate_human(self) -> None:
+        mock_client = AsyncMock(spec=LLMClient)
+        mock_client.complete.side_effect = LLMError("connection refused")
+        service = TriageService(mock_client)
+
+        result = await service.classify(_make_event())
+
+        assert result.disposition == Disposition.ESCALATE_HUMAN
+        assert result.confidence == 0.0
+        assert "llm_unavailable" in result.reasoning
+
+    async def test_invalid_json_returns_escalate_human(self) -> None:
+        service = _mock_triage_service("this is not json at all")
+
+        result = await service.classify(_make_event())
+
+        assert result.disposition == Disposition.ESCALATE_HUMAN
+        assert "parse_failure" in result.reasoning
+
+    async def test_invalid_disposition_returns_escalate_human(self) -> None:
+        service = _mock_triage_service(
+            _t1_json(disposition="investigate_further")
+        )
+
+        result = await service.classify(_make_event())
+
+        assert result.disposition == Disposition.ESCALATE_HUMAN
+        assert "parse_failure" in result.reasoning
+
+    async def test_slm_variation_handled(self) -> None:
+        """SLM returns 'notify' instead of 'escalate_human' — still works."""
+        service = _mock_triage_service(_t1_json(disposition="notify"))
+
+        result = await service.classify(_make_event())
+
+        assert result.disposition == Disposition.ESCALATE_HUMAN
+
+
+# ---------------------------------------------------------------------------
+# Decision engine T1 integration
+# ---------------------------------------------------------------------------
+
+
+class TestDecisionEngineT1:
+    """Decision engine uses T1 triage when T0 doesn't match."""
+
+    async def test_t0_miss_t1_drop(self) -> None:
+        service = _mock_triage_service(_t1_json(disposition="drop"))
+        engine = DecisionEngine(
+            registry=KnownFixRegistry(),
+            guardrails=GuardrailsEngine(GuardrailsConfig(circuit_breaker=CircuitBreakerConfig())),
+            triage_service=service,
+        )
+
+        result = await engine.process_event(_make_event())
+
+        assert result.tier == DecisionTier.T1
+        assert result.disposition == DecisionDisposition.DROPPED
+
+    async def test_t0_miss_t1_escalate_t2(self) -> None:
+        service = _mock_triage_service(_t1_json(disposition="escalate_t2"))
+        engine = DecisionEngine(
+            registry=KnownFixRegistry(),
+            guardrails=GuardrailsEngine(GuardrailsConfig(circuit_breaker=CircuitBreakerConfig())),
+            triage_service=service,
+        )
+
+        result = await engine.process_event(_make_event())
+
+        assert result.tier == DecisionTier.T1
+        assert result.disposition == DecisionDisposition.ESCALATED
+        assert result.details["escalate_to"] == "t2"
+
+    async def test_t0_miss_t1_escalate_human(self) -> None:
+        service = _mock_triage_service(_t1_json(disposition="escalate_human"))
+        engine = DecisionEngine(
+            registry=KnownFixRegistry(),
+            guardrails=GuardrailsEngine(GuardrailsConfig(circuit_breaker=CircuitBreakerConfig())),
+            triage_service=service,
+        )
+
+        result = await engine.process_event(_make_event())
+
+        assert result.tier == DecisionTier.T1
+        assert result.disposition == DecisionDisposition.ESCALATED
+        assert result.details["escalate_to"] == "human"
+
+    async def test_t0_miss_t1_known_pattern(self) -> None:
+        service = _mock_triage_service(
+            _t1_json(disposition="known_pattern", suggested_fix="Restart it")
+        )
+        engine = DecisionEngine(
+            registry=KnownFixRegistry(),
+            guardrails=GuardrailsEngine(GuardrailsConfig(circuit_breaker=CircuitBreakerConfig())),
+            triage_service=service,
+        )
+
+        result = await engine.process_event(_make_event())
+
+        assert result.tier == DecisionTier.T1
+        assert result.disposition == DecisionDisposition.MATCHED
+        assert result.details["suggested_fix"] == "Restart it"
+
+    async def test_t0_miss_t1_llm_failure_escalates(self) -> None:
+        mock_client = AsyncMock(spec=LLMClient)
+        mock_client.complete.side_effect = LLMError("down")
+        service = TriageService(mock_client)
+        engine = DecisionEngine(
+            registry=KnownFixRegistry(),
+            guardrails=GuardrailsEngine(GuardrailsConfig(circuit_breaker=CircuitBreakerConfig())),
+            triage_service=service,
+        )
+
+        result = await engine.process_event(_make_event())
+
+        assert result.tier == DecisionTier.T1
+        assert result.disposition == DecisionDisposition.ESCALATED
+        assert result.details["escalate_to"] == "human"
+
+    async def test_t0_match_skips_t1(self) -> None:
+        """T0 match should not call T1 at all."""
+        mock_client = AsyncMock(spec=LLMClient)
+        service = TriageService(mock_client)
+
+        from oasisagent.engine.known_fixes import FixAction, FixActionType, FixMatch, KnownFix
+
+        fix = KnownFix(
+            id="test-fix",
+            match=FixMatch(system="homeassistant"),
+            diagnosis="Known fix",
+            action=FixAction(
+                type=FixActionType.RECOMMEND,
+                handler="homeassistant",
+                operation="notify",
+            ),
+            risk_tier="recommend",
+        )
+        registry = KnownFixRegistry()
+        registry._fixes = [fix]
+
+        engine = DecisionEngine(
+            registry=registry,
+            guardrails=GuardrailsEngine(GuardrailsConfig(circuit_breaker=CircuitBreakerConfig())),
+            triage_service=service,
+        )
+
+        result = await engine.process_event(_make_event())
+
+        assert result.tier == DecisionTier.T0
+        assert result.disposition == DecisionDisposition.MATCHED
+        mock_client.complete.assert_not_called()


### PR DESCRIPTION
## Summary
- Adds `TriageService` connecting the LLM client to the decision engine for T1 event classification
- `T1ClassifyOutput` — flat, string-typed SLM output schema separate from canonical `TriageResult`, with disposition normalization for common SLM variations (`"notify"` → `escalate_human`, `"noise"` → `drop`)
- `process_event()` is now **async** — all 16 existing decision engine tests migrated, all callers updated
- Distinguishes `llm_unavailable` (ERROR level) from `parse_failure` (WARNING level) in safe fallback
- New `DecisionDisposition` values: `DROPPED` (T1 drop), `ESCALATED` (T1 escalate to T2 or human)
- System prompt explicitly lists all valid dispositions with descriptions for local model reliability
- T0 match skips T1 entirely (verified by test with `assert_not_called`)

## Test plan
- [x] 27 new triage tests: T1ClassifyOutput schema, disposition parsing (canonical + variations + case insensitive), prompt building, TriageService.classify (valid responses, confidence clamping, error paths), decision engine T1 integration (drop/escalate_t2/escalate_human/known_pattern/llm_failure/t0_skips_t1)
- [x] 16 existing decision engine tests migrated to async — all pass
- [x] Full suite: 311 tests pass, ruff clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)