### PR TITLE
Add pipeline diagram to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,6 +17,10 @@
 
 OasisAgent bridges the gap between **monitoring** (you know something broke) and **resolution** (it's fixed). It sits alongside your existing stack — not inside it — and closes that gap automatically for known issues, and with intelligent diagnosis for novel ones.
 
+<p align="center">
+  <img src="docs/pipeline.svg" alt="OasisAgent data and analytics pipeline" width="800"/>
+</p>
+
 ## Three-Tier Reasoning
 
 | Tier | What it does | Latency | Cost |

--- a/docs/pipeline.svg
+++ b/docs/pipeline.svg
@@ -1,0 +1,216 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 800 330">
+  <defs>
+    <linearGradient id="pbg" x1="0%" y1="0%" x2="100%" y2="100%">
+      <stop offset="0%" style="stop-color:#0f172a"/>
+      <stop offset="100%" style="stop-color:#1e293b"/>
+    </linearGradient>
+    <marker id="arr" viewBox="0 0 10 6" refX="10" refY="3"
+            markerWidth="8" markerHeight="6" orient="auto-start-auto">
+      <path d="M0,0 L10,3 L0,6" fill="#475569"/>
+    </marker>
+    <marker id="arr-warn" viewBox="0 0 10 6" refX="10" refY="3"
+            markerWidth="8" markerHeight="6" orient="auto-start-auto">
+      <path d="M0,0 L10,3 L0,6" fill="#f59e0b"/>
+    </marker>
+  </defs>
+  <rect width="800" height="330" rx="12" fill="url(#pbg)"/>
+
+  <!-- Title -->
+  <text x="400" y="28" font-family="system-ui, -apple-system, sans-serif"
+        font-size="13" fill="#64748b" text-anchor="middle" font-weight="600"
+        letter-spacing="2">DATA &amp; ANALYTICS PIPELINE</text>
+
+  <!-- ================================================================== -->
+  <!-- ROW 1: Sources → Queue → Decision Engine → Guardrails              -->
+  <!-- y baseline: 90                                                     -->
+  <!-- ================================================================== -->
+
+  <!-- Event Sources -->
+  <g transform="translate(20, 48)">
+    <rect width="110" height="84" rx="6" fill="#1e293b" stroke="#334155" stroke-width="1"/>
+    <text x="55" y="17" font-family="system-ui, sans-serif" font-size="10"
+          fill="#64748b" text-anchor="middle" font-weight="600" letter-spacing="1">SOURCES</text>
+    <text x="55" y="35" font-family="ui-monospace, monospace" font-size="10"
+          fill="#22d3ee" text-anchor="middle">MQTT</text>
+    <text x="55" y="50" font-family="ui-monospace, monospace" font-size="10"
+          fill="#22d3ee" text-anchor="middle">HA WebSocket</text>
+    <text x="55" y="65" font-family="ui-monospace, monospace" font-size="10"
+          fill="#22d3ee" text-anchor="middle">HA Log Poller</text>
+    <text x="55" y="79" font-family="ui-monospace, monospace" font-size="9"
+          fill="#475569" text-anchor="middle">+ future adapters</text>
+  </g>
+
+  <!-- Arrow -->
+  <line x1="134" y1="90" x2="158" y2="90" stroke="#475569" stroke-width="1.5" marker-end="url(#arr)"/>
+
+  <!-- Event Queue -->
+  <g transform="translate(162, 68)">
+    <rect width="88" height="44" rx="6" fill="#1e293b" stroke="#334155" stroke-width="1"/>
+    <text x="44" y="17" font-family="system-ui, sans-serif" font-size="10"
+          fill="#64748b" text-anchor="middle" font-weight="600" letter-spacing="1">EVENT QUEUE</text>
+    <text x="44" y="34" font-family="ui-monospace, monospace" font-size="9"
+          fill="#94a3b8" text-anchor="middle">dedup + backpressure</text>
+  </g>
+
+  <!-- Arrow -->
+  <line x1="254" y1="90" x2="278" y2="90" stroke="#475569" stroke-width="1.5" marker-end="url(#arr)"/>
+
+  <!-- Decision Engine -->
+  <g transform="translate(282, 48)">
+    <rect width="270" height="84" rx="6" fill="#1e293b" stroke="#475569" stroke-width="1.5"/>
+    <text x="135" y="17" font-family="system-ui, sans-serif" font-size="10"
+          fill="#94a3b8" text-anchor="middle" font-weight="600" letter-spacing="1">DECISION ENGINE</text>
+
+    <!-- T0 -->
+    <rect x="12" y="26" width="72" height="48" rx="4" fill="#0f172a" stroke="#22d3ee" stroke-width="1"/>
+    <text x="48" y="44" font-family="ui-monospace, monospace" font-size="11"
+          fill="#22d3ee" text-anchor="middle" font-weight="700">T0</text>
+    <text x="48" y="57" font-family="system-ui, sans-serif" font-size="9"
+          fill="#64748b" text-anchor="middle">Known Fixes</text>
+    <text x="48" y="69" font-family="ui-monospace, monospace" font-size="8"
+          fill="#475569" text-anchor="middle">&lt;1ms</text>
+
+    <!-- Arrow T0→T1 -->
+    <line x1="88" y1="50" x2="96" y2="50" stroke="#475569" stroke-width="1" marker-end="url(#arr)"/>
+
+    <!-- T1 -->
+    <rect x="100" y="26" width="72" height="48" rx="4" fill="#0f172a" stroke="#818cf8" stroke-width="1"/>
+    <text x="136" y="44" font-family="ui-monospace, monospace" font-size="11"
+          fill="#818cf8" text-anchor="middle" font-weight="700">T1</text>
+    <text x="136" y="57" font-family="system-ui, sans-serif" font-size="9"
+          fill="#64748b" text-anchor="middle">Local SLM</text>
+    <text x="136" y="69" font-family="ui-monospace, monospace" font-size="8"
+          fill="#475569" text-anchor="middle">100-500ms</text>
+
+    <!-- Arrow T1→T2 -->
+    <line x1="176" y1="50" x2="184" y2="50" stroke="#475569" stroke-width="1" marker-end="url(#arr)"/>
+
+    <!-- T2 -->
+    <rect x="188" y="26" width="72" height="48" rx="4" fill="#0f172a" stroke="#a78bfa" stroke-width="1"/>
+    <text x="224" y="44" font-family="ui-monospace, monospace" font-size="11"
+          fill="#a78bfa" text-anchor="middle" font-weight="700">T2</text>
+    <text x="224" y="57" font-family="system-ui, sans-serif" font-size="9"
+          fill="#64748b" text-anchor="middle">Cloud LLM</text>
+    <text x="224" y="69" font-family="ui-monospace, monospace" font-size="8"
+          fill="#475569" text-anchor="middle">5-45s</text>
+  </g>
+
+  <!-- Arrow -->
+  <line x1="556" y1="90" x2="580" y2="90" stroke="#475569" stroke-width="1.5" marker-end="url(#arr)"/>
+
+  <!-- Guardrails -->
+  <g transform="translate(584, 56)">
+    <rect width="96" height="68" rx="6" fill="#1e293b" stroke="#f59e0b" stroke-width="1"/>
+    <text x="48" y="17" font-family="system-ui, sans-serif" font-size="10"
+          fill="#f59e0b" text-anchor="middle" font-weight="600">GUARDRAILS</text>
+    <text x="48" y="33" font-family="ui-monospace, monospace" font-size="8"
+          fill="#64748b" text-anchor="middle">risk tiers</text>
+    <text x="48" y="45" font-family="ui-monospace, monospace" font-size="8"
+          fill="#64748b" text-anchor="middle">blocked domains</text>
+    <text x="48" y="57" font-family="ui-monospace, monospace" font-size="8"
+          fill="#64748b" text-anchor="middle">circuit breaker</text>
+  </g>
+
+  <!-- ================================================================== -->
+  <!-- ROW 2: Handlers → Verify → Audit / Notifications                  -->
+  <!-- y baseline: 200                                                    -->
+  <!-- ================================================================== -->
+
+  <!-- Arrow: Guardrails → Handlers (down) -->
+  <line x1="680" y1="128" x2="680" y2="156" stroke="#475569" stroke-width="1.5" marker-end="url(#arr)"/>
+
+  <!-- Handlers -->
+  <g transform="translate(610, 160)">
+    <rect width="130" height="66" rx="6" fill="#1e293b" stroke="#334155" stroke-width="1"/>
+    <text x="65" y="17" font-family="system-ui, sans-serif" font-size="10"
+          fill="#94a3b8" text-anchor="middle" font-weight="600" letter-spacing="1">HANDLERS</text>
+    <text x="65" y="35" font-family="ui-monospace, monospace" font-size="10"
+          fill="#22d3ee" text-anchor="middle">Home Assistant</text>
+    <text x="65" y="49" font-family="ui-monospace, monospace" font-size="10"
+          fill="#475569" text-anchor="middle">Docker</text>
+    <text x="65" y="62" font-family="ui-monospace, monospace" font-size="9"
+          fill="#475569" text-anchor="middle">+ future handlers</text>
+  </g>
+
+  <!-- Arrow: Handlers ← Verify -->
+  <line x1="606" y1="193" x2="564" y2="193" stroke="#475569" stroke-width="1.5" marker-end="url(#arr)"/>
+
+  <!-- Verify -->
+  <g transform="translate(468, 175)">
+    <rect width="92" height="36" rx="6" fill="#1e293b" stroke="#334155" stroke-width="1"/>
+    <text x="46" y="15" font-family="system-ui, sans-serif" font-size="10"
+          fill="#94a3b8" text-anchor="middle" font-weight="600" letter-spacing="1">VERIFY</text>
+    <text x="46" y="30" font-family="ui-monospace, monospace" font-size="9"
+          fill="#64748b" text-anchor="middle">poll for effect</text>
+  </g>
+
+  <!-- Arrow: Verify ← Audit -->
+  <line x1="464" y1="193" x2="432" y2="193" stroke="#475569" stroke-width="1.5" marker-end="url(#arr)"/>
+
+  <!-- Audit -->
+  <g transform="translate(326, 168)">
+    <rect width="102" height="50" rx="6" fill="#1e293b" stroke="#334155" stroke-width="1"/>
+    <text x="51" y="17" font-family="system-ui, sans-serif" font-size="10"
+          fill="#94a3b8" text-anchor="middle" font-weight="600" letter-spacing="1">AUDIT</text>
+    <text x="51" y="33" font-family="ui-monospace, monospace" font-size="10"
+          fill="#22d3ee" text-anchor="middle">InfluxDB</text>
+    <text x="51" y="46" font-family="ui-monospace, monospace" font-size="9"
+          fill="#475569" text-anchor="middle">every decision</text>
+  </g>
+
+  <!-- Arrow: Audit ← Notifications -->
+  <line x1="322" y1="193" x2="240" y2="193" stroke="#475569" stroke-width="1.5" marker-end="url(#arr)"/>
+
+  <!-- Notifications -->
+  <g transform="translate(118, 162)">
+    <rect width="118" height="76" rx="6" fill="#1e293b" stroke="#334155" stroke-width="1"/>
+    <text x="59" y="17" font-family="system-ui, sans-serif" font-size="10"
+          fill="#94a3b8" text-anchor="middle" font-weight="600" letter-spacing="1">NOTIFICATIONS</text>
+    <text x="59" y="35" font-family="ui-monospace, monospace" font-size="10"
+          fill="#22d3ee" text-anchor="middle">MQTT</text>
+    <text x="59" y="49" font-family="ui-monospace, monospace" font-size="10"
+          fill="#22d3ee" text-anchor="middle">Email</text>
+    <text x="59" y="63" font-family="ui-monospace, monospace" font-size="10"
+          fill="#22d3ee" text-anchor="middle">Webhook</text>
+  </g>
+
+  <!-- ================================================================== -->
+  <!-- ROW 3: Observability + Approval Queue                              -->
+  <!-- ================================================================== -->
+
+  <!-- Arrow: Audit → Observability (down) -->
+  <line x1="377" y1="222" x2="377" y2="252" stroke="#475569" stroke-width="1.5" marker-end="url(#arr)"/>
+
+  <!-- Grafana -->
+  <g transform="translate(282, 256)">
+    <rect width="84" height="34" rx="4" fill="#0f172a" stroke="#334155" stroke-width="1"/>
+    <text x="42" y="15" font-family="ui-monospace, monospace" font-size="10"
+          fill="#818cf8" text-anchor="middle">Grafana</text>
+    <text x="42" y="28" font-family="ui-monospace, monospace" font-size="8"
+          fill="#475569" text-anchor="middle">dashboards</text>
+  </g>
+
+  <!-- Prometheus -->
+  <g transform="translate(378, 256)">
+    <rect width="84" height="34" rx="4" fill="#0f172a" stroke="#334155" stroke-width="1"/>
+    <text x="42" y="15" font-family="ui-monospace, monospace" font-size="10"
+          fill="#818cf8" text-anchor="middle">Prometheus</text>
+    <text x="42" y="28" font-family="ui-monospace, monospace" font-size="8"
+          fill="#475569" text-anchor="middle">/metrics</text>
+  </g>
+
+  <!-- Approval Queue -->
+  <g transform="translate(20, 262)">
+    <rect width="118" height="48" rx="6" fill="#1e293b" stroke="#f59e0b" stroke-width="1" opacity="0.8"/>
+    <text x="59" y="17" font-family="system-ui, sans-serif" font-size="10"
+          fill="#f59e0b" text-anchor="middle" font-weight="600">APPROVAL QUEUE</text>
+    <text x="59" y="32" font-family="ui-monospace, monospace" font-size="9"
+          fill="#64748b" text-anchor="middle">RECOMMEND actions</text>
+    <text x="59" y="44" font-family="ui-monospace, monospace" font-size="9"
+          fill="#64748b" text-anchor="middle">await operator OK</text>
+  </g>
+
+  <!-- Dashed arrow: Notifications → Approval Queue -->
+  <line x1="152" y1="242" x2="100" y2="258" stroke="#f59e0b" stroke-width="1" stroke-dasharray="4,3" marker-end="url(#arr-warn)"/>
+
+</svg>


### PR DESCRIPTION
## Summary
- Adds an SVG data and analytics pipeline diagram to the README, placed between the project description and Three-Tier Reasoning section
- Shows the full flow: Sources → Event Queue → Decision Engine (T0/T1/T2) → Guardrails → Handlers → Verify → Audit
- Includes Notifications, Approval Queue, and observability outputs (Grafana, Prometheus)
- Matches the banner's dark theme and color palette

## Test plan
- [x] Docs-only, no code changes
- [x] SVG is valid (no malformed tags)

🤖 Generated with [Claude Code](https://claude.com/claude-code)