### PR TITLE
Add Handler ABC and Home Assistant handler

### DIFF
--- a/config.example.yaml
+++ b/config.example.yaml
@@ -132,6 +132,7 @@ handlers:
     url: http://localhost:8123
     token: ${HA_TOKEN}
     verify_timeout: 30           # Seconds to wait after action to verify effect
+    verify_poll_interval: 2.0    # Seconds between verification polls
 
   # Docker — container health and restart (Phase 2)
   docker:

--- a/oasisagent/config.py
+++ b/oasisagent/config.py
@@ -326,6 +326,7 @@ class HaHandlerConfig(BaseModel):
     url: str = "http://localhost:8123"
     token: str = ""
     verify_timeout: Annotated[int, Field(ge=1)] = 30
+    verify_poll_interval: Annotated[float, Field(gt=0.0)] = 2.0
 
 
 class DockerHandlerConfig(BaseModel):

--- a/oasisagent/handlers/__init__.py
+++ b/oasisagent/handlers/__init__.py
@@ -1,1 +1,9 @@
 """System handlers — execute actions against managed infrastructure."""
+
+from oasisagent.handlers.base import Handler
+from oasisagent.handlers.homeassistant import HomeAssistantHandler
+
+__all__ = [
+    "Handler",
+    "HomeAssistantHandler",
+]

--- a/oasisagent/handlers/base.py
+++ b/oasisagent/handlers/base.py
@@ -1,0 +1,57 @@
+"""Handler abstract base class.
+
+All handlers implement this interface. The decision engine dispatches
+actions to handlers based on the ``handler`` field in RecommendedAction.
+
+ARCHITECTURE.md §8 defines the handler contract.
+"""
+
+from __future__ import annotations
+
+from abc import ABC, abstractmethod
+from typing import TYPE_CHECKING, Any
+
+if TYPE_CHECKING:
+    from oasisagent.models import ActionResult, Event, RecommendedAction, VerifyResult
+
+
+class Handler(ABC):
+    """Base class for all system handlers.
+
+    Handlers are the "hands" — they execute actions against managed
+    systems (Home Assistant, Docker, Proxmox, etc.).
+    """
+
+    @abstractmethod
+    def name(self) -> str:
+        """Handler identifier, matches Event.system and RecommendedAction.handler."""
+
+    @abstractmethod
+    async def can_handle(self, event: Event, action: RecommendedAction) -> bool:
+        """Check if this handler can execute the given action."""
+
+    @abstractmethod
+    async def execute(self, event: Event, action: RecommendedAction) -> ActionResult:
+        """Execute the action. Returns success/failure with details."""
+
+    @abstractmethod
+    async def verify(
+        self, event: Event, action: RecommendedAction, result: ActionResult
+    ) -> VerifyResult:
+        """Verify the action had the desired effect."""
+
+    @abstractmethod
+    async def get_context(self, event: Event) -> dict[str, Any]:
+        """Gather system-specific context for diagnosis (called by T1/T2)."""
+
+    async def start(self) -> None:  # noqa: B027 — intentional non-abstract default
+        """Initialize handler resources (e.g., HTTP sessions).
+
+        Default no-op. Override in handlers that need async setup.
+        """
+
+    async def stop(self) -> None:  # noqa: B027 — intentional non-abstract default
+        """Clean up handler resources.
+
+        Default no-op. Override in handlers that need async teardown.
+        """

--- a/oasisagent/handlers/homeassistant.py
+++ b/oasisagent/handlers/homeassistant.py
@@ -1,0 +1,309 @@
+"""Home Assistant handler — executes actions via the HA REST API.
+
+Phase 1 operations: notify, restart_integration, reload_automations,
+call_service, get_entity_state, get_error_log.
+
+ARCHITECTURE.md §8 defines the handler interface and HA-specific operations.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import logging
+import time
+from typing import TYPE_CHECKING, Any
+
+import aiohttp
+
+from oasisagent.handlers.base import Handler
+from oasisagent.models import ActionResult, ActionStatus, VerifyResult
+
+if TYPE_CHECKING:
+    from oasisagent.config import HaHandlerConfig
+    from oasisagent.models import Event, RecommendedAction
+
+logger = logging.getLogger(__name__)
+
+# Operations this handler supports. can_handle() whitelists these.
+_KNOWN_OPERATIONS: frozenset[str] = frozenset({
+    "notify",
+    "restart_integration",
+    "reload_automations",
+    "call_service",
+    "get_entity_state",
+    "get_error_log",
+})
+
+
+class HandlerNotStartedError(Exception):
+    """Raised when handler methods are called before start()."""
+
+
+class HomeAssistantHandler(Handler):
+    """Executes actions against Home Assistant via its REST API.
+
+    Must be started with ``await handler.start()`` before use.
+    The aiohttp session is created in start() and closed in stop().
+    """
+
+    def __init__(self, config: HaHandlerConfig) -> None:
+        self._config = config
+        self._session: aiohttp.ClientSession | None = None
+
+    def name(self) -> str:
+        return "homeassistant"
+
+    async def start(self) -> None:
+        """Create the aiohttp session with bearer token auth."""
+        headers: dict[str, str] = {
+            "Content-Type": "application/json",
+        }
+        if self._config.token:
+            headers["Authorization"] = f"Bearer {self._config.token}"
+
+        self._session = aiohttp.ClientSession(
+            base_url=self._config.url,
+            headers=headers,
+        )
+        logger.info("HA handler started (url=%s)", self._config.url)
+
+    async def stop(self) -> None:
+        """Close the aiohttp session."""
+        if self._session is not None:
+            await self._session.close()
+            self._session = None
+            logger.info("HA handler stopped")
+
+    async def can_handle(self, event: Event, action: RecommendedAction) -> bool:
+        """Check if this handler supports the action."""
+        return (
+            action.handler == "homeassistant"
+            and action.operation in _KNOWN_OPERATIONS
+        )
+
+    async def execute(
+        self, event: Event, action: RecommendedAction
+    ) -> ActionResult:
+        """Dispatch to the appropriate operation method."""
+        self._ensure_started()
+
+        dispatch = {
+            "notify": self._op_notify,
+            "restart_integration": self._op_restart_integration,
+            "reload_automations": self._op_reload_automations,
+            "call_service": self._op_call_service,
+            "get_entity_state": self._op_get_entity_state,
+            "get_error_log": self._op_get_error_log,
+        }
+
+        handler_fn = dispatch.get(action.operation)
+        if handler_fn is None:
+            return ActionResult(
+                status=ActionStatus.FAILURE,
+                error_message=f"Unknown operation: {action.operation}",
+            )
+
+        start = time.monotonic()
+        try:
+            result = await handler_fn(event, action)
+            elapsed = (time.monotonic() - start) * 1000
+            return result.model_copy(update={"duration_ms": elapsed})
+        except aiohttp.ClientError as exc:
+            elapsed = (time.monotonic() - start) * 1000
+            logger.error(
+                "HA handler HTTP error for %s: %s", action.operation, exc
+            )
+            return ActionResult(
+                status=ActionStatus.FAILURE,
+                error_message=f"HTTP error: {exc}",
+                duration_ms=elapsed,
+            )
+
+    async def verify(
+        self, event: Event, action: RecommendedAction, result: ActionResult
+    ) -> VerifyResult:
+        """Verify an action had the desired effect.
+
+        Only restart_integration has real verification (polls entity state).
+        Other operations return verified=True immediately (Phase 1).
+        """
+        if action.operation != "restart_integration":
+            return VerifyResult(verified=True, message="No verification needed")
+
+        self._ensure_started()
+        return await self._verify_entity_recovery(event.entity_id)
+
+    async def get_context(self, event: Event) -> dict[str, Any]:
+        """Gather HA-specific context for diagnosis."""
+        self._ensure_started()
+        context: dict[str, Any] = {}
+
+        try:
+            state = await self._get_state(event.entity_id)
+            context["entity_state"] = state
+        except aiohttp.ClientError as exc:
+            context["entity_state_error"] = str(exc)
+
+        try:
+            error_log = await self._get_error_log()
+            context["recent_errors"] = error_log
+        except aiohttp.ClientError as exc:
+            context["error_log_error"] = str(exc)
+
+        return context
+
+    # -------------------------------------------------------------------
+    # Operation implementations
+    # -------------------------------------------------------------------
+
+    async def _op_notify(
+        self, event: Event, action: RecommendedAction
+    ) -> ActionResult:
+        """Notify — no system changes. Returns the diagnosis message."""
+        message = action.params.get("message", action.description)
+        logger.info("HA notify: %s (entity=%s)", message, event.entity_id)
+        return ActionResult(
+            status=ActionStatus.SUCCESS,
+            details={"message": message, "entity_id": event.entity_id},
+        )
+
+    async def _op_restart_integration(
+        self, event: Event, action: RecommendedAction
+    ) -> ActionResult:
+        """Restart an integration via homeassistant.reload_config_entry."""
+        entry_id = action.params.get("entry_id")
+        if not entry_id:
+            return ActionResult(
+                status=ActionStatus.FAILURE,
+                error_message="restart_integration requires 'entry_id' in params",
+            )
+
+        assert self._session is not None
+        async with self._session.post(
+            "/api/services/homeassistant/reload_config_entry",
+            json={"entry_id": entry_id},
+        ) as resp:
+            resp.raise_for_status()
+
+        logger.info("HA restart_integration: entry_id=%s", entry_id)
+        return ActionResult(
+            status=ActionStatus.SUCCESS,
+            details={"entry_id": entry_id},
+        )
+
+    async def _op_reload_automations(
+        self, event: Event, action: RecommendedAction
+    ) -> ActionResult:
+        """Reload all automations."""
+        assert self._session is not None
+        async with self._session.post(
+            "/api/services/automation/reload",
+            json={},
+        ) as resp:
+            resp.raise_for_status()
+
+        logger.info("HA reload_automations completed")
+        return ActionResult(
+            status=ActionStatus.SUCCESS,
+            details={"operation": "reload_automations"},
+        )
+
+    async def _op_call_service(
+        self, event: Event, action: RecommendedAction
+    ) -> ActionResult:
+        """Generic HA service call."""
+        domain = action.params.get("domain")
+        service = action.params.get("service")
+        if not domain or not service:
+            return ActionResult(
+                status=ActionStatus.FAILURE,
+                error_message="call_service requires 'domain' and 'service' in params",
+            )
+
+        service_data = action.params.get("service_data", {})
+        assert self._session is not None
+        async with self._session.post(
+            f"/api/services/{domain}/{service}",
+            json=service_data,
+        ) as resp:
+            resp.raise_for_status()
+
+        logger.info("HA call_service: %s.%s", domain, service)
+        return ActionResult(
+            status=ActionStatus.SUCCESS,
+            details={"domain": domain, "service": service, "service_data": service_data},
+        )
+
+    async def _op_get_entity_state(
+        self, event: Event, action: RecommendedAction
+    ) -> ActionResult:
+        """Read entity state — context-gathering, not a mutating action."""
+        entity_id = action.params.get("entity_id", event.entity_id)
+        state = await self._get_state(entity_id)
+        return ActionResult(
+            status=ActionStatus.SUCCESS,
+            details={"entity_id": entity_id, "state": state},
+        )
+
+    async def _op_get_error_log(
+        self, event: Event, action: RecommendedAction
+    ) -> ActionResult:
+        """Fetch recent error log entries."""
+        log_text = await self._get_error_log()
+        return ActionResult(
+            status=ActionStatus.SUCCESS,
+            details={"error_log": log_text},
+        )
+
+    # -------------------------------------------------------------------
+    # Internal helpers
+    # -------------------------------------------------------------------
+
+    def _ensure_started(self) -> None:
+        """Raise if the handler hasn't been started."""
+        if self._session is None:
+            raise HandlerNotStartedError(
+                "HomeAssistantHandler.start() must be called before use"
+            )
+
+    async def _get_state(self, entity_id: str) -> dict[str, Any]:
+        """GET /api/states/{entity_id}."""
+        assert self._session is not None
+        async with self._session.get(f"/api/states/{entity_id}") as resp:
+            resp.raise_for_status()
+            return await resp.json()
+
+    async def _get_error_log(self) -> str:
+        """GET /api/error_log — returns plain text."""
+        assert self._session is not None
+        async with self._session.get("/api/error_log") as resp:
+            resp.raise_for_status()
+            return await resp.text()
+
+    async def _verify_entity_recovery(self, entity_id: str) -> VerifyResult:
+        """Poll entity state to check if it recovers from unavailable."""
+        timeout = self._config.verify_timeout
+        interval = self._config.verify_poll_interval
+        deadline = time.monotonic() + timeout
+
+        while time.monotonic() < deadline:
+            try:
+                state = await self._get_state(entity_id)
+                current = state.get("state", "unknown")
+                if current not in ("unavailable", "unknown"):
+                    return VerifyResult(
+                        verified=True,
+                        message=f"Entity {entity_id} recovered to state '{current}'",
+                    )
+            except aiohttp.ClientError:
+                pass  # Keep polling
+
+            await asyncio.sleep(interval)
+
+        return VerifyResult(
+            verified=False,
+            message=(
+                f"Entity {entity_id} did not recover within "
+                f"{timeout}s (still unavailable/unknown)"
+            ),
+        )

--- a/tests/test_ha_handler.py
+++ b/tests/test_ha_handler.py
@@ -1,1 +1,572 @@
 """Tests for the Home Assistant handler."""
+
+from __future__ import annotations
+
+from datetime import UTC, datetime
+from typing import Any
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import aiohttp
+import pytest
+
+from oasisagent.config import HaHandlerConfig
+from oasisagent.handlers.homeassistant import (
+    HandlerNotStartedError,
+    HomeAssistantHandler,
+)
+from oasisagent.models import (
+    ActionStatus,
+    Event,
+    EventMetadata,
+    RecommendedAction,
+    RiskTier,
+    Severity,
+)
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _make_config(**overrides: Any) -> HaHandlerConfig:
+    defaults: dict[str, Any] = {
+        "enabled": True,
+        "url": "http://localhost:8123",
+        "token": "test-token",
+        "verify_timeout": 5,
+        "verify_poll_interval": 0.1,
+    }
+    defaults.update(overrides)
+    return HaHandlerConfig(**defaults)
+
+
+def _make_event(**overrides: Any) -> Event:
+    defaults: dict[str, Any] = {
+        "source": "test",
+        "system": "homeassistant",
+        "event_type": "state_unavailable",
+        "entity_id": "light.kitchen",
+        "severity": Severity.WARNING,
+        "timestamp": datetime.now(UTC),
+        "payload": {},
+        "metadata": EventMetadata(),
+    }
+    defaults.update(overrides)
+    return Event(**defaults)
+
+
+def _make_action(**overrides: Any) -> RecommendedAction:
+    defaults: dict[str, Any] = {
+        "description": "Test action",
+        "handler": "homeassistant",
+        "operation": "notify",
+        "params": {},
+        "risk_tier": RiskTier.RECOMMEND,
+    }
+    defaults.update(overrides)
+    return RecommendedAction(**defaults)
+
+
+def _mock_response(
+    status: int = 200,
+    json_data: dict[str, Any] | None = None,
+    text_data: str = "",
+) -> MagicMock:
+    """Create a mock aiohttp response.
+
+    Uses MagicMock (not AsyncMock) because aiohttp's raise_for_status()
+    is synchronous. json()/text() are async.
+    """
+    resp = MagicMock()
+    resp.status = status
+    resp.json = AsyncMock(return_value=json_data or {})
+    resp.text = AsyncMock(return_value=text_data)
+    if status >= 400:
+        resp.raise_for_status.side_effect = aiohttp.ClientResponseError(
+            request_info=MagicMock(),
+            history=(),
+            status=status,
+            message=f"HTTP {status}",
+        )
+    else:
+        resp.raise_for_status.return_value = None
+    return resp
+
+
+def _patch_session(
+    handler: HomeAssistantHandler, responses: dict[str, MagicMock]
+) -> None:
+    """Replace the handler's session with a mock that returns specified responses.
+
+    responses maps method+path patterns to mock responses, e.g.:
+        {"post:/api/services/automation/reload": _mock_response()}
+    """
+    session = MagicMock(spec=aiohttp.ClientSession)
+
+    def _make_cm(resp: MagicMock) -> MagicMock:
+        cm = MagicMock()
+        cm.__aenter__ = AsyncMock(return_value=resp)
+        cm.__aexit__ = AsyncMock(return_value=False)
+        return cm
+
+    def _get_handler(path: str, **kwargs: Any) -> MagicMock:
+        key = f"get:{path}"
+        resp = responses.get(key, _mock_response())
+        return _make_cm(resp)
+
+    def _post_handler(path: str, **kwargs: Any) -> MagicMock:
+        key = f"post:{path}"
+        resp = responses.get(key, _mock_response())
+        return _make_cm(resp)
+
+    session.get = MagicMock(side_effect=_get_handler)
+    session.post = MagicMock(side_effect=_post_handler)
+    session.close = AsyncMock()
+
+    handler._session = session
+
+
+async def _started_handler(**config_overrides: Any) -> HomeAssistantHandler:
+    """Create a handler with a mocked session (skipping real HTTP)."""
+    handler = HomeAssistantHandler(_make_config(**config_overrides))
+    handler._session = AsyncMock(spec=aiohttp.ClientSession)
+    return handler
+
+
+# ---------------------------------------------------------------------------
+# Lifecycle
+# ---------------------------------------------------------------------------
+
+
+class TestLifecycle:
+    """Handler start/stop lifecycle."""
+
+    async def test_start_creates_session(self) -> None:
+        handler = HomeAssistantHandler(_make_config())
+        with patch("oasisagent.handlers.homeassistant.aiohttp.ClientSession") as mock_cls:
+            await handler.start()
+            mock_cls.assert_called_once()
+            assert handler._session is not None
+
+    async def test_stop_closes_session(self) -> None:
+        handler = HomeAssistantHandler(_make_config())
+        mock_session = AsyncMock()
+        handler._session = mock_session
+
+        await handler.stop()
+
+        mock_session.close.assert_called_once()
+        assert handler._session is None
+
+    async def test_stop_without_start_is_noop(self) -> None:
+        handler = HomeAssistantHandler(_make_config())
+        await handler.stop()  # Should not raise
+
+    async def test_execute_before_start_raises(self) -> None:
+        handler = HomeAssistantHandler(_make_config())
+
+        with pytest.raises(HandlerNotStartedError):
+            await handler.execute(_make_event(), _make_action())
+
+    async def test_get_context_before_start_raises(self) -> None:
+        handler = HomeAssistantHandler(_make_config())
+
+        with pytest.raises(HandlerNotStartedError):
+            await handler.get_context(_make_event())
+
+    async def test_verify_before_start_raises_for_restart(self) -> None:
+        handler = HomeAssistantHandler(_make_config())
+        action = _make_action(operation="restart_integration")
+        from oasisagent.models import ActionResult
+
+        result = ActionResult(status=ActionStatus.SUCCESS)
+        with pytest.raises(HandlerNotStartedError):
+            await handler.verify(_make_event(), action, result)
+
+
+# ---------------------------------------------------------------------------
+# name()
+# ---------------------------------------------------------------------------
+
+
+class TestName:
+    def test_name_is_homeassistant(self) -> None:
+        handler = HomeAssistantHandler(_make_config())
+        assert handler.name() == "homeassistant"
+
+
+# ---------------------------------------------------------------------------
+# can_handle()
+# ---------------------------------------------------------------------------
+
+
+class TestCanHandle:
+    """can_handle whitelists known operations."""
+
+    async def test_known_operation_accepted(self) -> None:
+        handler = HomeAssistantHandler(_make_config())
+        event = _make_event()
+
+        for op in ["notify", "restart_integration", "reload_automations",
+                    "call_service", "get_entity_state", "get_error_log"]:
+            action = _make_action(operation=op)
+            assert await handler.can_handle(event, action) is True
+
+    async def test_unknown_operation_rejected(self) -> None:
+        handler = HomeAssistantHandler(_make_config())
+        action = _make_action(operation="delete_everything")
+
+        assert await handler.can_handle(_make_event(), action) is False
+
+    async def test_wrong_handler_rejected(self) -> None:
+        handler = HomeAssistantHandler(_make_config())
+        action = _make_action(handler="docker", operation="notify")
+
+        assert await handler.can_handle(_make_event(), action) is False
+
+
+# ---------------------------------------------------------------------------
+# execute: notify
+# ---------------------------------------------------------------------------
+
+
+class TestNotify:
+    async def test_notify_returns_success(self) -> None:
+        handler = await _started_handler()
+        _patch_session(handler, {})
+        action = _make_action(
+            operation="notify",
+            params={"message": "Integration restarted"},
+        )
+
+        result = await handler.execute(_make_event(), action)
+
+        assert result.status == ActionStatus.SUCCESS
+        assert result.details["message"] == "Integration restarted"
+
+    async def test_notify_uses_description_as_fallback(self) -> None:
+        handler = await _started_handler()
+        _patch_session(handler, {})
+        action = _make_action(
+            operation="notify",
+            description="Fallback message",
+            params={},
+        )
+
+        result = await handler.execute(_make_event(), action)
+
+        assert result.details["message"] == "Fallback message"
+
+
+# ---------------------------------------------------------------------------
+# execute: restart_integration
+# ---------------------------------------------------------------------------
+
+
+class TestRestartIntegration:
+    async def test_success(self) -> None:
+        handler = await _started_handler()
+        _patch_session(handler, {
+            "post:/api/services/homeassistant/reload_config_entry": _mock_response(),
+        })
+        action = _make_action(
+            operation="restart_integration",
+            params={"entry_id": "abc123"},
+        )
+
+        result = await handler.execute(_make_event(), action)
+
+        assert result.status == ActionStatus.SUCCESS
+        assert result.details["entry_id"] == "abc123"
+        assert result.duration_ms is not None
+
+    async def test_missing_entry_id_fails(self) -> None:
+        handler = await _started_handler()
+        _patch_session(handler, {})
+        action = _make_action(operation="restart_integration", params={})
+
+        result = await handler.execute(_make_event(), action)
+
+        assert result.status == ActionStatus.FAILURE
+        assert "entry_id" in result.error_message
+
+    async def test_http_error_returns_failure(self) -> None:
+        handler = await _started_handler()
+        _patch_session(handler, {
+            "post:/api/services/homeassistant/reload_config_entry": _mock_response(status=500),
+        })
+        action = _make_action(
+            operation="restart_integration",
+            params={"entry_id": "abc123"},
+        )
+
+        result = await handler.execute(_make_event(), action)
+
+        assert result.status == ActionStatus.FAILURE
+        assert "HTTP error" in result.error_message
+
+
+# ---------------------------------------------------------------------------
+# execute: reload_automations
+# ---------------------------------------------------------------------------
+
+
+class TestReloadAutomations:
+    async def test_success(self) -> None:
+        handler = await _started_handler()
+        _patch_session(handler, {
+            "post:/api/services/automation/reload": _mock_response(),
+        })
+        action = _make_action(operation="reload_automations")
+
+        result = await handler.execute(_make_event(), action)
+
+        assert result.status == ActionStatus.SUCCESS
+
+
+# ---------------------------------------------------------------------------
+# execute: call_service
+# ---------------------------------------------------------------------------
+
+
+class TestCallService:
+    async def test_success(self) -> None:
+        handler = await _started_handler()
+        _patch_session(handler, {
+            "post:/api/services/light/turn_on": _mock_response(),
+        })
+        action = _make_action(
+            operation="call_service",
+            params={
+                "domain": "light",
+                "service": "turn_on",
+                "service_data": {"entity_id": "light.kitchen"},
+            },
+        )
+
+        result = await handler.execute(_make_event(), action)
+
+        assert result.status == ActionStatus.SUCCESS
+        assert result.details["domain"] == "light"
+        assert result.details["service"] == "turn_on"
+
+    async def test_missing_domain_fails(self) -> None:
+        handler = await _started_handler()
+        _patch_session(handler, {})
+        action = _make_action(
+            operation="call_service",
+            params={"service": "turn_on"},
+        )
+
+        result = await handler.execute(_make_event(), action)
+
+        assert result.status == ActionStatus.FAILURE
+        assert "domain" in result.error_message
+
+    async def test_missing_service_fails(self) -> None:
+        handler = await _started_handler()
+        _patch_session(handler, {})
+        action = _make_action(
+            operation="call_service",
+            params={"domain": "light"},
+        )
+
+        result = await handler.execute(_make_event(), action)
+
+        assert result.status == ActionStatus.FAILURE
+        assert "service" in result.error_message
+
+
+# ---------------------------------------------------------------------------
+# execute: get_entity_state
+# ---------------------------------------------------------------------------
+
+
+class TestGetEntityState:
+    async def test_success(self) -> None:
+        state_data = {"entity_id": "light.kitchen", "state": "on"}
+        handler = await _started_handler()
+        _patch_session(handler, {
+            "get:/api/states/light.kitchen": _mock_response(json_data=state_data),
+        })
+        action = _make_action(
+            operation="get_entity_state",
+            params={"entity_id": "light.kitchen"},
+        )
+
+        result = await handler.execute(_make_event(), action)
+
+        assert result.status == ActionStatus.SUCCESS
+        assert result.details["state"] == state_data
+
+    async def test_uses_event_entity_id_as_fallback(self) -> None:
+        handler = await _started_handler()
+        _patch_session(handler, {
+            "get:/api/states/light.kitchen": _mock_response(json_data={"state": "on"}),
+        })
+        action = _make_action(operation="get_entity_state", params={})
+
+        result = await handler.execute(
+            _make_event(entity_id="light.kitchen"), action
+        )
+
+        assert result.status == ActionStatus.SUCCESS
+
+
+# ---------------------------------------------------------------------------
+# execute: get_error_log
+# ---------------------------------------------------------------------------
+
+
+class TestGetErrorLog:
+    async def test_success(self) -> None:
+        handler = await _started_handler()
+        _patch_session(handler, {
+            "get:/api/error_log": _mock_response(text_data="Error: something broke\n"),
+        })
+        action = _make_action(operation="get_error_log")
+
+        result = await handler.execute(_make_event(), action)
+
+        assert result.status == ActionStatus.SUCCESS
+        assert "something broke" in result.details["error_log"]
+
+
+# ---------------------------------------------------------------------------
+# execute: unknown operation
+# ---------------------------------------------------------------------------
+
+
+class TestUnknownOperation:
+    async def test_unknown_operation_returns_failure(self) -> None:
+        handler = await _started_handler()
+        _patch_session(handler, {})
+        action = _make_action(operation="delete_everything")
+
+        result = await handler.execute(_make_event(), action)
+
+        assert result.status == ActionStatus.FAILURE
+        assert "Unknown operation" in result.error_message
+
+
+# ---------------------------------------------------------------------------
+# execute: duration tracking
+# ---------------------------------------------------------------------------
+
+
+class TestDurationTracking:
+    async def test_duration_ms_set_on_success(self) -> None:
+        handler = await _started_handler()
+        _patch_session(handler, {})
+        action = _make_action(operation="notify")
+
+        result = await handler.execute(_make_event(), action)
+
+        assert result.duration_ms is not None
+        assert result.duration_ms >= 0
+
+    async def test_duration_ms_set_on_http_error(self) -> None:
+        handler = await _started_handler()
+        _patch_session(handler, {
+            "post:/api/services/homeassistant/reload_config_entry": _mock_response(status=500),
+        })
+        action = _make_action(
+            operation="restart_integration",
+            params={"entry_id": "abc123"},
+        )
+
+        result = await handler.execute(_make_event(), action)
+
+        assert result.duration_ms is not None
+
+
+# ---------------------------------------------------------------------------
+# verify
+# ---------------------------------------------------------------------------
+
+
+class TestVerify:
+    """Verification after action execution."""
+
+    async def test_non_restart_returns_verified(self) -> None:
+        handler = HomeAssistantHandler(_make_config())
+        action = _make_action(operation="notify")
+        from oasisagent.models import ActionResult
+
+        result = ActionResult(status=ActionStatus.SUCCESS)
+        verify = await handler.verify(_make_event(), action, result)
+
+        assert verify.verified is True
+
+    async def test_restart_verified_when_entity_recovers(self) -> None:
+        handler = await _started_handler(verify_timeout=5, verify_poll_interval=0.05)
+        _patch_session(handler, {
+            "get:/api/states/light.kitchen": _mock_response(
+                json_data={"state": "on"}
+            ),
+        })
+        action = _make_action(operation="restart_integration")
+        from oasisagent.models import ActionResult
+
+        result = ActionResult(status=ActionStatus.SUCCESS)
+        verify = await handler.verify(
+            _make_event(entity_id="light.kitchen"), action, result
+        )
+
+        assert verify.verified is True
+        assert "recovered" in verify.message
+
+    async def test_restart_not_verified_when_still_unavailable(self) -> None:
+        handler = await _started_handler(verify_timeout=1, verify_poll_interval=0.05)
+        _patch_session(handler, {
+            "get:/api/states/light.kitchen": _mock_response(
+                json_data={"state": "unavailable"}
+            ),
+        })
+        action = _make_action(operation="restart_integration")
+        from oasisagent.models import ActionResult
+
+        result = ActionResult(status=ActionStatus.SUCCESS)
+        verify = await handler.verify(
+            _make_event(entity_id="light.kitchen"), action, result
+        )
+
+        assert verify.verified is False
+        assert "did not recover" in verify.message
+
+
+# ---------------------------------------------------------------------------
+# get_context
+# ---------------------------------------------------------------------------
+
+
+class TestGetContext:
+    async def test_gathers_state_and_log(self) -> None:
+        handler = await _started_handler()
+        _patch_session(handler, {
+            "get:/api/states/light.kitchen": _mock_response(
+                json_data={"state": "unavailable"}
+            ),
+            "get:/api/error_log": _mock_response(text_data="Error log text"),
+        })
+
+        context = await handler.get_context(
+            _make_event(entity_id="light.kitchen")
+        )
+
+        assert "entity_state" in context
+        assert "recent_errors" in context
+
+    async def test_handles_state_error_gracefully(self) -> None:
+        handler = await _started_handler()
+        _patch_session(handler, {
+            "get:/api/states/light.kitchen": _mock_response(status=404),
+            "get:/api/error_log": _mock_response(text_data="logs"),
+        })
+
+        context = await handler.get_context(
+            _make_event(entity_id="light.kitchen")
+        )
+
+        assert "entity_state_error" in context
+        assert "recent_errors" in context


### PR DESCRIPTION
## Summary
- Adds `Handler` ABC (`oasisagent/handlers/base.py`) with the five abstract methods from ARCHITECTURE.md §8 plus non-abstract `start()`/`stop()` lifecycle methods (default no-op)
- Implements `HomeAssistantHandler` with six operations via HA REST API:
  - `notify`, `restart_integration`, `reload_automations`, `call_service`, `get_entity_state`, `get_error_log`
- Operation dispatch via dict lookup; `can_handle()` whitelists known operations (defense in depth)
- `HandlerNotStartedError` raised if methods called before `start()` — no silent NPE
- HTTP errors return `ActionResult(status=FAILURE)` with error details — handler never crashes the pipeline
- `verify()` polls entity state for `restart_integration` using configurable `verify_timeout` + `verify_poll_interval`; other operations return `verified=True` immediately (Phase 1)
- Added `verify_poll_interval: float = 2.0` to `HaHandlerConfig` and `config.example.yaml`

## Test plan
- [x] 30 tests with mocked aiohttp sessions
- [x] Lifecycle: start creates session, stop closes it, stop-before-start no-op, execute/verify/get_context-before-start raise
- [x] can_handle: all 6 operations accepted, unknown operation rejected, wrong handler rejected
- [x] Each operation: success path + failure paths (missing params, HTTP errors)
- [x] Duration tracking on success and failure
- [x] Verify: non-restart returns verified, restart polls until recovery or timeout
- [x] get_context: gathers state + error log, handles HTTP errors gracefully
- [x] Full suite: 341 tests pass, ruff clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)