### PR TITLE
Add InfluxDB audit writer for event/decision/action logging

### DIFF
--- a/oasisagent/audit/__init__.py
+++ b/oasisagent/audit/__init__.py
@@ -1,1 +1,8 @@
 """Audit logging — every event, decision, and action recorded to InfluxDB."""
+
+from oasisagent.audit.influxdb import AuditNotStartedError, AuditWriter
+
+__all__ = [
+    "AuditNotStartedError",
+    "AuditWriter",
+]

--- a/oasisagent/audit/influxdb.py
+++ b/oasisagent/audit/influxdb.py
@@ -1,0 +1,214 @@
+"""InfluxDB audit writer — records events, decisions, and actions.
+
+Every event, decision, and action that passes through OasisAgent is
+recorded to InfluxDB for full audit trail. This is best-effort: write
+failures are logged but never crash the pipeline.
+
+ARCHITECTURE.md §9 defines the measurement schemas.
+
+Tag vs. field split (InfluxDB performance):
+  Tags (indexed, low cardinality):
+    source, system, event_type, severity, entity_id, tier,
+    disposition, risk_tier, handler, operation, action_status,
+    trigger_type
+  Fields (not indexed, high cardinality or variable):
+    payload (JSON), details (JSON), error_message, duration_ms,
+    confidence, diagnosis, reasoning, correlation_id, summary,
+    attempts, window_minutes, message, event_timestamp
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+from datetime import UTC, datetime
+from typing import TYPE_CHECKING
+
+from influxdb_client import Point
+from influxdb_client.client.influxdb_client_async import InfluxDBClientAsync
+
+if TYPE_CHECKING:
+    from influxdb_client.client.write_api_async import WriteApiAsync
+
+    from oasisagent.config import AuditConfig
+    from oasisagent.engine.circuit_breaker import CircuitBreakerResult
+    from oasisagent.engine.decision import DecisionResult
+    from oasisagent.models import ActionResult, Event, RecommendedAction
+
+logger = logging.getLogger(__name__)
+
+
+class AuditNotStartedError(Exception):
+    """Raised when audit methods are called before start()."""
+
+
+class AuditWriter:
+    """Records audit data to InfluxDB v2.
+
+    Follows the same lifecycle pattern as Handler: start() creates
+    async resources, stop() tears them down. If InfluxDB is disabled
+    in config, all methods are no-ops.
+    """
+
+    def __init__(self, config: AuditConfig) -> None:
+        self._config = config
+        self._client: InfluxDBClientAsync | None = None
+        self._write_api: WriteApiAsync | None = None
+
+    @property
+    def _enabled(self) -> bool:
+        return self._config.influxdb.enabled
+
+    @property
+    def _bucket(self) -> str:
+        return self._config.influxdb.bucket
+
+    async def start(self) -> None:
+        """Create InfluxDB client. No-op if disabled."""
+        if not self._enabled:
+            logger.info("Audit writer disabled — skipping InfluxDB connection")
+            return
+
+        influx = self._config.influxdb
+        self._client = InfluxDBClientAsync(
+            url=influx.url,
+            token=influx.token,
+            org=influx.org,
+        )
+        self._write_api = self._client.write_api()
+        logger.info("Audit writer started (url=%s, bucket=%s)", influx.url, influx.bucket)
+
+    async def stop(self) -> None:
+        """Close InfluxDB client. No-op if disabled or not started."""
+        if self._client is not None:
+            await self._client.close()
+            self._client = None
+            self._write_api = None
+            logger.info("Audit writer stopped")
+
+    async def write_event(self, event: Event) -> None:
+        """Record an ingested event (oasis_event measurement)."""
+        if not self._enabled:
+            return
+        self._ensure_started()
+
+        point = (
+            Point("oasis_event")
+            .tag("source", event.source)
+            .tag("system", event.system)
+            .tag("event_type", event.event_type)
+            .tag("entity_id", event.entity_id)
+            .tag("severity", event.severity.value)
+            .field("payload", json.dumps(event.payload, default=str))
+            .field("correlation_id", event.metadata.correlation_id or "")
+            .field("event_id", event.id)
+            .time(event.timestamp)
+        )
+
+        await self._write(point)
+
+    async def write_decision(
+        self, event: Event, result: DecisionResult
+    ) -> None:
+        """Record a decision engine result (oasis_decision measurement)."""
+        if not self._enabled:
+            return
+        self._ensure_started()
+
+        risk_tier = ""
+        if result.guardrail_result is not None:
+            risk_tier = result.guardrail_result.risk_tier.value
+
+        point = (
+            Point("oasis_decision")
+            .tag("event_id", result.event_id)
+            .tag("tier", result.tier.value)
+            .tag("disposition", result.disposition.value)
+            .tag("risk_tier", risk_tier)
+            .field("diagnosis", result.diagnosis)
+            .field("matched_fix_id", result.matched_fix_id or "")
+            .field("details", json.dumps(result.details, default=str))
+            .field("event_timestamp", event.timestamp.isoformat())
+            .time(datetime.now(UTC))
+        )
+
+        await self._write(point)
+
+    async def write_action(
+        self,
+        event: Event,
+        action: RecommendedAction,
+        result: ActionResult,
+    ) -> None:
+        """Record a handler action result (oasis_action measurement)."""
+        if not self._enabled:
+            return
+        self._ensure_started()
+
+        point = (
+            Point("oasis_action")
+            .tag("event_id", event.id)
+            .tag("handler", action.handler)
+            .tag("operation", action.operation)
+            .tag("action_status", result.status.value)
+            .field("details", json.dumps(result.details, default=str))
+            .field("duration_ms", result.duration_ms or 0.0)
+            .field("error_message", result.error_message or "")
+            .field("event_timestamp", event.timestamp.isoformat())
+            .time(datetime.now(UTC))
+        )
+
+        await self._write(point)
+
+    async def write_circuit_breaker(
+        self,
+        entity_id: str,
+        result: CircuitBreakerResult,
+    ) -> None:
+        """Record a circuit breaker trip (oasis_circuit_breaker measurement)."""
+        if not self._enabled:
+            return
+        self._ensure_started()
+
+        if result.entity_tripped:
+            trigger_type = "entity"
+        elif result.global_tripped:
+            trigger_type = "global"
+        elif result.entity_cooldown:
+            trigger_type = "cooldown"
+        else:
+            trigger_type = "unknown"
+
+        point = (
+            Point("oasis_circuit_breaker")
+            .tag("entity_id", entity_id)
+            .tag("trigger_type", trigger_type)
+            .field("reason", result.reason)
+            .field("allowed", result.allowed)
+            .time(datetime.now(UTC))
+        )
+
+        await self._write(point)
+
+    # -------------------------------------------------------------------
+    # Internal helpers
+    # -------------------------------------------------------------------
+
+    def _ensure_started(self) -> None:
+        """Raise if the writer hasn't been started."""
+        if self._write_api is None:
+            raise AuditNotStartedError(
+                "AuditWriter.start() must be called before writing"
+            )
+
+    async def _write(self, point: Point) -> None:
+        """Write a point to InfluxDB. Best-effort — errors are logged."""
+        try:
+            assert self._write_api is not None
+            await self._write_api.write(bucket=self._bucket, record=point)
+        except Exception as exc:
+            logger.warning(
+                "Audit write failed for %s: %s",
+                point._name,
+                exc,
+            )

--- a/tests/test_audit.py
+++ b/tests/test_audit.py
@@ -1,0 +1,376 @@
+"""Tests for the InfluxDB audit writer."""
+
+from __future__ import annotations
+
+from datetime import UTC, datetime
+from typing import Any
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from oasisagent.audit.influxdb import AuditNotStartedError, AuditWriter
+from oasisagent.config import AuditConfig, InfluxDbConfig
+from oasisagent.engine.circuit_breaker import CircuitBreakerResult
+from oasisagent.engine.decision import (
+    DecisionDisposition,
+    DecisionResult,
+    DecisionTier,
+)
+from oasisagent.engine.guardrails import GuardrailResult
+from oasisagent.models import (
+    ActionResult,
+    ActionStatus,
+    Event,
+    EventMetadata,
+    RecommendedAction,
+    RiskTier,
+    Severity,
+)
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _make_config(enabled: bool = True) -> AuditConfig:
+    return AuditConfig(
+        influxdb=InfluxDbConfig(
+            enabled=enabled,
+            url="http://localhost:8086",
+            token="test-token",
+            org="testorg",
+            bucket="testbucket",
+        ),
+    )
+
+
+def _make_event(**overrides: Any) -> Event:
+    defaults: dict[str, Any] = {
+        "source": "mqtt",
+        "system": "homeassistant",
+        "event_type": "state_unavailable",
+        "entity_id": "light.kitchen",
+        "severity": Severity.WARNING,
+        "timestamp": datetime(2026, 3, 8, 12, 0, 0, tzinfo=UTC),
+        "payload": {"old_state": "on", "new_state": "unavailable"},
+        "metadata": EventMetadata(correlation_id="corr-123"),
+    }
+    defaults.update(overrides)
+    return Event(**defaults)
+
+
+def _make_decision(**overrides: Any) -> DecisionResult:
+    defaults: dict[str, Any] = {
+        "event_id": "evt-001",
+        "tier": DecisionTier.T0,
+        "disposition": DecisionDisposition.MATCHED,
+        "matched_fix_id": "ha-fix-1",
+        "diagnosis": "Known issue",
+        "guardrail_result": GuardrailResult(
+            allowed=True,
+            reason="ok",
+            risk_tier=RiskTier.RECOMMEND,
+        ),
+    }
+    defaults.update(overrides)
+    return DecisionResult(**defaults)
+
+
+def _make_action_pair() -> tuple[RecommendedAction, ActionResult]:
+    action = RecommendedAction(
+        description="Restart integration",
+        handler="homeassistant",
+        operation="restart_integration",
+        params={"entry_id": "abc123"},
+        risk_tier=RiskTier.AUTO_FIX,
+    )
+    result = ActionResult(
+        status=ActionStatus.SUCCESS,
+        details={"entry_id": "abc123"},
+        duration_ms=150.0,
+    )
+    return action, result
+
+
+async def _started_writer(enabled: bool = True) -> AuditWriter:
+    """Create a writer with a mocked InfluxDB client."""
+    writer = AuditWriter(_make_config(enabled=enabled))
+    if enabled:
+        writer._write_api = AsyncMock()
+        writer._client = MagicMock()
+        writer._client.close = AsyncMock()
+    return writer
+
+
+# ---------------------------------------------------------------------------
+# Lifecycle
+# ---------------------------------------------------------------------------
+
+
+class TestLifecycle:
+    """start/stop lifecycle follows Handler pattern."""
+
+    @patch("oasisagent.audit.influxdb.InfluxDBClientAsync")
+    async def test_start_creates_client(self, mock_cls: MagicMock) -> None:
+        mock_instance = MagicMock()
+        mock_instance.write_api.return_value = MagicMock()
+        mock_cls.return_value = mock_instance
+
+        writer = AuditWriter(_make_config())
+        await writer.start()
+
+        mock_cls.assert_called_once_with(
+            url="http://localhost:8086",
+            token="test-token",
+            org="testorg",
+        )
+        assert writer._client is not None
+        assert writer._write_api is not None
+
+    async def test_stop_closes_client(self) -> None:
+        writer = await _started_writer()
+        mock_client = writer._client
+
+        await writer.stop()
+
+        mock_client.close.assert_called_once()
+        assert writer._client is None
+        assert writer._write_api is None
+
+    async def test_stop_without_start_is_noop(self) -> None:
+        writer = AuditWriter(_make_config())
+        await writer.stop()  # Should not raise
+
+    async def test_write_before_start_raises(self) -> None:
+        writer = AuditWriter(_make_config())
+
+        with pytest.raises(AuditNotStartedError):
+            await writer.write_event(_make_event())
+
+    @patch("oasisagent.audit.influxdb.InfluxDBClientAsync")
+    async def test_disabled_start_no_client_created(
+        self, mock_cls: MagicMock
+    ) -> None:
+        writer = AuditWriter(_make_config(enabled=False))
+        await writer.start()
+
+        mock_cls.assert_not_called()
+        assert writer._client is None
+
+
+# ---------------------------------------------------------------------------
+# Disabled mode
+# ---------------------------------------------------------------------------
+
+
+class TestDisabledMode:
+    """All writes are no-ops when InfluxDB is disabled."""
+
+    async def test_write_event_noop(self) -> None:
+        writer = await _started_writer(enabled=False)
+        await writer.write_event(_make_event())  # Should not raise
+
+    async def test_write_decision_noop(self) -> None:
+        writer = await _started_writer(enabled=False)
+        await writer.write_decision(_make_event(), _make_decision())
+
+    async def test_write_action_noop(self) -> None:
+        writer = await _started_writer(enabled=False)
+        action, result = _make_action_pair()
+        await writer.write_action(_make_event(), action, result)
+
+    async def test_write_circuit_breaker_noop(self) -> None:
+        writer = await _started_writer(enabled=False)
+        cb_result = CircuitBreakerResult(
+            allowed=False, reason="tripped", entity_tripped=True
+        )
+        await writer.write_circuit_breaker("light.kitchen", cb_result)
+
+
+# ---------------------------------------------------------------------------
+# write_event
+# ---------------------------------------------------------------------------
+
+
+class TestWriteEvent:
+    async def test_writes_correct_point(self) -> None:
+        writer = await _started_writer()
+        event = _make_event()
+
+        await writer.write_event(event)
+
+        writer._write_api.write.assert_called_once()
+        call_kwargs = writer._write_api.write.call_args.kwargs
+        assert call_kwargs["bucket"] == "testbucket"
+
+        point = call_kwargs["record"]
+        line = point.to_line_protocol()
+        assert "oasis_event" in line
+        assert "source=mqtt" in line
+        assert "system=homeassistant" in line
+        assert "event_type=state_unavailable" in line
+        assert "entity_id=light.kitchen" in line
+        assert "severity=warning" in line
+        assert "corr-123" in line
+
+    async def test_payload_serialized_as_json(self) -> None:
+        writer = await _started_writer()
+        event = _make_event(payload={"key": "value"})
+
+        await writer.write_event(event)
+
+        point = writer._write_api.write.call_args.kwargs["record"]
+        line = point.to_line_protocol()
+        # Line protocol escapes inner quotes: {\"key\": \"value\"}
+        assert "key" in line
+        assert "value" in line
+
+
+# ---------------------------------------------------------------------------
+# write_decision
+# ---------------------------------------------------------------------------
+
+
+class TestWriteDecision:
+    async def test_writes_correct_point(self) -> None:
+        writer = await _started_writer()
+        event = _make_event()
+        decision = _make_decision()
+
+        await writer.write_decision(event, decision)
+
+        point = writer._write_api.write.call_args.kwargs["record"]
+        line = point.to_line_protocol()
+        assert "oasis_decision" in line
+        assert "tier=t0" in line
+        assert "disposition=matched" in line
+        assert "risk_tier=recommend" in line
+        assert "Known issue" in line
+
+    async def test_includes_event_timestamp_field(self) -> None:
+        writer = await _started_writer()
+        event = _make_event()
+
+        await writer.write_decision(event, _make_decision())
+
+        point = writer._write_api.write.call_args.kwargs["record"]
+        line = point.to_line_protocol()
+        assert "event_timestamp=" in line
+
+    async def test_no_guardrail_result_empty_risk_tier(self) -> None:
+        writer = await _started_writer()
+        decision = _make_decision(guardrail_result=None)
+
+        await writer.write_decision(_make_event(), decision)
+
+        point = writer._write_api.write.call_args.kwargs["record"]
+        line = point.to_line_protocol()
+        # risk_tier tag should be empty string (InfluxDB omits empty tags)
+        assert "oasis_decision" in line
+
+
+# ---------------------------------------------------------------------------
+# write_action
+# ---------------------------------------------------------------------------
+
+
+class TestWriteAction:
+    async def test_writes_correct_point(self) -> None:
+        writer = await _started_writer()
+        event = _make_event()
+        action, result = _make_action_pair()
+
+        await writer.write_action(event, action, result)
+
+        point = writer._write_api.write.call_args.kwargs["record"]
+        line = point.to_line_protocol()
+        assert "oasis_action" in line
+        assert "handler=homeassistant" in line
+        assert "operation=restart_integration" in line
+        assert "action_status=success" in line
+        assert "duration_ms=150" in line
+
+    async def test_failure_includes_error_message(self) -> None:
+        writer = await _started_writer()
+        action = RecommendedAction(
+            description="Test",
+            handler="homeassistant",
+            operation="notify",
+            risk_tier=RiskTier.RECOMMEND,
+        )
+        result = ActionResult(
+            status=ActionStatus.FAILURE,
+            error_message="Connection refused",
+        )
+
+        await writer.write_action(_make_event(), action, result)
+
+        point = writer._write_api.write.call_args.kwargs["record"]
+        line = point.to_line_protocol()
+        assert "Connection refused" in line
+
+
+# ---------------------------------------------------------------------------
+# write_circuit_breaker
+# ---------------------------------------------------------------------------
+
+
+class TestWriteCircuitBreaker:
+    async def test_entity_tripped(self) -> None:
+        writer = await _started_writer()
+        cb = CircuitBreakerResult(
+            allowed=False, reason="3 attempts", entity_tripped=True
+        )
+
+        await writer.write_circuit_breaker("light.kitchen", cb)
+
+        point = writer._write_api.write.call_args.kwargs["record"]
+        line = point.to_line_protocol()
+        assert "oasis_circuit_breaker" in line
+        assert "entity_id=light.kitchen" in line
+        assert "trigger_type=entity" in line
+
+    async def test_global_tripped(self) -> None:
+        writer = await _started_writer()
+        cb = CircuitBreakerResult(
+            allowed=False, reason="failure rate", global_tripped=True
+        )
+
+        await writer.write_circuit_breaker("entity.new", cb)
+
+        point = writer._write_api.write.call_args.kwargs["record"]
+        line = point.to_line_protocol()
+        assert "trigger_type=global" in line
+
+    async def test_cooldown(self) -> None:
+        writer = await _started_writer()
+        cb = CircuitBreakerResult(
+            allowed=False, reason="cooldown active", entity_cooldown=True
+        )
+
+        await writer.write_circuit_breaker("light.kitchen", cb)
+
+        point = writer._write_api.write.call_args.kwargs["record"]
+        line = point.to_line_protocol()
+        assert "trigger_type=cooldown" in line
+
+
+# ---------------------------------------------------------------------------
+# Error handling
+# ---------------------------------------------------------------------------
+
+
+class TestErrorHandling:
+    async def test_write_error_logged_not_raised(
+        self, caplog: pytest.LogCaptureFixture
+    ) -> None:
+        writer = await _started_writer()
+        writer._write_api.write.side_effect = Exception("connection refused")
+
+        import logging
+
+        with caplog.at_level(logging.WARNING, logger="oasisagent.audit.influxdb"):
+            await writer.write_event(_make_event())
+
+        assert any("Audit write failed" in r.message for r in caplog.records)
+        # Should NOT raise


### PR DESCRIPTION
## Summary
- Adds `AuditWriter` that records all events, decisions, actions, and circuit breaker trips to InfluxDB v2
- Four measurements per ARCHITECTURE.md §9: `oasis_event`, `oasis_decision`, `oasis_action`, `oasis_circuit_breaker`
- Tag/field split documented in module docstring (tags=indexed low-cardinality, fields=high-cardinality/variable)
- Best-effort writes: errors logged at WARNING level, never crash the processing pipeline
- `start()`/`stop()` lifecycle matching Handler pattern with `AuditNotStartedError` guard
- Disabled mode: all methods are no-ops, `InfluxDBClientAsync` never instantiated (verified by test)
- Explicit timestamps on all Points: `event.timestamp` for events, `datetime.now(UTC)` for decisions/actions with `event_timestamp` field for correlation

## Test plan
- [x] 20 tests with mocked InfluxDB client
- [x] Lifecycle: start creates client, stop closes it, stop-before-start no-op, write-before-start raises
- [x] Disabled mode: start doesn't create client, all four write methods are no-ops
- [x] write_event: correct tags/fields, payload serialized as JSON
- [x] write_decision: correct tags including risk_tier, event_timestamp field, handles None guardrail_result
- [x] write_action: correct tags, duration_ms, error_message for failures
- [x] write_circuit_breaker: entity/global/cooldown trigger types
- [x] Error handling: write failure logged but not raised
- [x] Full suite: 361 tests pass, ruff clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)