### PR TITLE
Fix HA log poller endpoint path

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -202,7 +202,7 @@ class IngestAdapter(ABC):
   ```
 
 #### Home Assistant Log Poller
-- Polls HA's `/api/error/all` endpoint or reads log file directly
+- Polls HA's `/api/error_log` endpoint or reads log file directly
 - Pattern-matches log entries against known error signatures
 - Deduplicates based on error fingerprint + time window
 - Config:

--- a/oasisagent/ingestion/ha_log_poller.py
+++ b/oasisagent/ingestion/ha_log_poller.py
@@ -102,7 +102,7 @@ class HaLogPollerAdapter(IngestAdapter):
 
     async def _poll(self) -> None:
         """Fetch the error log and process entries."""
-        url = f"{self._config.url.rstrip('/')}/api/error/all"
+        url = f"{self._config.url.rstrip('/')}/api/error_log"
         headers = {
             "Authorization": f"Bearer {self._config.token}",
             "Content-Type": "application/json",


### PR DESCRIPTION
## Summary

- Fix `/api/error/all` → `/api/error_log` in `ha_log_poller.py` (line 105)
- Update ARCHITECTURE.md to match
- The HA handler (`homeassistant.py:279`) already used the correct path — the poller was the outlier

Fixes #33. Discovered during first Swarm deployment — poller was returning 404 every 30 seconds.

## Test plan

- [x] 701 tests passing
- [x] Ruff clean
- [ ] After deploy: verify poller ingests HA error log entries

🤖 Generated with [Claude Code](https://claude.com/claude-code)