### PR TITLE
Add Docker handler with four operations and known fixes (§16.6)

### DIFF
--- a/config.example.yaml
+++ b/config.example.yaml
@@ -143,6 +143,8 @@ handlers:
     # For remote Docker hosts:
     # url: tcp://192.168.1.120:2375
     # tls_verify: true
+    verify_timeout: 30           # Seconds to wait after restart to verify container running
+    verify_poll_interval: 2.0    # Seconds between verification polls
 
   # Proxmox — VM/CT management (Phase 3)
   proxmox:

--- a/known_fixes/docker.yaml
+++ b/known_fixes/docker.yaml
@@ -1,2 +1,64 @@
-# Known fixes for Docker container failures (Phase 2).
-fixes: []
+# Known fixes for Docker container failures.
+# Evaluated by the T0 match engine — first match wins.
+# See ARCHITECTURE.md §5 for match semantics.
+#
+# Note: payload_contains patterns assume Docker event payloads as
+# serialized JSON. Exact key names depend on the ingestion adapter's
+# event normalization. Refine patterns once the Docker ingestion
+# adapter is implemented.
+
+fixes:
+  - id: docker-oomkilled
+    match:
+      system: docker
+      event_type: container_die
+      payload_contains: "OOMKilled"
+    diagnosis: "Container was OOM-killed — memory limit exceeded"
+    action:
+      type: auto_fix
+      handler: docker
+      operation: restart_container
+      details:
+        message: "OOM-killed container restarted — review memory limits"
+    risk_tier: auto_fix
+
+  - id: docker-healthcheck-failure
+    match:
+      system: docker
+      event_type: health_status_unhealthy
+    diagnosis: "Container health check is failing"
+    action:
+      type: auto_fix
+      handler: docker
+      operation: restart_container
+      details:
+        message: "Unhealthy container restarted via health check trigger"
+    risk_tier: auto_fix
+
+  - id: docker-exit-137
+    match:
+      system: docker
+      event_type: container_die
+      payload_contains: "exitCode\":137"
+    diagnosis: "Container received SIGKILL (exit code 137) — possibly OOM or external kill"
+    action:
+      type: auto_fix
+      handler: docker
+      operation: restart_container
+      details:
+        message: "Container killed with SIGKILL — restarted, check logs for root cause"
+    risk_tier: auto_fix
+
+  - id: docker-crash-loop
+    match:
+      system: docker
+      event_type: container_die
+      payload_contains: "RestartCount"
+    diagnosis: "Container is in a crash loop — repeated restarts detected"
+    action:
+      type: recommend
+      handler: docker
+      operation: inspect_container
+      details:
+        message: "Container crash loop detected — escalating for human review"
+    risk_tier: escalate

--- a/oasisagent/config.py
+++ b/oasisagent/config.py
@@ -340,6 +340,8 @@ class DockerHandlerConfig(BaseModel):
     socket: str = "unix:///var/run/docker.sock"
     url: str | None = None
     tls_verify: bool = True
+    verify_timeout: Annotated[int, Field(ge=1)] = 30
+    verify_poll_interval: Annotated[float, Field(gt=0.0)] = 2.0
 
 
 class ProxmoxHandlerConfig(BaseModel):

--- a/oasisagent/handlers/__init__.py
+++ b/oasisagent/handlers/__init__.py
@@ -1,9 +1,11 @@
 """System handlers — execute actions against managed infrastructure."""
 
 from oasisagent.handlers.base import Handler
+from oasisagent.handlers.docker import DockerHandler
 from oasisagent.handlers.homeassistant import HomeAssistantHandler
 
 __all__ = [
+    "DockerHandler",
     "Handler",
     "HomeAssistantHandler",
 ]

--- a/oasisagent/handlers/docker.py
+++ b/oasisagent/handlers/docker.py
@@ -1,0 +1,328 @@
+"""Docker handler — executes actions via the Docker Engine REST API.
+
+Operations: restart_container, get_container_logs, get_container_stats,
+inspect_container.
+
+Connection: Unix socket (default) or TCP with optional TLS.
+Uses aiohttp with UnixConnector for socket access.
+
+ARCHITECTURE.md §8 and §16.6 define the handler interface and operations.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import logging
+import time
+from typing import TYPE_CHECKING, Any
+
+import aiohttp
+
+from oasisagent.handlers.base import Handler
+from oasisagent.models import ActionResult, ActionStatus, VerifyResult
+
+if TYPE_CHECKING:
+    from oasisagent.config import DockerHandlerConfig
+    from oasisagent.models import Event, RecommendedAction
+
+logger = logging.getLogger(__name__)
+
+# Operations this handler supports. can_handle() whitelists these.
+_KNOWN_OPERATIONS: frozenset[str] = frozenset({
+    "restart_container",
+    "get_container_logs",
+    "get_container_stats",
+    "inspect_container",
+})
+
+
+class HandlerNotStartedError(Exception):
+    """Raised when handler methods are called before start()."""
+
+
+class DockerHandler(Handler):
+    """Executes actions against Docker via the Engine REST API.
+
+    Must be started with ``await handler.start()`` before use.
+    Supports unix socket (default) and TCP connections.
+    """
+
+    def __init__(self, config: DockerHandlerConfig) -> None:
+        self._config = config
+        self._session: aiohttp.ClientSession | None = None
+
+    def name(self) -> str:
+        return "docker"
+
+    async def start(self) -> None:
+        """Create the aiohttp session with the appropriate connector."""
+        if self._config.url is not None:
+            # TCP mode
+            ssl_context: bool | None = None
+            if self._config.url.startswith("https"):
+                ssl_context = self._config.tls_verify if self._config.tls_verify else False
+            connector = aiohttp.TCPConnector(ssl=ssl_context)
+            self._session = aiohttp.ClientSession(
+                base_url=self._config.url,
+                connector=connector,
+            )
+            logger.info("Docker handler started (mode=tcp, url=%s)", self._config.url)
+        else:
+            # Unix socket mode
+            socket_path = self._config.socket.removeprefix("unix://")
+            connector = aiohttp.UnixConnector(path=socket_path)
+            self._session = aiohttp.ClientSession(
+                connector=connector,
+                base_url="http://localhost",
+            )
+            logger.info("Docker handler started (mode=unix, socket=%s)", socket_path)
+
+    async def stop(self) -> None:
+        """Close the aiohttp session."""
+        if self._session is not None:
+            await self._session.close()
+            self._session = None
+            logger.info("Docker handler stopped")
+
+    async def can_handle(self, event: Event, action: RecommendedAction) -> bool:
+        """Check if this handler supports the action."""
+        return (
+            action.handler == "docker"
+            and action.operation in _KNOWN_OPERATIONS
+        )
+
+    async def execute(
+        self, event: Event, action: RecommendedAction
+    ) -> ActionResult:
+        """Dispatch to the appropriate operation method."""
+        self._ensure_started()
+
+        dispatch = {
+            "restart_container": self._op_restart_container,
+            "get_container_logs": self._op_get_container_logs,
+            "get_container_stats": self._op_get_container_stats,
+            "inspect_container": self._op_inspect_container,
+        }
+
+        handler_fn = dispatch.get(action.operation)
+        if handler_fn is None:
+            return ActionResult(
+                status=ActionStatus.FAILURE,
+                error_message=f"Unknown operation: {action.operation}",
+            )
+
+        start = time.monotonic()
+        try:
+            result = await handler_fn(event, action)
+            elapsed = (time.monotonic() - start) * 1000
+            return result.model_copy(update={"duration_ms": elapsed})
+        except aiohttp.ClientError as exc:
+            elapsed = (time.monotonic() - start) * 1000
+            logger.error(
+                "Docker handler HTTP error for %s: %s", action.operation, exc
+            )
+            return ActionResult(
+                status=ActionStatus.FAILURE,
+                error_message=f"HTTP error: {exc}",
+                duration_ms=elapsed,
+            )
+
+    async def verify(
+        self, event: Event, action: RecommendedAction, result: ActionResult
+    ) -> VerifyResult:
+        """Verify an action had the desired effect.
+
+        Only restart_container has real verification (polls container status).
+        Other operations return verified=True immediately.
+        """
+        if action.operation != "restart_container":
+            return VerifyResult(verified=True, message="No verification needed")
+
+        self._ensure_started()
+        container_id = (
+            result.details.get("container_id")
+            or action.params.get("container_id")
+            or event.entity_id
+        )
+        return await self._verify_container_running(container_id)
+
+    async def get_context(self, event: Event) -> dict[str, Any]:
+        """Gather Docker-specific context for diagnosis.
+
+        Fetches both container inspect data (state, config, restart count,
+        OOM flag, exit code, health check config) and recent logs.
+        """
+        self._ensure_started()
+        context: dict[str, Any] = {}
+        container_id = event.entity_id
+
+        try:
+            assert self._session is not None
+            async with self._session.get(
+                f"/containers/{container_id}/json"
+            ) as resp:
+                resp.raise_for_status()
+                context["container_inspect"] = await resp.json()
+        except aiohttp.ClientError as exc:
+            context["container_inspect_error"] = str(exc)
+
+        try:
+            assert self._session is not None
+            async with self._session.get(
+                f"/containers/{container_id}/logs",
+                params={"tail": "100", "stdout": "true", "stderr": "true"},
+            ) as resp:
+                resp.raise_for_status()
+                context["container_logs"] = await resp.text()
+        except aiohttp.ClientError as exc:
+            context["container_logs_error"] = str(exc)
+
+        return context
+
+    # -------------------------------------------------------------------
+    # Operation implementations
+    # -------------------------------------------------------------------
+
+    async def _op_restart_container(
+        self, event: Event, action: RecommendedAction
+    ) -> ActionResult:
+        """Restart a container via POST /containers/{id}/restart."""
+        container_id = action.params.get("container_id") or event.entity_id
+        if not container_id:
+            return ActionResult(
+                status=ActionStatus.FAILURE,
+                error_message="restart_container requires container_id in params or entity_id",
+            )
+
+        assert self._session is not None
+        params: dict[str, str] = {}
+        timeout = action.params.get("timeout")
+        if timeout is not None:
+            params["t"] = str(timeout)
+
+        async with self._session.post(
+            f"/containers/{container_id}/restart", params=params
+        ) as resp:
+            resp.raise_for_status()
+
+        logger.info("Docker restart_container: %s", container_id)
+        return ActionResult(
+            status=ActionStatus.SUCCESS,
+            details={"container_id": container_id},
+        )
+
+    async def _op_get_container_logs(
+        self, event: Event, action: RecommendedAction
+    ) -> ActionResult:
+        """Fetch container logs via GET /containers/{id}/logs."""
+        container_id = action.params.get("container_id") or event.entity_id
+        if not container_id:
+            return ActionResult(
+                status=ActionStatus.FAILURE,
+                error_message="get_container_logs requires container_id in params or entity_id",
+            )
+
+        tail = action.params.get("tail", "100")
+        assert self._session is not None
+        async with self._session.get(
+            f"/containers/{container_id}/logs",
+            params={"tail": str(tail), "stdout": "true", "stderr": "true"},
+        ) as resp:
+            resp.raise_for_status()
+            logs = await resp.text()
+
+        return ActionResult(
+            status=ActionStatus.SUCCESS,
+            details={"container_id": container_id, "logs": logs},
+        )
+
+    async def _op_get_container_stats(
+        self, event: Event, action: RecommendedAction
+    ) -> ActionResult:
+        """Fetch container stats via GET /containers/{id}/stats."""
+        container_id = action.params.get("container_id") or event.entity_id
+        if not container_id:
+            return ActionResult(
+                status=ActionStatus.FAILURE,
+                error_message="get_container_stats requires container_id in params or entity_id",
+            )
+
+        assert self._session is not None
+        async with self._session.get(
+            f"/containers/{container_id}/stats",
+            params={"stream": "false"},
+        ) as resp:
+            resp.raise_for_status()
+            stats = await resp.json()
+
+        return ActionResult(
+            status=ActionStatus.SUCCESS,
+            details={"container_id": container_id, "stats": stats},
+        )
+
+    async def _op_inspect_container(
+        self, event: Event, action: RecommendedAction
+    ) -> ActionResult:
+        """Inspect a container via GET /containers/{id}/json."""
+        container_id = action.params.get("container_id") or event.entity_id
+        if not container_id:
+            return ActionResult(
+                status=ActionStatus.FAILURE,
+                error_message="inspect_container requires container_id in params or entity_id",
+            )
+
+        assert self._session is not None
+        async with self._session.get(
+            f"/containers/{container_id}/json"
+        ) as resp:
+            resp.raise_for_status()
+            inspect_data = await resp.json()
+
+        return ActionResult(
+            status=ActionStatus.SUCCESS,
+            details={"container_id": container_id, "inspect": inspect_data},
+        )
+
+    # -------------------------------------------------------------------
+    # Internal helpers
+    # -------------------------------------------------------------------
+
+    def _ensure_started(self) -> None:
+        """Raise if the handler hasn't been started."""
+        if self._session is None:
+            raise HandlerNotStartedError(
+                "DockerHandler.start() must be called before use"
+            )
+
+    async def _verify_container_running(self, container_id: str) -> VerifyResult:
+        """Poll container status to check if it reaches 'running'."""
+        timeout = self._config.verify_timeout
+        interval = self._config.verify_poll_interval
+        deadline = time.monotonic() + timeout
+
+        while time.monotonic() < deadline:
+            try:
+                assert self._session is not None
+                async with self._session.get(
+                    f"/containers/{container_id}/json"
+                ) as resp:
+                    resp.raise_for_status()
+                    data = await resp.json()
+                    status = data.get("State", {}).get("Status", "unknown")
+                    if status == "running":
+                        return VerifyResult(
+                            verified=True,
+                            message=f"Container {container_id} is running",
+                        )
+            except aiohttp.ClientError:
+                pass  # Keep polling
+
+            await asyncio.sleep(interval)
+
+        return VerifyResult(
+            verified=False,
+            message=(
+                f"Container {container_id} did not reach 'running' within "
+                f"{timeout}s"
+            ),
+        )

--- a/oasisagent/orchestrator.py
+++ b/oasisagent/orchestrator.py
@@ -32,6 +32,7 @@ from oasisagent.engine.decision import (
 from oasisagent.engine.guardrails import GuardrailsEngine
 from oasisagent.engine.known_fixes import KnownFixRegistry
 from oasisagent.engine.queue import EventQueue
+from oasisagent.handlers.docker import DockerHandler
 from oasisagent.handlers.homeassistant import HomeAssistantHandler
 from oasisagent.ingestion.ha_log_poller import HaLogPollerAdapter
 from oasisagent.ingestion.ha_websocket import HaWebSocketAdapter
@@ -190,6 +191,9 @@ class Orchestrator:
         if cfg.handlers.homeassistant.enabled:
             ha = HomeAssistantHandler(cfg.handlers.homeassistant)
             self._handlers[ha.name()] = ha
+        if cfg.handlers.docker.enabled:
+            docker = DockerHandler(cfg.handlers.docker)
+            self._handlers[docker.name()] = docker
 
         # 10. Audit writer
         self._audit = AuditWriter(cfg.audit)

--- a/tests/test_docker_handler.py
+++ b/tests/test_docker_handler.py
@@ -1,0 +1,588 @@
+"""Tests for the Docker handler."""
+
+from __future__ import annotations
+
+from datetime import UTC, datetime
+from typing import Any
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import aiohttp
+import pytest
+
+from oasisagent.config import DockerHandlerConfig
+from oasisagent.handlers.docker import (
+    DockerHandler,
+    HandlerNotStartedError,
+)
+from oasisagent.models import (
+    ActionResult,
+    ActionStatus,
+    Event,
+    EventMetadata,
+    RecommendedAction,
+    RiskTier,
+    Severity,
+)
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _make_config(**overrides: Any) -> DockerHandlerConfig:
+    defaults: dict[str, Any] = {
+        "enabled": True,
+        "socket": "unix:///var/run/docker.sock",
+        "verify_timeout": 5,
+        "verify_poll_interval": 0.05,
+    }
+    defaults.update(overrides)
+    return DockerHandlerConfig(**defaults)
+
+
+def _make_event(**overrides: Any) -> Event:
+    defaults: dict[str, Any] = {
+        "source": "test",
+        "system": "docker",
+        "event_type": "container_die",
+        "entity_id": "my_container",
+        "severity": Severity.WARNING,
+        "timestamp": datetime.now(UTC),
+        "payload": {},
+        "metadata": EventMetadata(),
+    }
+    defaults.update(overrides)
+    return Event(**defaults)
+
+
+def _make_action(**overrides: Any) -> RecommendedAction:
+    defaults: dict[str, Any] = {
+        "description": "Test action",
+        "handler": "docker",
+        "operation": "restart_container",
+        "params": {"container_id": "my_container"},
+        "risk_tier": RiskTier.AUTO_FIX,
+    }
+    defaults.update(overrides)
+    return RecommendedAction(**defaults)
+
+
+def _mock_response(
+    status: int = 200,
+    json_data: dict[str, Any] | None = None,
+    text_data: str = "",
+) -> MagicMock:
+    """Create a mock aiohttp response."""
+    resp = MagicMock()
+    resp.status = status
+    resp.json = AsyncMock(return_value=json_data or {})
+    resp.text = AsyncMock(return_value=text_data)
+    if status >= 400:
+        resp.raise_for_status.side_effect = aiohttp.ClientResponseError(
+            request_info=MagicMock(),
+            history=(),
+            status=status,
+            message=f"HTTP {status}",
+        )
+    else:
+        resp.raise_for_status.return_value = None
+    return resp
+
+
+def _patch_session(
+    handler: DockerHandler, responses: dict[str, MagicMock]
+) -> None:
+    """Replace the handler's session with a mock returning specified responses."""
+    session = MagicMock(spec=aiohttp.ClientSession)
+
+    def _make_cm(resp: MagicMock) -> MagicMock:
+        cm = MagicMock()
+        cm.__aenter__ = AsyncMock(return_value=resp)
+        cm.__aexit__ = AsyncMock(return_value=False)
+        return cm
+
+    def _get_handler(path: str, **kwargs: Any) -> MagicMock:
+        key = f"get:{path}"
+        resp = responses.get(key, _mock_response())
+        return _make_cm(resp)
+
+    def _post_handler(path: str, **kwargs: Any) -> MagicMock:
+        key = f"post:{path}"
+        resp = responses.get(key, _mock_response())
+        return _make_cm(resp)
+
+    session.get = MagicMock(side_effect=_get_handler)
+    session.post = MagicMock(side_effect=_post_handler)
+    session.close = AsyncMock()
+
+    handler._session = session
+
+
+async def _started_handler(**config_overrides: Any) -> DockerHandler:
+    """Create a handler with a mocked session (skipping real HTTP)."""
+    handler = DockerHandler(_make_config(**config_overrides))
+    handler._session = AsyncMock(spec=aiohttp.ClientSession)
+    return handler
+
+
+# ---------------------------------------------------------------------------
+# Lifecycle
+# ---------------------------------------------------------------------------
+
+
+class TestLifecycle:
+    async def test_start_creates_session_unix_socket(self) -> None:
+        handler = DockerHandler(_make_config())
+        with (
+            patch("oasisagent.handlers.docker.aiohttp.UnixConnector") as mock_conn,
+            patch("oasisagent.handlers.docker.aiohttp.ClientSession") as mock_cls,
+        ):
+            await handler.start()
+            mock_conn.assert_called_once_with(path="/var/run/docker.sock")
+            mock_cls.assert_called_once()
+            assert handler._session is not None
+
+    async def test_start_creates_session_tcp(self) -> None:
+        handler = DockerHandler(_make_config(url="http://docker-host:2375"))
+        with (
+            patch("oasisagent.handlers.docker.aiohttp.TCPConnector") as mock_conn,
+            patch("oasisagent.handlers.docker.aiohttp.ClientSession") as mock_cls,
+        ):
+            await handler.start()
+            mock_conn.assert_called_once()
+            mock_cls.assert_called_once()
+
+    async def test_start_tcp_https_respects_tls_verify(self) -> None:
+        config = _make_config(url="https://docker-host:2376", tls_verify=False)
+        handler = DockerHandler(config)
+        with (
+            patch("oasisagent.handlers.docker.aiohttp.TCPConnector") as mock_conn,
+            patch("oasisagent.handlers.docker.aiohttp.ClientSession"),
+        ):
+            await handler.start()
+            mock_conn.assert_called_once_with(ssl=False)
+
+    async def test_stop_closes_session(self) -> None:
+        handler = DockerHandler(_make_config())
+        mock_session = AsyncMock()
+        handler._session = mock_session
+
+        await handler.stop()
+
+        mock_session.close.assert_called_once()
+        assert handler._session is None
+
+    async def test_stop_without_start_is_noop(self) -> None:
+        handler = DockerHandler(_make_config())
+        await handler.stop()  # Should not raise
+
+    async def test_execute_before_start_raises(self) -> None:
+        handler = DockerHandler(_make_config())
+
+        with pytest.raises(HandlerNotStartedError):
+            await handler.execute(_make_event(), _make_action())
+
+    async def test_get_context_before_start_raises(self) -> None:
+        handler = DockerHandler(_make_config())
+
+        with pytest.raises(HandlerNotStartedError):
+            await handler.get_context(_make_event())
+
+    async def test_verify_before_start_raises_for_restart(self) -> None:
+        handler = DockerHandler(_make_config())
+        action = _make_action(operation="restart_container")
+        result = ActionResult(
+            status=ActionStatus.SUCCESS,
+            details={"container_id": "my_container"},
+        )
+
+        with pytest.raises(HandlerNotStartedError):
+            await handler.verify(_make_event(), action, result)
+
+
+# ---------------------------------------------------------------------------
+# name()
+# ---------------------------------------------------------------------------
+
+
+class TestName:
+    def test_name_is_docker(self) -> None:
+        handler = DockerHandler(_make_config())
+        assert handler.name() == "docker"
+
+
+# ---------------------------------------------------------------------------
+# can_handle()
+# ---------------------------------------------------------------------------
+
+
+class TestCanHandle:
+    async def test_known_operations_accepted(self) -> None:
+        handler = DockerHandler(_make_config())
+        event = _make_event()
+
+        for op in ["restart_container", "get_container_logs",
+                    "get_container_stats", "inspect_container"]:
+            action = _make_action(operation=op)
+            assert await handler.can_handle(event, action) is True
+
+    async def test_unknown_operation_rejected(self) -> None:
+        handler = DockerHandler(_make_config())
+        action = _make_action(operation="delete_container")
+
+        assert await handler.can_handle(_make_event(), action) is False
+
+    async def test_wrong_handler_rejected(self) -> None:
+        handler = DockerHandler(_make_config())
+        action = _make_action(handler="homeassistant", operation="restart_container")
+
+        assert await handler.can_handle(_make_event(), action) is False
+
+
+# ---------------------------------------------------------------------------
+# execute: restart_container
+# ---------------------------------------------------------------------------
+
+
+class TestRestartContainer:
+    async def test_success(self) -> None:
+        handler = await _started_handler()
+        _patch_session(handler, {
+            "post:/containers/my_container/restart": _mock_response(status=204),
+        })
+        action = _make_action(
+            operation="restart_container",
+            params={"container_id": "my_container"},
+        )
+
+        result = await handler.execute(_make_event(), action)
+
+        assert result.status == ActionStatus.SUCCESS
+        assert result.details["container_id"] == "my_container"
+
+    async def test_uses_event_entity_id_as_fallback(self) -> None:
+        handler = await _started_handler()
+        _patch_session(handler, {
+            "post:/containers/nginx/restart": _mock_response(status=204),
+        })
+        action = _make_action(
+            operation="restart_container",
+            params={},  # no container_id
+        )
+
+        result = await handler.execute(_make_event(entity_id="nginx"), action)
+
+        assert result.status == ActionStatus.SUCCESS
+        assert result.details["container_id"] == "nginx"
+
+    async def test_missing_container_id_fails(self) -> None:
+        handler = await _started_handler()
+        _patch_session(handler, {})
+        action = _make_action(
+            operation="restart_container",
+            params={},
+        )
+
+        result = await handler.execute(_make_event(entity_id=""), action)
+
+        assert result.status == ActionStatus.FAILURE
+        assert "container_id" in (result.error_message or "")
+
+    async def test_http_error_returns_failure(self) -> None:
+        handler = await _started_handler()
+        _patch_session(handler, {
+            "post:/containers/my_container/restart": _mock_response(status=500),
+        })
+        action = _make_action(
+            operation="restart_container",
+            params={"container_id": "my_container"},
+        )
+
+        result = await handler.execute(_make_event(), action)
+
+        assert result.status == ActionStatus.FAILURE
+        assert "HTTP error" in (result.error_message or "")
+
+    async def test_timeout_param_passed(self) -> None:
+        handler = await _started_handler()
+        _patch_session(handler, {
+            "post:/containers/my_container/restart": _mock_response(status=204),
+        })
+        action = _make_action(
+            operation="restart_container",
+            params={"container_id": "my_container", "timeout": 10},
+        )
+
+        result = await handler.execute(_make_event(), action)
+
+        assert result.status == ActionStatus.SUCCESS
+
+
+# ---------------------------------------------------------------------------
+# execute: get_container_logs
+# ---------------------------------------------------------------------------
+
+
+class TestGetContainerLogs:
+    async def test_success(self) -> None:
+        handler = await _started_handler()
+        _patch_session(handler, {
+            "get:/containers/my_container/logs": _mock_response(
+                text_data="2024-01-01 Error: something failed\n"
+            ),
+        })
+        action = _make_action(
+            operation="get_container_logs",
+            params={"container_id": "my_container"},
+        )
+
+        result = await handler.execute(_make_event(), action)
+
+        assert result.status == ActionStatus.SUCCESS
+        assert "something failed" in result.details["logs"]
+
+    async def test_http_error_returns_failure(self) -> None:
+        handler = await _started_handler()
+        _patch_session(handler, {
+            "get:/containers/my_container/logs": _mock_response(status=404),
+        })
+        action = _make_action(
+            operation="get_container_logs",
+            params={"container_id": "my_container"},
+        )
+
+        result = await handler.execute(_make_event(), action)
+
+        assert result.status == ActionStatus.FAILURE
+
+
+# ---------------------------------------------------------------------------
+# execute: get_container_stats
+# ---------------------------------------------------------------------------
+
+
+class TestGetContainerStats:
+    async def test_success(self) -> None:
+        stats_data = {"cpu_stats": {"total_usage": 100}, "memory_stats": {"usage": 1024}}
+        handler = await _started_handler()
+        _patch_session(handler, {
+            "get:/containers/my_container/stats": _mock_response(json_data=stats_data),
+        })
+        action = _make_action(
+            operation="get_container_stats",
+            params={"container_id": "my_container"},
+        )
+
+        result = await handler.execute(_make_event(), action)
+
+        assert result.status == ActionStatus.SUCCESS
+        assert result.details["stats"] == stats_data
+
+    async def test_http_error_returns_failure(self) -> None:
+        handler = await _started_handler()
+        _patch_session(handler, {
+            "get:/containers/my_container/stats": _mock_response(status=500),
+        })
+        action = _make_action(
+            operation="get_container_stats",
+            params={"container_id": "my_container"},
+        )
+
+        result = await handler.execute(_make_event(), action)
+
+        assert result.status == ActionStatus.FAILURE
+
+
+# ---------------------------------------------------------------------------
+# execute: inspect_container
+# ---------------------------------------------------------------------------
+
+
+class TestInspectContainer:
+    async def test_success(self) -> None:
+        inspect_data = {
+            "Id": "abc123",
+            "State": {"Status": "running", "OOMKilled": False},
+            "Config": {"Image": "nginx:latest"},
+        }
+        handler = await _started_handler()
+        _patch_session(handler, {
+            "get:/containers/my_container/json": _mock_response(json_data=inspect_data),
+        })
+        action = _make_action(
+            operation="inspect_container",
+            params={"container_id": "my_container"},
+        )
+
+        result = await handler.execute(_make_event(), action)
+
+        assert result.status == ActionStatus.SUCCESS
+        assert result.details["inspect"]["Id"] == "abc123"
+
+    async def test_http_error_returns_failure(self) -> None:
+        handler = await _started_handler()
+        _patch_session(handler, {
+            "get:/containers/my_container/json": _mock_response(status=404),
+        })
+        action = _make_action(
+            operation="inspect_container",
+            params={"container_id": "my_container"},
+        )
+
+        result = await handler.execute(_make_event(), action)
+
+        assert result.status == ActionStatus.FAILURE
+
+
+# ---------------------------------------------------------------------------
+# execute: unknown operation
+# ---------------------------------------------------------------------------
+
+
+class TestUnknownOperation:
+    async def test_unknown_operation_returns_failure(self) -> None:
+        handler = await _started_handler()
+        _patch_session(handler, {})
+        action = _make_action(operation="delete_container")
+
+        result = await handler.execute(_make_event(), action)
+
+        assert result.status == ActionStatus.FAILURE
+        assert "Unknown operation" in (result.error_message or "")
+
+
+# ---------------------------------------------------------------------------
+# execute: duration tracking
+# ---------------------------------------------------------------------------
+
+
+class TestDurationTracking:
+    async def test_duration_ms_set_on_success(self) -> None:
+        handler = await _started_handler()
+        _patch_session(handler, {
+            "post:/containers/my_container/restart": _mock_response(status=204),
+        })
+        action = _make_action(
+            operation="restart_container",
+            params={"container_id": "my_container"},
+        )
+
+        result = await handler.execute(_make_event(), action)
+
+        assert result.duration_ms is not None
+        assert result.duration_ms >= 0
+
+    async def test_duration_ms_set_on_http_error(self) -> None:
+        handler = await _started_handler()
+        _patch_session(handler, {
+            "post:/containers/my_container/restart": _mock_response(status=500),
+        })
+        action = _make_action(
+            operation="restart_container",
+            params={"container_id": "my_container"},
+        )
+
+        result = await handler.execute(_make_event(), action)
+
+        assert result.duration_ms is not None
+
+
+# ---------------------------------------------------------------------------
+# verify
+# ---------------------------------------------------------------------------
+
+
+class TestVerify:
+    async def test_non_restart_returns_verified(self) -> None:
+        handler = DockerHandler(_make_config())
+        action = _make_action(operation="inspect_container")
+        result = ActionResult(status=ActionStatus.SUCCESS)
+
+        verify = await handler.verify(_make_event(), action, result)
+
+        assert verify.verified is True
+
+    async def test_restart_verified_when_container_running(self) -> None:
+        handler = await _started_handler(verify_timeout=5, verify_poll_interval=0.05)
+        _patch_session(handler, {
+            "get:/containers/my_container/json": _mock_response(
+                json_data={"State": {"Status": "running"}}
+            ),
+        })
+        action = _make_action(operation="restart_container")
+        result = ActionResult(
+            status=ActionStatus.SUCCESS,
+            details={"container_id": "my_container"},
+        )
+
+        verify = await handler.verify(_make_event(), action, result)
+
+        assert verify.verified is True
+        assert "running" in verify.message
+
+    async def test_restart_not_verified_when_still_exited(self) -> None:
+        handler = await _started_handler(verify_timeout=1, verify_poll_interval=0.05)
+        _patch_session(handler, {
+            "get:/containers/my_container/json": _mock_response(
+                json_data={"State": {"Status": "exited"}}
+            ),
+        })
+        action = _make_action(operation="restart_container")
+        result = ActionResult(
+            status=ActionStatus.SUCCESS,
+            details={"container_id": "my_container"},
+        )
+
+        verify = await handler.verify(_make_event(), action, result)
+
+        assert verify.verified is False
+        assert "did not reach" in verify.message
+
+
+# ---------------------------------------------------------------------------
+# get_context
+# ---------------------------------------------------------------------------
+
+
+class TestGetContext:
+    async def test_gathers_inspect_and_logs(self) -> None:
+        handler = await _started_handler()
+        inspect_data = {"State": {"Status": "exited", "OOMKilled": True}}
+        _patch_session(handler, {
+            "get:/containers/my_container/json": _mock_response(json_data=inspect_data),
+            "get:/containers/my_container/logs": _mock_response(
+                text_data="Error: out of memory\n"
+            ),
+        })
+
+        context = await handler.get_context(_make_event(entity_id="my_container"))
+
+        assert "container_inspect" in context
+        assert context["container_inspect"]["State"]["OOMKilled"] is True
+        assert "container_logs" in context
+        assert "out of memory" in context["container_logs"]
+
+    async def test_handles_inspect_error_gracefully(self) -> None:
+        handler = await _started_handler()
+        _patch_session(handler, {
+            "get:/containers/my_container/json": _mock_response(status=404),
+            "get:/containers/my_container/logs": _mock_response(text_data="logs"),
+        })
+
+        context = await handler.get_context(_make_event(entity_id="my_container"))
+
+        assert "container_inspect_error" in context
+        assert "container_logs" in context
+
+    async def test_handles_logs_error_gracefully(self) -> None:
+        handler = await _started_handler()
+        inspect_data = {"State": {"Status": "running"}}
+        _patch_session(handler, {
+            "get:/containers/my_container/json": _mock_response(json_data=inspect_data),
+            "get:/containers/my_container/logs": _mock_response(status=500),
+        })
+
+        context = await handler.get_context(_make_event(entity_id="my_container"))
+
+        assert "container_inspect" in context
+        assert "container_logs_error" in context


### PR DESCRIPTION
## Summary

- **New `oasisagent/handlers/docker.py`** — Full Docker handler implementing the `Handler` ABC. Connects via unix socket (`aiohttp.UnixConnector`) or TCP (`aiohttp.TCPConnector` with `tls_verify` support). Four operations: `restart_container` (POST), `get_container_logs` (GET, tail=100), `get_container_stats` (GET, stream=false), `inspect_container` (GET). Verify polls container status for `running` after restart. `get_context()` fetches both inspect data and recent logs (per CTO callout).
- **`oasisagent/config.py`** — Added `verify_timeout` (30s) and `verify_poll_interval` (2.0s) to `DockerHandlerConfig`.
- **`known_fixes/docker.yaml`** — Four T0 patterns: OOMKilled → auto_fix restart, health check failure → auto_fix restart, exit code 137 → auto_fix restart, crash loop → escalate.
- **`oasisagent/orchestrator.py`** — Registers Docker handler in `_build_components()` when `cfg.handlers.docker.enabled`.
- **`oasisagent/handlers/__init__.py`** — Exports `DockerHandler`.
- **`config.example.yaml`** — Documents verify_timeout and verify_poll_interval for docker handler.
- **`tests/test_docker_handler.py`** — 32 tests: lifecycle (unix socket/TCP/TLS/start/stop/not-started guards), name, can_handle, all four operations (success/error/edge cases), unknown operation, duration tracking, verify (non-restart/running/timeout), get_context (inspect+logs, error handling).

## Test plan

- [x] `ruff check` passes (0 errors)
- [x] All 641 tests pass (32 new Docker handler tests + 609 existing)
- [ ] Manual: enable Docker handler, restart a container, verify `[VERIFY_FAILED]` or success log
- [ ] Manual: `get_container_logs` against a real container returns readable output

🤖 Generated with [Claude Code](https://claude.com/claude-code)