### PR TITLE
Bump version to 0.2.2

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "oasisagent"
-version = "0.2.1"
+version = "0.2.2"
 description = "Autonomous infrastructure operations agent for home labs"
 readme = "README.md"
 license = "MIT"


### PR DESCRIPTION
## Summary

- Version bump `0.2.1` → `0.2.2` in `pyproject.toml`
- Triggers GHCR build with embedded `config.default.yaml` for Portainer deployment

## Test plan

- [ ] Merge → tag `v0.2.2` → verify GHCR builds image with baked-in config
- [ ] Deploy to Portainer with env vars only

🤖 Generated with [Claude Code](https://claude.com/claude-code)