### PR TITLE
Suppress noisy LiteLLM debug logs

### DIFF
--- a/oasisagent/__main__.py
+++ b/oasisagent/__main__.py
@@ -75,6 +75,12 @@ def _run_agent() -> None:
     log_level = config.agent.log_level.value.upper()
     logging.getLogger().setLevel(log_level)
 
+    # Suppress noisy LiteLLM logs ("Provider List: ..." on every call)
+    logging.getLogger("LiteLLM").setLevel(logging.WARNING)
+    logging.getLogger("LiteLLM Proxy").setLevel(logging.WARNING)
+    import litellm
+    litellm.suppress_debug_info = True
+
     orchestrator = Orchestrator(config)
     asyncio.run(orchestrator.run())
 


### PR DESCRIPTION
## Summary
- Suppresses LiteLLM's "Provider List: ..." spam that prints on every completion call
- Sets `LiteLLM` and `LiteLLM Proxy` loggers to WARNING level
- Enables `litellm.suppress_debug_info = True`

## Test plan
- [x] 736 tests passing
- [x] ruff clean
- [ ] Deploy and verify clean logs

🤖 Generated with [Claude Code](https://claude.com/claude-code)