### PR TITLE
Bump version to 0.2.3

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "oasisagent"
-version = "0.2.2"
+version = "0.2.3"
 description = "Autonomous infrastructure operations agent for home labs"
 readme = "README.md"
 license = "MIT"


### PR DESCRIPTION
## Summary

- Version bump `0.2.2` → `0.2.3` for HA log poller endpoint fix (#34)

## Test plan

- [ ] Merge → tag `v0.2.3` → GHCR build → redeploy in Portainer
- [ ] Verify log poller no longer returns 404

🤖 Generated with [Claude Code](https://claude.com/claude-code)