### PR TITLE
Add Prometheus metrics endpoint (§16.9)

### DIFF
--- a/config.example.yaml
+++ b/config.example.yaml
@@ -21,6 +21,7 @@ agent:
   event_ttl: 300                # Default TTL (seconds) for events; per-event TTL takes precedence
   known_fixes_dir: known_fixes/ # Directory containing T0 YAML fix registries
   correlation_window: 30        # Group related events within this window (seconds); 0 to disable
+  metrics_port: 0               # Prometheus /metrics port; 0 to disable
 
 # -----------------------------------------------------------------------------
 # Ingestion — Event sources

--- a/oasisagent/approval/pending.py
+++ b/oasisagent/approval/pending.py
@@ -171,6 +171,11 @@ class PendingQueue:
         """Look up a pending action by ID. Returns None if not found."""
         return self._actions.get(action_id)
 
+    @property
+    def pending_count(self) -> int:
+        """Return the number of actions with PENDING status."""
+        return sum(1 for a in self._actions.values() if a.status == PendingStatus.PENDING)
+
     def list_pending(self) -> list[PendingAction]:
         """Return all actions with PENDING status."""
         return [

--- a/oasisagent/config.py
+++ b/oasisagent/config.py
@@ -137,6 +137,7 @@ class AgentConfig(BaseModel):
     event_ttl: Annotated[int, Field(ge=0)] = 300
     known_fixes_dir: str = "known_fixes/"
     correlation_window: Annotated[int, Field(ge=0)] = 30
+    metrics_port: Annotated[int, Field(ge=0, le=65535)] = 0
 
 
 # -- Ingestion: MQTT --------------------------------------------------------

--- a/oasisagent/metrics.py
+++ b/oasisagent/metrics.py
@@ -1,0 +1,191 @@
+"""Prometheus metrics endpoint — exposes /metrics for scraping.
+
+Uses a custom CollectorRegistry to isolate OasisAgent metrics from
+any global metrics registered by dependencies (e.g. LiteLLM).
+
+ARCHITECTURE.md §16.9 defines the metrics specification.
+"""
+
+from __future__ import annotations
+
+import logging
+import time
+from typing import TYPE_CHECKING
+
+from aiohttp import web
+from prometheus_client import (
+    CONTENT_TYPE_LATEST,
+    CollectorRegistry,
+    Counter,
+    Gauge,
+    Histogram,
+    generate_latest,
+)
+
+if TYPE_CHECKING:
+    from oasisagent.approval.pending import PendingQueue
+    from oasisagent.engine.queue import EventQueue
+
+logger = logging.getLogger(__name__)
+
+# ---------------------------------------------------------------------------
+# Custom registry — isolated from global default
+# ---------------------------------------------------------------------------
+
+REGISTRY = CollectorRegistry()
+
+# ---------------------------------------------------------------------------
+# Metric definitions
+# ---------------------------------------------------------------------------
+
+EVENTS_TOTAL = Counter(
+    "oasis_events_total",
+    "Total ingested events",
+    labelnames=["source", "severity"],
+    registry=REGISTRY,
+)
+
+DECISIONS_TOTAL = Counter(
+    "oasis_decisions_total",
+    "Total decisions made",
+    labelnames=["tier", "disposition", "risk_tier"],
+    registry=REGISTRY,
+)
+
+ACTIONS_TOTAL = Counter(
+    "oasis_actions_total",
+    "Total handler actions executed",
+    labelnames=["handler", "operation", "result"],
+    registry=REGISTRY,
+)
+
+CIRCUIT_BREAKER_TRIPS_TOTAL = Counter(
+    "oasis_circuit_breaker_trips_total",
+    "Total circuit breaker trips",
+    labelnames=["trigger_type"],
+    registry=REGISTRY,
+)
+
+EVENT_PROCESSING_SECONDS = Histogram(
+    "oasis_event_processing_seconds",
+    "Event processing duration in seconds",
+    labelnames=["tier"],
+    registry=REGISTRY,
+)
+
+QUEUE_DEPTH = Gauge(
+    "oasis_queue_depth",
+    "Current event queue depth",
+    registry=REGISTRY,
+)
+
+PENDING_ACTIONS = Gauge(
+    "oasis_pending_actions",
+    "Current number of pending approval actions",
+    registry=REGISTRY,
+)
+
+UPTIME_SECONDS = Gauge(
+    "oasis_uptime_seconds",
+    "Agent uptime in seconds",
+    registry=REGISTRY,
+)
+
+
+# ---------------------------------------------------------------------------
+# Instrumentation API — called from the orchestrator
+# ---------------------------------------------------------------------------
+
+
+def inc_events(source: str, severity: str) -> None:
+    """Increment the events counter."""
+    EVENTS_TOTAL.labels(source=source, severity=severity).inc()
+
+
+def inc_decisions(tier: str, disposition: str, risk_tier: str = "") -> None:
+    """Increment the decisions counter."""
+    DECISIONS_TOTAL.labels(tier=tier, disposition=disposition, risk_tier=risk_tier).inc()
+
+
+def inc_actions(handler: str, operation: str, result: str) -> None:
+    """Increment the actions counter."""
+    ACTIONS_TOTAL.labels(handler=handler, operation=operation, result=result).inc()
+
+
+def inc_circuit_breaker_trips(trigger_type: str) -> None:
+    """Increment the circuit breaker trips counter."""
+    CIRCUIT_BREAKER_TRIPS_TOTAL.labels(trigger_type=trigger_type).inc()
+
+
+def observe_processing_time(tier: str, seconds: float) -> None:
+    """Record an event processing duration."""
+    EVENT_PROCESSING_SECONDS.labels(tier=tier).observe(seconds)
+
+
+# ---------------------------------------------------------------------------
+# Metrics HTTP server
+# ---------------------------------------------------------------------------
+
+_start_time: float = 0.0
+_event_queue: EventQueue | None = None
+_pending_queue: PendingQueue | None = None
+
+
+def set_callback_sources(
+    event_queue: EventQueue,
+    pending_queue: PendingQueue,
+) -> None:
+    """Register queue references for callback gauges."""
+    global _event_queue, _pending_queue
+    _event_queue = event_queue
+    _pending_queue = pending_queue
+
+
+def _update_callback_gauges() -> None:
+    """Update callback gauges with current values. Called at scrape time."""
+    if _event_queue is not None:
+        QUEUE_DEPTH.set(_event_queue.size)
+    if _pending_queue is not None:
+        PENDING_ACTIONS.set(_pending_queue.pending_count)
+    if _start_time > 0:
+        UPTIME_SECONDS.set(time.monotonic() - _start_time)
+
+
+async def _metrics_handler(request: web.Request) -> web.Response:
+    """Handle GET /metrics requests."""
+    _update_callback_gauges()
+    body = generate_latest(REGISTRY)
+    return web.Response(
+        body=body,
+        headers={"Content-Type": CONTENT_TYPE_LATEST},
+    )
+
+
+class MetricsServer:
+    """Lightweight aiohttp server exposing /metrics for Prometheus scraping."""
+
+    def __init__(self, port: int) -> None:
+        self._port = port
+        self._runner: web.AppRunner | None = None
+
+    async def start(self) -> None:
+        """Start the HTTP server."""
+        global _start_time
+        _start_time = time.monotonic()
+
+        app = web.Application()
+        app.router.add_get("/metrics", _metrics_handler)
+
+        self._runner = web.AppRunner(app)
+        await self._runner.setup()
+
+        site = web.TCPSite(self._runner, "0.0.0.0", self._port)
+        await site.start()
+        logger.info("Metrics server started on port %d", self._port)
+
+    async def stop(self) -> None:
+        """Stop the HTTP server."""
+        if self._runner is not None:
+            await self._runner.cleanup()
+            self._runner = None
+            logger.info("Metrics server stopped")

--- a/oasisagent/orchestrator.py
+++ b/oasisagent/orchestrator.py
@@ -40,6 +40,11 @@ from oasisagent.ingestion.mqtt import MqttAdapter
 from oasisagent.llm.client import LLMClient
 from oasisagent.llm.reasoning import ReasoningService
 from oasisagent.llm.triage import TriageService
+from oasisagent.metrics import MetricsServer
+from oasisagent.metrics import inc_actions as _inc_actions
+from oasisagent.metrics import inc_decisions as _inc_decisions
+from oasisagent.metrics import inc_events as _inc_events
+from oasisagent.metrics import observe_processing_time as _observe_processing_time
 from oasisagent.models import (
     ActionResult,
     ActionStatus,
@@ -90,6 +95,7 @@ class Orchestrator:
         self._approval_listener: ApprovalListener | None = None
         self._approval_listener_task: asyncio.Task[None] | None = None
         self._background_tasks: set[asyncio.Task[None]] = set()
+        self._metrics_server: MetricsServer | None = None
         self._adapters: list[IngestAdapter] = []
         self._adapter_tasks: list[asyncio.Task[None]] = []
 
@@ -235,6 +241,13 @@ class Orchestrator:
                 HaLogPollerAdapter(cfg.ingestion.ha_log_poller, self._queue)
             )
 
+        # 15. Metrics server (Prometheus)
+        if cfg.agent.metrics_port > 0:
+            from oasisagent import metrics as metrics_mod
+
+            self._metrics_server = MetricsServer(cfg.agent.metrics_port)
+            metrics_mod.set_callback_sources(self._queue, self._pending_queue)
+
     # -------------------------------------------------------------------
     # Component lifecycle
     # -------------------------------------------------------------------
@@ -270,6 +283,13 @@ class Orchestrator:
                 name="approval-listener",
             )
             logger.info("Approval listener started")
+
+        # Metrics server
+        if self._metrics_server is not None:
+            try:
+                await self._metrics_server.start()
+            except Exception:
+                logger.exception("Failed to start metrics server")
 
         # Ingestion adapters — launched as background tasks
         for adapter in self._adapters:
@@ -362,7 +382,14 @@ class Orchestrator:
             except Exception:
                 logger.exception("Error stopping notification dispatcher")
 
-        # 7. Stop audit writer
+        # 7. Stop metrics server
+        if self._metrics_server is not None:
+            try:
+                await self._metrics_server.stop()
+            except Exception:
+                logger.exception("Error stopping metrics server")
+
+        # 8. Stop audit writer
         if self._audit is not None:
             try:
                 await self._audit.stop()
@@ -414,6 +441,9 @@ class Orchestrator:
                 logger.info("Event %s expired (TTL), dropping", event.id)
                 return
 
+            # 1b. Metrics: count ingested event
+            _inc_events(event.source, event.severity.value)
+
             # 2. Correlation check
             assert self._correlator is not None
             correlation = self._correlator.check(event)
@@ -431,6 +461,7 @@ class Orchestrator:
                 )
                 await self._audit_decision(event, correlated_result)
                 self._events_processed += 1
+                _observe_processing_time("t0", time.monotonic() - start)
                 logger.debug(
                     "Event %s correlated with leader %s, skipping",
                     event.id,
@@ -460,6 +491,7 @@ class Orchestrator:
             elif self._is_dry_run(result):
                 # DRY_RUN always notifies, skip _should_notify check
                 self._events_processed += 1
+                _observe_processing_time(result.tier.value, time.monotonic() - start)
                 await self._send_notification(event, result)
                 return
 
@@ -468,6 +500,7 @@ class Orchestrator:
                 await self._send_notification(event, result)
 
             self._events_processed += 1
+            _observe_processing_time(result.tier.value, time.monotonic() - start)
 
         except Exception:
             logger.exception("Unhandled error processing event %s", event.id)
@@ -1020,6 +1053,11 @@ class Orchestrator:
         self, event: Event, result: DecisionResult
     ) -> None:
         """Write decision to audit trail. Best-effort."""
+        risk_tier = ""
+        if result.guardrail_result is not None:
+            risk_tier = result.guardrail_result.risk_tier.value
+        _inc_decisions(result.tier.value, result.disposition.value, risk_tier)
+
         if self._audit is None:
             return
         try:
@@ -1038,14 +1076,19 @@ class Orchestrator:
         duration_ms: float,
     ) -> None:
         """Write action result to audit trail. Best-effort."""
-        if self._audit is None:
-            return
-
         fix = (
             self._registry.get_fix_by_id(result.matched_fix_id)
             if self._registry and result.matched_fix_id
             else None
         )
+        if fix is not None:
+            _inc_actions(
+                fix.action.handler, fix.action.operation, action_result.status.value
+            )
+
+        if self._audit is None:
+            return
+
         if fix is None:
             return
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -29,6 +29,7 @@ dependencies = [
     "aiomqtt>=2.0",
     "aiohttp>=3.9",
     "aiosmtplib>=3.0",
+    "prometheus_client>=0.20",
     "influxdb-client[async]>=1.36",
 ]
 

--- a/tests/test_metrics.py
+++ b/tests/test_metrics.py
@@ -1,0 +1,284 @@
+"""Tests for the Prometheus metrics module."""
+
+from __future__ import annotations
+
+import time
+
+from oasisagent.approval.pending import PendingQueue
+from oasisagent.engine.queue import EventQueue
+from oasisagent.metrics import (
+    ACTIONS_TOTAL,
+    CIRCUIT_BREAKER_TRIPS_TOTAL,
+    DECISIONS_TOTAL,
+    EVENT_PROCESSING_SECONDS,
+    EVENTS_TOTAL,
+    PENDING_ACTIONS,
+    QUEUE_DEPTH,
+    REGISTRY,
+    UPTIME_SECONDS,
+    MetricsServer,
+    _metrics_handler,
+    _update_callback_gauges,
+    inc_actions,
+    inc_circuit_breaker_trips,
+    inc_decisions,
+    inc_events,
+    observe_processing_time,
+    set_callback_sources,
+)
+from oasisagent.models import RecommendedAction, RiskTier
+
+
+class TestCustomRegistry:
+    def test_registry_is_not_default(self) -> None:
+        """Custom registry isolates from global default."""
+        from prometheus_client import REGISTRY as DEFAULT_REGISTRY
+
+        assert REGISTRY is not DEFAULT_REGISTRY
+
+    def test_all_metrics_on_custom_registry(self) -> None:
+        """All defined metrics are registered on the custom registry."""
+        collectors = REGISTRY._names_to_collectors.values()
+        collector_names = {c._name for c in collectors if hasattr(c, "_name")}
+        # prometheus_client stores internal _name without _total suffix for counters
+        expected = {
+            "oasis_events",
+            "oasis_decisions",
+            "oasis_actions",
+            "oasis_circuit_breaker_trips",
+            "oasis_event_processing_seconds",
+            "oasis_queue_depth",
+            "oasis_pending_actions",
+            "oasis_uptime_seconds",
+        }
+        assert expected.issubset(collector_names)
+
+
+class TestIncEvents:
+    def test_increments_with_labels(self) -> None:
+        before = EVENTS_TOTAL.labels(source="mqtt", severity="error")._value.get()
+        inc_events("mqtt", "error")
+        after = EVENTS_TOTAL.labels(source="mqtt", severity="error")._value.get()
+        assert after == before + 1
+
+    def test_different_labels_independent(self) -> None:
+        before_a = EVENTS_TOTAL.labels(source="ha_ws", severity="warning")._value.get()
+        before_b = EVENTS_TOTAL.labels(source="ha_ws", severity="critical")._value.get()
+        inc_events("ha_ws", "warning")
+        after_a = EVENTS_TOTAL.labels(source="ha_ws", severity="warning")._value.get()
+        after_b = EVENTS_TOTAL.labels(source="ha_ws", severity="critical")._value.get()
+        assert after_a == before_a + 1
+        assert after_b == before_b
+
+
+class TestIncDecisions:
+    def test_increments_with_labels(self) -> None:
+        before = DECISIONS_TOTAL.labels(
+            tier="t0", disposition="matched", risk_tier="auto_fix"
+        )._value.get()
+        inc_decisions("t0", "matched", "auto_fix")
+        after = DECISIONS_TOTAL.labels(
+            tier="t0", disposition="matched", risk_tier="auto_fix"
+        )._value.get()
+        assert after == before + 1
+
+    def test_empty_risk_tier(self) -> None:
+        before = DECISIONS_TOTAL.labels(
+            tier="t1", disposition="dropped", risk_tier=""
+        )._value.get()
+        inc_decisions("t1", "dropped")
+        after = DECISIONS_TOTAL.labels(
+            tier="t1", disposition="dropped", risk_tier=""
+        )._value.get()
+        assert after == before + 1
+
+
+class TestIncActions:
+    def test_increments_with_labels(self) -> None:
+        before = ACTIONS_TOTAL.labels(
+            handler="docker", operation="restart_container", result="success"
+        )._value.get()
+        inc_actions("docker", "restart_container", "success")
+        after = ACTIONS_TOTAL.labels(
+            handler="docker", operation="restart_container", result="success"
+        )._value.get()
+        assert after == before + 1
+
+
+class TestIncCircuitBreakerTrips:
+    def test_increments_with_label(self) -> None:
+        before = CIRCUIT_BREAKER_TRIPS_TOTAL.labels(
+            trigger_type="entity"
+        )._value.get()
+        inc_circuit_breaker_trips("entity")
+        after = CIRCUIT_BREAKER_TRIPS_TOTAL.labels(
+            trigger_type="entity"
+        )._value.get()
+        assert after == before + 1
+
+
+class TestObserveProcessingTime:
+    def test_records_observation(self) -> None:
+        before = EVENT_PROCESSING_SECONDS.labels(tier="t2")._sum.get()
+        observe_processing_time("t2", 0.5)
+        after = EVENT_PROCESSING_SECONDS.labels(tier="t2")._sum.get()
+        assert after >= before + 0.5
+
+
+class TestCallbackGauges:
+    def test_queue_depth_reads_from_event_queue(self) -> None:
+        queue = EventQueue(max_size=100)
+        pending = PendingQueue()
+        set_callback_sources(queue, pending)
+
+        _update_callback_gauges()
+        assert QUEUE_DEPTH._value.get() == 0
+
+    def test_pending_actions_reads_from_pending_queue(self) -> None:
+        queue = EventQueue(max_size=100)
+        pending = PendingQueue()
+
+        action = RecommendedAction(
+            description="test",
+            handler="docker",
+            operation="restart_container",
+            params={},
+            risk_tier=RiskTier.RECOMMEND,
+        )
+        pending.add("evt-1", action, "test diagnosis", timeout_minutes=30)
+        pending.add("evt-2", action, "test diagnosis", timeout_minutes=30)
+
+        set_callback_sources(queue, pending)
+        _update_callback_gauges()
+        assert PENDING_ACTIONS._value.get() == 2
+
+    def test_uptime_increases(self) -> None:
+        import oasisagent.metrics as m
+
+        old_start = m._start_time
+        m._start_time = time.monotonic() - 10.0
+        try:
+            _update_callback_gauges()
+            assert UPTIME_SECONDS._value.get() >= 10.0
+        finally:
+            m._start_time = old_start
+
+
+class TestMetricsHandler:
+    async def test_returns_200_with_prometheus_content_type(self) -> None:
+        from aiohttp.test_utils import make_mocked_request
+
+        request = make_mocked_request("GET", "/metrics")
+        response = await _metrics_handler(request)
+        assert response.status == 200
+        assert "text/plain" in response.content_type
+
+    async def test_response_contains_metric_names(self) -> None:
+        from aiohttp.test_utils import make_mocked_request
+
+        # Ensure at least one sample exists
+        inc_events("test_handler", "info")
+
+        request = make_mocked_request("GET", "/metrics")
+        response = await _metrics_handler(request)
+        body = response.body.decode()
+        assert "oasis_events_total" in body
+        assert "oasis_decisions_total" in body
+        assert "oasis_actions_total" in body
+        assert "oasis_queue_depth" in body
+        assert "oasis_uptime_seconds" in body
+
+
+class TestMetricsServer:
+    async def test_start_stop(self) -> None:
+        server = MetricsServer(port=0)
+        # Port 0 won't actually bind usefully, but tests the lifecycle
+        # Use a high random port instead
+        server = MetricsServer(port=19876)
+        await server.start()
+        assert server._runner is not None
+        await server.stop()
+        assert server._runner is None
+
+    async def test_stop_without_start(self) -> None:
+        server = MetricsServer(port=19877)
+        await server.stop()  # Should not raise
+
+
+class TestPendingQueueCount:
+    def test_pending_count_with_mixed_statuses(self) -> None:
+        queue = PendingQueue()
+        action = RecommendedAction(
+            description="test",
+            handler="docker",
+            operation="restart_container",
+            params={},
+            risk_tier=RiskTier.RECOMMEND,
+        )
+        p1 = queue.add("evt-1", action, "diag", timeout_minutes=30)
+        p2 = queue.add("evt-2", action, "diag", timeout_minutes=30)
+        queue.add("evt-3", action, "diag", timeout_minutes=30)
+
+        assert queue.pending_count == 3
+
+        queue.approve(p1.id)
+        assert queue.pending_count == 2
+
+        queue.reject(p2.id)
+        assert queue.pending_count == 1
+
+    def test_pending_count_empty(self) -> None:
+        queue = PendingQueue()
+        assert queue.pending_count == 0
+
+
+class TestOrchestratorRegistration:
+    async def test_metrics_server_created_when_port_set(self) -> None:
+        from oasisagent.config import OasisAgentConfig
+        from oasisagent.orchestrator import Orchestrator
+
+        config = OasisAgentConfig.model_validate({
+            "agent": {"metrics_port": 9090, "correlation_window": 0},
+            "notifications": {"mqtt": {"enabled": False}},
+            "llm": {
+                "triage": {
+                    "base_url": "http://localhost:11434/v1",
+                    "model": "test",
+                    "api_key": "test",
+                },
+                "reasoning": {
+                    "base_url": "http://localhost:11434/v1",
+                    "model": "test",
+                    "api_key": "test",
+                },
+            },
+        })
+
+        orch = Orchestrator(config)
+        orch._build_components()
+        assert orch._metrics_server is not None
+
+    async def test_metrics_server_not_created_when_disabled(self) -> None:
+        from oasisagent.config import OasisAgentConfig
+        from oasisagent.orchestrator import Orchestrator
+
+        config = OasisAgentConfig.model_validate({
+            "agent": {"metrics_port": 0, "correlation_window": 0},
+            "notifications": {"mqtt": {"enabled": False}},
+            "llm": {
+                "triage": {
+                    "base_url": "http://localhost:11434/v1",
+                    "model": "test",
+                    "api_key": "test",
+                },
+                "reasoning": {
+                    "base_url": "http://localhost:11434/v1",
+                    "model": "test",
+                    "api_key": "test",
+                },
+            },
+        })
+
+        orch = Orchestrator(config)
+        orch._build_components()
+        assert orch._metrics_server is None


### PR DESCRIPTION
## Summary
- **`oasisagent/metrics.py`** — Metrics module with custom `CollectorRegistry`, 8 metric definitions, instrumentation API functions, and aiohttp `/metrics` server
- **`oasisagent/orchestrator.py`** — Instrumented pipeline: `inc_events` after TTL check, `inc_decisions` in `_audit_decision`, `inc_actions` in `_audit_action`, `observe_processing_time` at all `_process_one` exit points
- **`oasisagent/config.py`** — Added `metrics_port: int = 0` to `AgentConfig` (0 disables)
- **`oasisagent/approval/pending.py`** — Added `pending_count` property for callback gauge
- **`pyproject.toml`** — Added `prometheus_client>=0.20` dependency

### Metrics exposed

| Metric | Type | Labels |
|--------|------|--------|
| `oasis_events_total` | Counter | source, severity |
| `oasis_decisions_total` | Counter | tier, disposition, risk_tier |
| `oasis_actions_total` | Counter | handler, operation, result |
| `oasis_circuit_breaker_trips_total` | Counter | trigger_type |
| `oasis_event_processing_seconds` | Histogram | tier |
| `oasis_queue_depth` | Gauge | — |
| `oasis_pending_actions` | Gauge | — |
| `oasis_uptime_seconds` | Gauge | — |

## Test plan
- [x] Custom registry isolation from global default (2 tests)
- [x] Counter increments with correct labels: events, decisions, actions, circuit breaker (5 tests)
- [x] Histogram observation recording (1 test)
- [x] Callback gauges: queue depth, pending actions, uptime (3 tests)
- [x] HTTP handler: 200 status, prometheus content type, metric names in body (2 tests)
- [x] Server lifecycle: start/stop, stop-without-start (2 tests)
- [x] PendingQueue.pending_count: mixed statuses, empty (2 tests)
- [x] Orchestrator registration: enabled/disabled (2 tests)
- [x] Full suite: 694 tests passing
- [x] Ruff lint clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)