### PR TITLE
Embed default config in image for env-var-only deploy

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -32,6 +32,7 @@ htmlcov/
 Dockerfile
 docker-compose.yml
 docker-stack.yml
+portainer-stack.yml
 .dockerignore
 
 # CI/CD

--- a/.gitignore
+++ b/.gitignore
@@ -13,6 +13,8 @@ env/
 # Environment and secrets
 .env
 config.yaml
+config.production.yaml
+portainer-stack.yml
 *.pem
 *.key
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -23,6 +23,7 @@ RUN groupadd --gid 1000 oasis && \
 
 COPY --from=builder /install /usr/local
 COPY --from=builder /build/known_fixes /app/known_fixes
+COPY config.default.yaml /app/config.yaml
 
 WORKDIR /app
 

--- a/config.default.yaml
+++ b/config.default.yaml
@@ -1,0 +1,164 @@
+# =============================================================================
+# OasisAgent — Default Configuration (embedded in Docker image)
+# =============================================================================
+#
+# All environment-specific values use ${VAR:-default} syntax.
+# Override via environment variables in Portainer, docker-compose, or .env.
+#
+# Required env vars (no defaults):
+#   HA_TOKEN, MQTT_PASS, REASONING_LLM_API_KEY, INFLUXDB_TOKEN
+#
+# Optional env vars (have sensible defaults):
+#   HA_URL, MQTT_BROKER, MQTT_USER, INFLUX_URL, INFLUX_ORG, INFLUX_BUCKET,
+#   TRIAGE_LLM_BASE_URL, TRIAGE_LLM_MODEL, TRIAGE_LLM_API_KEY
+# =============================================================================
+
+agent:
+  name: oasis-agent
+  log_level: info
+  event_queue_size: 1000
+  dedup_window_seconds: 300
+  shutdown_timeout: 30
+  event_ttl: 300
+  known_fixes_dir: known_fixes/
+  correlation_window: 30
+  metrics_port: 9090
+
+ingestion:
+
+  mqtt:
+    enabled: true
+    broker: ${MQTT_BROKER:-mqtt://localhost:1883}
+    username: ${MQTT_USER:-oasisagent}
+    password: ${MQTT_PASS}
+    client_id: oasis-agent
+    qos: 1
+    topics:
+      - pattern: "homeassistant/error/#"
+        system: homeassistant
+        event_type: automation_error
+        severity: error
+      - pattern: "oasis/alerts/#"
+        system: auto
+        event_type: auto
+        severity: auto
+
+  ha_websocket:
+    enabled: true
+    url: ${HA_WS_URL:-ws://localhost:8123/api/websocket}
+    token: ${HA_TOKEN}
+    subscriptions:
+      state_changes:
+        enabled: true
+        trigger_states: ["unavailable", "unknown"]
+        ignore_entities: []
+        min_duration: 60
+      automation_failures:
+        enabled: true
+      service_call_errors:
+        enabled: true
+
+  ha_log_poller:
+    enabled: true
+    url: ${HA_URL:-http://localhost:8123}
+    token: ${HA_TOKEN}
+    poll_interval: 30
+    dedup_window: 300
+    patterns:
+      - regex: "Error setting up integration '(.+)'"
+        event_type: integration_failure
+        severity: error
+      - regex: "(.+) is unavailable"
+        event_type: state_unavailable
+        severity: warning
+      - regex: "Deprecated .+ used in (.+)"
+        event_type: deprecation_warning
+        severity: warning
+
+llm:
+
+  triage:
+    base_url: ${TRIAGE_LLM_BASE_URL:-http://localhost:11434/v1}
+    model: ${TRIAGE_LLM_MODEL:-qwen2.5:7b}
+    api_key: ${TRIAGE_LLM_API_KEY:-not-needed}
+    timeout: ${TRIAGE_LLM_TIMEOUT:-5}
+    max_tokens: 1024
+    temperature: 0.1
+
+  reasoning:
+    base_url: ${REASONING_LLM_BASE_URL:-https://api.anthropic.com}
+    model: ${REASONING_LLM_MODEL:-claude-sonnet-4-5-20250929}
+    api_key: ${REASONING_LLM_API_KEY}
+    timeout: 45
+    max_tokens: 4096
+    temperature: 0.2
+
+  options:
+    cost_tracking: true
+    retry_attempts: 2
+    fallback_to_triage: true
+    log_prompts: false
+
+handlers:
+
+  homeassistant:
+    enabled: true
+    url: ${HA_URL:-http://localhost:8123}
+    token: ${HA_TOKEN}
+    verify_timeout: 30
+    verify_poll_interval: 2.0
+
+  docker:
+    enabled: false
+    socket: unix:///var/run/docker.sock
+    verify_timeout: 30
+    verify_poll_interval: 2.0
+
+  proxmox:
+    enabled: false
+    url: https://localhost:8006
+    user: ""
+    token_name: ""
+    token_value: ""
+    verify_ssl: false
+
+guardrails:
+  blocked_domains:
+    - "lock.*"
+    - "alarm_control_panel.*"
+    - "camera.*"
+    - "cover.*"
+  blocked_entities: []
+  kill_switch: false
+  dry_run: ${DRY_RUN:-true}
+  approval_timeout_minutes: 30
+
+  circuit_breaker:
+    max_attempts_per_entity: 3
+    window_minutes: 60
+    cooldown_minutes: 15
+    global_failure_rate_threshold: 0.3
+    global_pause_minutes: 30
+
+audit:
+  influxdb:
+    enabled: true
+    url: ${INFLUX_URL:-http://localhost:8086}
+    token: ${INFLUXDB_TOKEN}
+    org: ${INFLUX_ORG:-myorg}
+    bucket: ${INFLUX_BUCKET:-oasisagent}
+  retention_days: 90
+
+notifications:
+  mqtt:
+    enabled: true
+    broker: ${MQTT_BROKER:-mqtt://localhost:1883}
+    topic_prefix: oasis/notifications
+    username: ${MQTT_USER:-oasisagent}
+    password: ${MQTT_PASS}
+
+  email:
+    enabled: false
+
+  webhook:
+    enabled: false


### PR DESCRIPTION
## Summary

- **`config.default.yaml`**: Full config with `${VAR:-default}` placeholders for all environment-specific values (hostnames, credentials, LLM endpoints, `dry_run` flag)
- **`Dockerfile`**: Copies `config.default.yaml` into image as `/app/config.yaml` — no Docker config create step needed
- **`.dockerignore`**: Excludes `portainer-stack.yml`
- **`.gitignore`**: Excludes `config.production.yaml` and `portainer-stack.yml` (local-only files)

Enables zero-config Swarm deployment: paste stack YAML into Portainer, set env vars, deploy.

## Env vars for Portainer

| Variable | Required | Default |
|---|---|---|
| `HA_TOKEN` | Yes | — |
| `HA_URL` | No | `http://localhost:8123` |
| `HA_WS_URL` | No | `ws://localhost:8123/api/websocket` |
| `MQTT_PASS` | Yes | — |
| `MQTT_BROKER` | No | `mqtt://localhost:1883` |
| `MQTT_USER` | No | `oasisagent` |
| `TRIAGE_LLM_API_KEY` | No | `not-needed` |
| `TRIAGE_LLM_BASE_URL` | No | `http://localhost:11434/v1` |
| `TRIAGE_LLM_MODEL` | No | `qwen2.5:7b` |
| `REASONING_LLM_API_KEY` | Yes | — |
| `INFLUXDB_TOKEN` | Yes | — |
| `INFLUX_URL` | No | `http://localhost:8086` |
| `DRY_RUN` | No | `true` |

## Test plan

- [x] 701 tests passing
- [x] Ruff clean
- [ ] After merge: tag v0.2.2 → GHCR build → deploy to Portainer with env vars only

🤖 Generated with [Claude Code](https://claude.com/claude-code)