### PR TITLE
Add MQTT notification channel and dispatcher (Phase 1, item #13)

### DIFF
--- a/oasisagent/config.py
+++ b/oasisagent/config.py
@@ -434,6 +434,8 @@ class MqttNotificationConfig(BaseModel):
     topic_prefix: str = "oasis/notifications"
     username: str = ""
     password: str = ""
+    qos: Annotated[int, Field(ge=0, le=2)] = 1
+    retain: bool = False
 
 
 class EmailNotificationConfig(BaseModel):

--- a/oasisagent/notifications/__init__.py
+++ b/oasisagent/notifications/__init__.py
@@ -1,1 +1,11 @@
 """Notification dispatch — alert channels for escalations and status updates."""
+
+from oasisagent.notifications.base import NotificationChannel
+from oasisagent.notifications.dispatcher import NotificationDispatcher
+from oasisagent.notifications.mqtt import MqttNotificationChannel
+
+__all__ = [
+    "MqttNotificationChannel",
+    "NotificationChannel",
+    "NotificationDispatcher",
+]

--- a/oasisagent/notifications/base.py
+++ b/oasisagent/notifications/base.py
@@ -1,0 +1,33 @@
+"""Notification channel abstract base class.
+
+All notification channels implement this interface. The dispatcher
+fans out notifications to all enabled channels.
+
+ARCHITECTURE.md §10 defines the notification contract.
+"""
+
+from __future__ import annotations
+
+from abc import ABC, abstractmethod
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from oasisagent.models import Notification
+
+
+class NotificationChannel(ABC):
+    """Base class for notification channels (MQTT, email, webhook, etc.)."""
+
+    @abstractmethod
+    async def send(self, notification: Notification) -> bool:
+        """Send a notification. Returns True on success."""
+
+    @abstractmethod
+    def name(self) -> str:
+        """Channel identifier for logging and result tracking."""
+
+    async def start(self) -> None:  # noqa: B027 — intentional non-abstract default
+        """Initialize channel resources. Default no-op."""
+
+    async def stop(self) -> None:  # noqa: B027 — intentional non-abstract default
+        """Clean up channel resources. Default no-op."""

--- a/oasisagent/notifications/dispatcher.py
+++ b/oasisagent/notifications/dispatcher.py
@@ -1,0 +1,69 @@
+"""Notification dispatcher — fans out notifications to all enabled channels.
+
+The dispatcher owns the lifecycle of all channels and provides a single
+point of entry for sending notifications.
+"""
+
+from __future__ import annotations
+
+import logging
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from oasisagent.models import Notification
+    from oasisagent.notifications.base import NotificationChannel
+
+logger = logging.getLogger(__name__)
+
+
+class NotificationDispatcher:
+    """Sends notifications to all registered channels.
+
+    One channel failing (connect, send, or disconnect) does not
+    affect the others.
+    """
+
+    def __init__(self, channels: list[NotificationChannel]) -> None:
+        self._channels = channels
+
+    async def start(self) -> None:
+        """Start all channels. Failures are logged, not raised."""
+        for channel in self._channels:
+            try:
+                await channel.start()
+            except Exception as exc:
+                logger.error(
+                    "Notification channel '%s' failed to start: %s",
+                    channel.name(),
+                    exc,
+                )
+
+    async def stop(self) -> None:
+        """Stop all channels. Failures are logged, not raised."""
+        for channel in self._channels:
+            try:
+                await channel.stop()
+            except Exception as exc:
+                logger.error(
+                    "Notification channel '%s' failed to stop: %s",
+                    channel.name(),
+                    exc,
+                )
+
+    async def dispatch(self, notification: Notification) -> dict[str, bool]:
+        """Send a notification to all channels.
+
+        Returns a dict mapping channel name → success boolean.
+        """
+        results: dict[str, bool] = {}
+        for channel in self._channels:
+            try:
+                results[channel.name()] = await channel.send(notification)
+            except Exception as exc:
+                logger.warning(
+                    "Notification channel '%s' raised during send: %s",
+                    channel.name(),
+                    exc,
+                )
+                results[channel.name()] = False
+        return results

--- a/oasisagent/notifications/mqtt.py
+++ b/oasisagent/notifications/mqtt.py
@@ -1,0 +1,114 @@
+"""MQTT notification channel — publishes notifications to MQTT topics.
+
+Topic structure: {topic_prefix}/{severity}
+Example: oasis/notifications/error, oasis/notifications/warning
+
+This allows downstream consumers (HA automations, Node-RED) to subscribe
+to specific severity levels or use wildcard oasis/notifications/#.
+"""
+
+from __future__ import annotations
+
+import logging
+from typing import TYPE_CHECKING
+from urllib.parse import urlparse
+
+import aiomqtt
+
+from oasisagent.notifications.base import NotificationChannel
+
+if TYPE_CHECKING:
+    from oasisagent.config import MqttNotificationConfig
+    from oasisagent.models import Notification
+
+logger = logging.getLogger(__name__)
+
+
+class MqttNotificationChannel(NotificationChannel):
+    """Publishes notifications as JSON to MQTT topics.
+
+    Must be started with ``await channel.start()`` before use.
+    If disabled in config, ``send()`` returns True immediately (no-op).
+    """
+
+    def __init__(self, config: MqttNotificationConfig) -> None:
+        self._config = config
+        self._client: aiomqtt.Client | None = None
+
+    def name(self) -> str:
+        return "mqtt"
+
+    async def start(self) -> None:
+        """Connect to the MQTT broker."""
+        if not self._config.enabled:
+            logger.info("MQTT notifications disabled — skipping connection")
+            return
+
+        parsed = urlparse(self._config.broker)
+        hostname = parsed.hostname or "localhost"
+        port = parsed.port or 1883
+
+        self._client = aiomqtt.Client(
+            hostname=hostname,
+            port=port,
+            username=self._config.username or None,
+            password=self._config.password or None,
+        )
+        await self._client.__aenter__()
+        logger.info(
+            "MQTT notification channel started (broker=%s, prefix=%s)",
+            self._config.broker,
+            self._config.topic_prefix,
+        )
+
+    async def stop(self) -> None:
+        """Disconnect from the MQTT broker."""
+        if self._client is not None:
+            try:
+                await self._client.__aexit__(None, None, None)
+            except Exception as exc:
+                logger.warning("Error closing MQTT notification client: %s", exc)
+            self._client = None
+            logger.info("MQTT notification channel stopped")
+
+    async def send(self, notification: Notification) -> bool:
+        """Publish a notification to MQTT.
+
+        Topic: {topic_prefix}/{severity}
+        Payload: JSON-serialized Notification model.
+
+        Returns True on success, False on failure (best-effort).
+        """
+        if not self._config.enabled:
+            return True
+
+        if self._client is None:
+            logger.warning(
+                "MQTT notification channel not started — dropping notification %s",
+                notification.id,
+            )
+            return False
+
+        topic = f"{self._config.topic_prefix}/{notification.severity.value}"
+        payload = notification.model_dump_json()
+
+        try:
+            await self._client.publish(
+                topic=topic,
+                payload=payload,
+                qos=self._config.qos,
+                retain=self._config.retain,
+            )
+            logger.debug(
+                "MQTT notification sent: topic=%s, id=%s",
+                topic,
+                notification.id,
+            )
+            return True
+        except Exception as exc:
+            logger.warning(
+                "MQTT notification publish failed for %s: %s",
+                notification.id,
+                exc,
+            )
+            return False

--- a/tests/test_notifications.py
+++ b/tests/test_notifications.py
@@ -1,0 +1,383 @@
+"""Tests for notification channels and dispatcher."""
+
+from __future__ import annotations
+
+from typing import Any
+from unittest.mock import AsyncMock, MagicMock, patch
+
+from oasisagent.config import MqttNotificationConfig
+from oasisagent.models import Notification, Severity
+from oasisagent.notifications.base import NotificationChannel
+from oasisagent.notifications.dispatcher import NotificationDispatcher
+from oasisagent.notifications.mqtt import MqttNotificationChannel
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _make_config(**overrides: Any) -> MqttNotificationConfig:
+    defaults: dict[str, Any] = {
+        "enabled": True,
+        "broker": "mqtt://localhost:1883",
+        "topic_prefix": "oasis/notifications",
+        "username": "user",
+        "password": "pass",
+        "qos": 1,
+        "retain": False,
+    }
+    defaults.update(overrides)
+    return MqttNotificationConfig(**defaults)
+
+
+def _make_notification(**overrides: Any) -> Notification:
+    defaults: dict[str, Any] = {
+        "title": "Test Alert",
+        "message": "Something happened",
+        "severity": Severity.WARNING,
+        "event_id": "evt-001",
+    }
+    defaults.update(overrides)
+    return Notification(**defaults)
+
+
+def _mock_mqtt_channel(
+    send_result: bool = True,
+    start_error: Exception | None = None,
+) -> MqttNotificationChannel:
+    """Create an MQTT channel with a mocked client."""
+    channel = MqttNotificationChannel(_make_config())
+    mock_client = AsyncMock()
+    if not send_result:
+        mock_client.publish.side_effect = Exception("publish failed")
+    channel._client = mock_client
+    return channel
+
+
+class _StubChannel(NotificationChannel):
+    """Test stub implementing NotificationChannel."""
+
+    def __init__(self, channel_name: str = "stub", success: bool = True) -> None:
+        self._name = channel_name
+        self._success = success
+        self.sent: list[Notification] = []
+
+    def name(self) -> str:
+        return self._name
+
+    async def send(self, notification: Notification) -> bool:
+        self.sent.append(notification)
+        return self._success
+
+
+class _FailingChannel(NotificationChannel):
+    """Channel that raises on start/send/stop."""
+
+    def __init__(self, fail_on: str = "send") -> None:
+        self._fail_on = fail_on
+
+    def name(self) -> str:
+        return "failing"
+
+    async def start(self) -> None:
+        if self._fail_on == "start":
+            raise ConnectionError("cannot connect")
+
+    async def stop(self) -> None:
+        if self._fail_on == "stop":
+            raise ConnectionError("cannot disconnect")
+
+    async def send(self, notification: Notification) -> bool:
+        if self._fail_on == "send":
+            raise ConnectionError("cannot send")
+        return True
+
+
+# ---------------------------------------------------------------------------
+# MQTT channel: name
+# ---------------------------------------------------------------------------
+
+
+class TestMqttName:
+    def test_name_is_mqtt(self) -> None:
+        channel = MqttNotificationChannel(_make_config())
+        assert channel.name() == "mqtt"
+
+
+# ---------------------------------------------------------------------------
+# MQTT channel: topic structure
+# ---------------------------------------------------------------------------
+
+
+class TestMqttTopicStructure:
+    """Notifications publish to {prefix}/{severity}."""
+
+    async def test_error_severity_topic(self) -> None:
+        channel = _mock_mqtt_channel()
+        notification = _make_notification(severity=Severity.ERROR)
+
+        await channel.send(notification)
+
+        channel._client.publish.assert_called_once()
+        call_kwargs = channel._client.publish.call_args.kwargs
+        assert call_kwargs["topic"] == "oasis/notifications/error"
+
+    async def test_warning_severity_topic(self) -> None:
+        channel = _mock_mqtt_channel()
+        notification = _make_notification(severity=Severity.WARNING)
+
+        await channel.send(notification)
+
+        call_kwargs = channel._client.publish.call_args.kwargs
+        assert call_kwargs["topic"] == "oasis/notifications/warning"
+
+    async def test_info_severity_topic(self) -> None:
+        channel = _mock_mqtt_channel()
+        notification = _make_notification(severity=Severity.INFO)
+
+        await channel.send(notification)
+
+        call_kwargs = channel._client.publish.call_args.kwargs
+        assert call_kwargs["topic"] == "oasis/notifications/info"
+
+    async def test_critical_severity_topic(self) -> None:
+        channel = _mock_mqtt_channel()
+        notification = _make_notification(severity=Severity.CRITICAL)
+
+        await channel.send(notification)
+
+        call_kwargs = channel._client.publish.call_args.kwargs
+        assert call_kwargs["topic"] == "oasis/notifications/critical"
+
+    async def test_custom_prefix(self) -> None:
+        channel = MqttNotificationChannel(_make_config(topic_prefix="alerts"))
+        channel._client = AsyncMock()
+        notification = _make_notification(severity=Severity.ERROR)
+
+        await channel.send(notification)
+
+        call_kwargs = channel._client.publish.call_args.kwargs
+        assert call_kwargs["topic"] == "alerts/error"
+
+
+# ---------------------------------------------------------------------------
+# MQTT channel: payload
+# ---------------------------------------------------------------------------
+
+
+class TestMqttPayload:
+    async def test_payload_is_json(self) -> None:
+        channel = _mock_mqtt_channel()
+        notification = _make_notification(title="Test", message="Hello")
+
+        await channel.send(notification)
+
+        call_kwargs = channel._client.publish.call_args.kwargs
+        payload = call_kwargs["payload"]
+        import json
+
+        data = json.loads(payload)
+        assert data["title"] == "Test"
+        assert data["message"] == "Hello"
+        assert data["severity"] == "warning"
+        assert data["event_id"] == "evt-001"
+
+
+# ---------------------------------------------------------------------------
+# MQTT channel: QoS and retain
+# ---------------------------------------------------------------------------
+
+
+class TestMqttQosRetain:
+    async def test_default_qos_1(self) -> None:
+        channel = _mock_mqtt_channel()
+
+        await channel.send(_make_notification())
+
+        call_kwargs = channel._client.publish.call_args.kwargs
+        assert call_kwargs["qos"] == 1
+
+    async def test_custom_qos(self) -> None:
+        channel = MqttNotificationChannel(_make_config(qos=2))
+        channel._client = AsyncMock()
+
+        await channel.send(_make_notification())
+
+        call_kwargs = channel._client.publish.call_args.kwargs
+        assert call_kwargs["qos"] == 2
+
+    async def test_default_retain_false(self) -> None:
+        channel = _mock_mqtt_channel()
+
+        await channel.send(_make_notification())
+
+        call_kwargs = channel._client.publish.call_args.kwargs
+        assert call_kwargs["retain"] is False
+
+    async def test_retain_true(self) -> None:
+        channel = MqttNotificationChannel(_make_config(retain=True))
+        channel._client = AsyncMock()
+
+        await channel.send(_make_notification())
+
+        call_kwargs = channel._client.publish.call_args.kwargs
+        assert call_kwargs["retain"] is True
+
+
+# ---------------------------------------------------------------------------
+# MQTT channel: disabled mode
+# ---------------------------------------------------------------------------
+
+
+class TestMqttDisabled:
+    async def test_send_returns_true(self) -> None:
+        channel = MqttNotificationChannel(_make_config(enabled=False))
+
+        result = await channel.send(_make_notification())
+
+        assert result is True
+
+    async def test_start_skips_connection(self) -> None:
+        channel = MqttNotificationChannel(_make_config(enabled=False))
+
+        await channel.start()
+
+        assert channel._client is None
+
+
+# ---------------------------------------------------------------------------
+# MQTT channel: error handling
+# ---------------------------------------------------------------------------
+
+
+class TestMqttErrors:
+    async def test_publish_failure_returns_false(self) -> None:
+        channel = _mock_mqtt_channel()
+        channel._client.publish.side_effect = Exception("broker down")
+
+        result = await channel.send(_make_notification())
+
+        assert result is False
+
+    async def test_send_without_start_returns_false(self) -> None:
+        channel = MqttNotificationChannel(_make_config())
+
+        result = await channel.send(_make_notification())
+
+        assert result is False
+
+
+# ---------------------------------------------------------------------------
+# MQTT channel: lifecycle
+# ---------------------------------------------------------------------------
+
+
+class TestMqttLifecycle:
+    @patch("oasisagent.notifications.mqtt.aiomqtt.Client")
+    async def test_start_connects(self, mock_cls: MagicMock) -> None:
+        mock_instance = AsyncMock()
+        mock_instance.__aenter__ = AsyncMock(return_value=mock_instance)
+        mock_cls.return_value = mock_instance
+
+        channel = MqttNotificationChannel(_make_config())
+        await channel.start()
+
+        mock_cls.assert_called_once()
+        assert channel._client is not None
+
+    async def test_stop_disconnects(self) -> None:
+        channel = _mock_mqtt_channel()
+        channel._client.__aexit__ = AsyncMock()
+
+        await channel.stop()
+
+        assert channel._client is None
+
+    async def test_stop_without_start_is_noop(self) -> None:
+        channel = MqttNotificationChannel(_make_config())
+        await channel.stop()  # Should not raise
+
+
+# ---------------------------------------------------------------------------
+# Dispatcher
+# ---------------------------------------------------------------------------
+
+
+class TestDispatcher:
+    async def test_dispatch_to_single_channel(self) -> None:
+        stub = _StubChannel()
+        dispatcher = NotificationDispatcher([stub])
+        notification = _make_notification()
+
+        results = await dispatcher.dispatch(notification)
+
+        assert results == {"stub": True}
+        assert len(stub.sent) == 1
+
+    async def test_dispatch_to_multiple_channels(self) -> None:
+        ch1 = _StubChannel("ch1")
+        ch2 = _StubChannel("ch2")
+        dispatcher = NotificationDispatcher([ch1, ch2])
+
+        results = await dispatcher.dispatch(_make_notification())
+
+        assert results == {"ch1": True, "ch2": True}
+
+    async def test_one_channel_failure_doesnt_block_others(self) -> None:
+        healthy = _StubChannel("healthy")
+        failing = _FailingChannel(fail_on="send")
+        dispatcher = NotificationDispatcher([failing, healthy])
+
+        results = await dispatcher.dispatch(_make_notification())
+
+        assert results["healthy"] is True
+        assert results["failing"] is False
+        assert len(healthy.sent) == 1
+
+    async def test_channel_returning_false(self) -> None:
+        ch = _StubChannel("ch", success=False)
+        dispatcher = NotificationDispatcher([ch])
+
+        results = await dispatcher.dispatch(_make_notification())
+
+        assert results == {"ch": False}
+
+
+# ---------------------------------------------------------------------------
+# Dispatcher lifecycle
+# ---------------------------------------------------------------------------
+
+
+class TestDispatcherLifecycle:
+    async def test_start_starts_all_channels(self) -> None:
+        ch1 = _StubChannel("ch1")
+        ch2 = _StubChannel("ch2")
+        dispatcher = NotificationDispatcher([ch1, ch2])
+
+        await dispatcher.start()
+        # No error = success (stub start is a no-op)
+
+    async def test_start_failure_doesnt_block_others(self) -> None:
+        healthy = _StubChannel("healthy")
+        failing = _FailingChannel(fail_on="start")
+        dispatcher = NotificationDispatcher([failing, healthy])
+
+        await dispatcher.start()
+        # Should not raise — failing channel logged, healthy started
+
+    async def test_stop_failure_doesnt_block_others(self) -> None:
+        healthy = _StubChannel("healthy")
+        failing = _FailingChannel(fail_on="stop")
+        dispatcher = NotificationDispatcher([failing, healthy])
+
+        await dispatcher.stop()
+        # Should not raise
+
+    async def test_empty_dispatcher(self) -> None:
+        dispatcher = NotificationDispatcher([])
+
+        await dispatcher.start()
+        results = await dispatcher.dispatch(_make_notification())
+        await dispatcher.stop()
+
+        assert results == {}


### PR DESCRIPTION
## Summary
- **NotificationChannel ABC** (`base.py`) — `name()`, `send()`, `start()`/`stop()` with non-abstract defaults (same pattern as Handler ABC)
- **MqttNotificationChannel** (`mqtt.py`) — publishes notifications as JSON to `{topic_prefix}/{severity}` topics, configurable QoS (0–2) and retain flag, disabled mode returns True immediately
- **NotificationDispatcher** (`dispatcher.py`) — fans out to all channels, one failure doesn't block others, per-channel result tracking
- Added `qos: int` and `retain: bool` fields to `MqttNotificationConfig`
- 26 tests covering topic routing, payload format, QoS/retain, disabled mode, error handling, lifecycle, and dispatcher failure isolation

## Test plan
- [x] `ruff check` passes with no errors
- [x] `pytest tests/test_notifications.py` — 26 tests pass
- [ ] Verify topic structure: `{prefix}/{severity}` for all four severity levels
- [ ] Verify disabled channel send() returns True without connecting
- [ ] Verify dispatcher isolates per-channel failures
- [ ] Verify QoS and retain propagate from config to publish call

🤖 Generated with [Claude Code](https://claude.com/claude-code)