### PR TITLE
Bump version to 0.2.5

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "oasisagent"
-version = "0.2.4"
+version = "0.2.5"
 description = "Autonomous infrastructure operations agent for home labs"
 readme = "README.md"
 license = "MIT"


### PR DESCRIPTION
## Summary
- Bump version to 0.2.5 for expanded log poller patterns (#40)

## Test plan
- [x] Version string updated in pyproject.toml
- [ ] CI builds multi-arch image on v0.2.5 tag

🤖 Generated with [Claude Code](https://claude.com/claude-code)