### PR TITLE
Expand log poller patterns for automation errors

### DIFF
--- a/config.default.yaml
+++ b/config.default.yaml
@@ -65,14 +65,33 @@ ingestion:
     poll_interval: 30
     dedup_window: 300
     patterns:
+      # Integration setup failures
       - regex: "Error setting up integration '(.+)'"
         event_type: integration_failure
         severity: error
+      # Automation execution errors (HA uses per-entity loggers)
+      - regex: "Error while executing automation automation\\.([^:]+)"
+        event_type: automation_error
+        severity: error
+      # Script/action execution errors within automations
+      - regex: "Error executing script.+for (\\w+) at pos"
+        event_type: automation_error
+        severity: error
+      # Template rendering errors
+      - regex: "Template variable error: (.+)"
+        event_type: template_error
+        severity: error
+      # Service deprecation warnings (e.g., kelvin → color_temp_kelvin)
+      - regex: "Got `(.+)` argument.+which is deprecated"
+        event_type: deprecation_warning
+        severity: warning
+      # Configuration validation errors
+      - regex: "Invalid config for \\[([^\\]]+)\\]"
+        event_type: config_error
+        severity: error
+      # Entity unavailability
       - regex: "(.+) is unavailable"
         event_type: state_unavailable
-        severity: warning
-      - regex: "Deprecated .+ used in (.+)"
-        event_type: deprecation_warning
         severity: warning
 
 llm:

--- a/config.example.yaml
+++ b/config.example.yaml
@@ -79,15 +79,48 @@ ingestion:
     poll_interval: 30            # Seconds between polls
     dedup_window: 300            # Same error within this window = one event
     patterns:
-      # Each pattern matches a log line regex and produces an event
+      # Each pattern matches against "component_name: message" from system_log/list.
+      # First match wins per entry. Capture group 1 becomes the event's entity_id.
+      # Severity here is a fallback — HA's native log level takes precedence.
+
+      # Integration setup failures (e.g., zwave_js, mqtt, hue)
       - regex: "Error setting up integration '(.+)'"
         event_type: integration_failure
         severity: error
+
+      # Automation execution errors
+      # HA logs: "Error while executing automation automation.<id>: <details>"
+      - regex: "Error while executing automation automation\\.([^:]+)"
+        event_type: automation_error
+        severity: error
+
+      # Script/action errors within automations (service calls, conditions)
+      # HA logs: "<Alias>: Error executing script. Error for call_service at pos N: <details>"
+      - regex: "Error executing script.+for (\\w+) at pos"
+        event_type: automation_error
+        severity: error
+
+      # Template rendering errors in automations and scripts
+      # HA logs: "Template variable error: 'dict object' has no attribute '...'"
+      - regex: "Template variable error: (.+)"
+        event_type: template_error
+        severity: error
+
+      # Service parameter deprecation warnings (e.g., kelvin → color_temp_kelvin)
+      # HA logs: "Got `kelvin` argument in `turn_on` service, which is deprecated..."
+      - regex: "Got `(.+)` argument.+which is deprecated"
+        event_type: deprecation_warning
+        severity: warning
+
+      # Configuration/schema validation errors
+      # HA logs: "Invalid config for [automation]: not a valid value..."
+      - regex: "Invalid config for \\[([^\\]]+)\\]"
+        event_type: config_error
+        severity: error
+
+      # Entity unavailability (generic catch-all)
       - regex: "(.+) is unavailable"
         event_type: state_unavailable
-        severity: warning
-      - regex: "Deprecated .+ used in (.+)"
-        event_type: deprecation_warning
         severity: warning
 
 # -----------------------------------------------------------------------------

--- a/tests/test_ingestion/test_ha_log_poller_ws.py
+++ b/tests/test_ingestion/test_ha_log_poller_ws.py
@@ -438,3 +438,183 @@ class TestFetchSystemLog:
         result = await adapter._fetch_system_log(ws)
 
         assert result == []
+
+
+# ---------------------------------------------------------------------------
+# Real HA log pattern matching
+# ---------------------------------------------------------------------------
+
+# All seven default patterns from config.default.yaml
+_DEFAULT_PATTERNS = [
+    LogPattern(
+        regex=r"Error setting up integration '(.+)'",
+        event_type="integration_failure",
+        severity="error",
+    ),
+    LogPattern(
+        regex=r"Error while executing automation automation\.([^:]+)",
+        event_type="automation_error",
+        severity="error",
+    ),
+    LogPattern(
+        regex=r"Error executing script.+for (\w+) at pos",
+        event_type="automation_error",
+        severity="error",
+    ),
+    LogPattern(
+        regex=r"Template variable error: (.+)",
+        event_type="template_error",
+        severity="error",
+    ),
+    LogPattern(
+        regex=r"Got `(.+)` argument.+which is deprecated",
+        event_type="deprecation_warning",
+        severity="warning",
+    ),
+    LogPattern(
+        regex=r"Invalid config for \[([^\]]+)\]",
+        event_type="config_error",
+        severity="error",
+    ),
+    LogPattern(
+        regex=r"(.+) is unavailable",
+        event_type="state_unavailable",
+        severity="warning",
+    ),
+]
+
+
+class TestDefaultPatterns:
+    """Tests that default patterns match real HA system log entries."""
+
+    def _make_adapter(self) -> tuple[HaLogPollerAdapter, EventQueue]:
+        queue = EventQueue(max_size=10)
+        adapter = HaLogPollerAdapter(
+            _make_config(patterns=_DEFAULT_PATTERNS), queue
+        )
+        return adapter, queue
+
+    def test_automation_execution_error(self) -> None:
+        adapter, queue = self._make_adapter()
+        adapter._process_entries([_make_log_entry(
+            name="homeassistant.components.automation.living_room_lights",
+            message="Error while executing automation automation.living_room_lights: "
+                    "service not found",
+            level="ERROR",
+        )])
+        assert queue.size == 1
+        event = queue.drain()[0]
+        assert event.event_type == "automation_error"
+        assert event.entity_id == "living_room_lights"
+
+    def test_automation_error_with_colon_in_details(self) -> None:
+        adapter, queue = self._make_adapter()
+        adapter._process_entries([_make_log_entry(
+            name="homeassistant.components.automation.night_mode",
+            message="Error while executing automation automation.night_mode: "
+                    "Error for call_service at pos 2: device unavailable",
+            level="ERROR",
+        )])
+        assert queue.size == 1
+        event = queue.drain()[0]
+        assert event.event_type == "automation_error"
+        assert event.entity_id == "night_mode"
+
+    def test_script_execution_error_service_call(self) -> None:
+        adapter, queue = self._make_adapter()
+        adapter._process_entries([_make_log_entry(
+            name="homeassistant.components.automation.dimmer",
+            message="Living Room Dimmer: Error executing script. "
+                    "Error for call_service at pos 2: Failed to send request",
+            level="ERROR",
+            source=["helpers/script.py", 1792],
+        )])
+        assert queue.size == 1
+        event = queue.drain()[0]
+        assert event.event_type == "automation_error"
+        assert event.entity_id == "call_service"
+
+    def test_template_variable_error(self) -> None:
+        adapter, queue = self._make_adapter()
+        adapter._process_entries([_make_log_entry(
+            name="homeassistant.helpers.template",
+            message="Template variable error: 'dict object' has no attribute 'payload_json'",
+            level="ERROR",
+            source=["helpers/template.py", 456],
+        )])
+        assert queue.size == 1
+        event = queue.drain()[0]
+        assert event.event_type == "template_error"
+
+    def test_deprecated_kelvin_parameter(self) -> None:
+        adapter, queue = self._make_adapter()
+        adapter._process_entries([_make_log_entry(
+            name="homeassistant.components.light",
+            message="Got `kelvin` argument in `turn_on` service, which is deprecated "
+                    "and will break in Home Assistant 2026.1, please use "
+                    "`color_temp_kelvin` argument",
+            level="WARNING",
+            source=["components/light/__init__.py", 331],
+        )])
+        assert queue.size == 1
+        event = queue.drain()[0]
+        assert event.event_type == "deprecation_warning"
+        assert event.entity_id == "kelvin"
+        assert event.severity == Severity.WARNING
+
+    def test_deprecated_color_temp_parameter(self) -> None:
+        adapter, queue = self._make_adapter()
+        adapter._process_entries([_make_log_entry(
+            name="homeassistant.components.light",
+            message="Got `color_temp` argument in `turn_on` service, which is deprecated "
+                    "and will break in Home Assistant 2026.1, please use "
+                    "`color_temp_kelvin` argument",
+            level="WARNING",
+            source=["components/light/__init__.py", 331],
+        )])
+        assert queue.size == 1
+        event = queue.drain()[0]
+        assert event.event_type == "deprecation_warning"
+        assert event.entity_id == "color_temp"
+
+    def test_invalid_config(self) -> None:
+        adapter, queue = self._make_adapter()
+        adapter._process_entries([_make_log_entry(
+            name="homeassistant.config",
+            message="Invalid config for [automation]: not a valid value for "
+                    "dictionary value @ data['type']. Got None",
+            level="ERROR",
+            source=["config.py", 464],
+        )])
+        assert queue.size == 1
+        event = queue.drain()[0]
+        assert event.event_type == "config_error"
+        assert event.entity_id == "automation"
+
+    def test_integration_failure_still_works(self) -> None:
+        adapter, queue = self._make_adapter()
+        adapter._process_entries([_make_log_entry()])
+        assert queue.size == 1
+        assert queue.drain()[0].event_type == "integration_failure"
+
+    def test_entity_unavailable_still_works(self) -> None:
+        adapter, queue = self._make_adapter()
+        adapter._process_entries([_make_log_entry(
+            name="homeassistant.components.sensor",
+            message="sensor.outdoor_temp is unavailable",
+            level="WARNING",
+        )])
+        assert queue.size == 1
+        assert queue.drain()[0].event_type == "state_unavailable"
+
+    def test_message_as_list_matches_automation_error(self) -> None:
+        """HA sometimes returns message as a list of strings."""
+        adapter, queue = self._make_adapter()
+        adapter._process_entries([_make_log_entry(
+            name="homeassistant.components.automation.garage_door",
+            message=["Error while executing automation", "automation.garage_door: timeout"],
+            level="ERROR",
+        )])
+        assert queue.size == 1
+        event = queue.drain()[0]
+        assert event.event_type == "automation_error"


### PR DESCRIPTION
## Summary
- Adds 5 new default log poller patterns to catch automation-related HA system log entries:
  - **Automation execution errors**: `Error while executing automation automation.(<id>)`
  - **Script/action errors**: `Error executing script...for <action_type> at pos`
  - **Template variable errors**: `Template variable error: <details>`
  - **Deprecation warnings**: `Got \`kelvin\` argument...which is deprecated`
  - **Config validation errors**: `Invalid config for [<component>]`
- Fixes the original use case gap: automation misconfigurations now produce events that flow through T0 known fixes (e.g., `ha-deprecated-kelvin`) and T1 triage
- Pattern regexes validated against real HA system log message formats from HA core source
- Updated both `config.default.yaml` (baked into image) and `config.example.yaml` (reference)

## Test plan
- [x] 736 tests passing (10 new pattern tests with real HA log message formats)
- [x] ruff lint clean
- [ ] Deploy to Portainer and verify automation errors are caught

🤖 Generated with [Claude Code](https://claude.com/claude-code)