### PR TITLE
Bump version to 0.2.1

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "oasisagent"
-version = "0.2.0"
+version = "0.2.1"
 description = "Autonomous infrastructure operations agent for home labs"
 readme = "README.md"
 license = "MIT"


### PR DESCRIPTION
## Summary

- Version bump `0.2.0` → `0.2.1` in `pyproject.toml`
- Enables `v0.2.1` tag to trigger GHCR multi-arch image build via `docker-publish.yml`

## Test plan

- [ ] Merge → tag `v0.2.1` → verify GHCR CI builds and pushes image
- [ ] Pull image: `docker pull ghcr.io/dadcoachengineer/oasisagent:0.2.1`

🤖 Generated with [Claude Code](https://claude.com/claude-code)