### PR TITLE
Add Portainer handler for Docker management via REST API (#54)

### DIFF
--- a/known_fixes/docker.yaml
+++ b/known_fixes/docker.yaml
@@ -62,3 +62,43 @@ fixes:
       details:
         message: "Container crash loop detected — escalating for human review"
     risk_tier: escalate
+
+  - id: docker-volume-mount-failed
+    match:
+      system: docker
+      event_type: container_start_error
+      payload_contains: "mount"
+    diagnosis: "Container failed to start due to a volume mount error — path missing, permissions, or stale NFS mount"
+    action:
+      type: recommend
+      handler: docker
+      operation: notify
+      details:
+        message: |
+          Volume mount failure. Diagnostic checklist:
+          1. Verify the host path exists and has correct permissions
+          2. Check if NFS/CIFS mounts are available (showmount, mount)
+          3. Look for stale mounts that need remounting
+          4. Verify SELinux/AppArmor labels if applicable
+          5. Check Docker volume driver logs for errors
+    risk_tier: recommend
+
+  - id: docker-image-pull-failed
+    match:
+      system: docker
+      event_type: image_pull_error
+    diagnosis: "Docker image pull failed — registry unreachable, auth error, or image not found"
+    action:
+      type: recommend
+      handler: docker
+      operation: notify
+      details:
+        message: |
+          Image pull failure. Diagnostic checklist:
+          1. Verify registry connectivity (ping, curl the registry URL)
+          2. Check registry authentication credentials (docker login)
+          3. Confirm the image name and tag exist in the registry
+          4. Check for rate limiting (Docker Hub: 100 pulls/6h for anonymous)
+          5. Review DNS resolution for the registry hostname
+          6. Check disk space — pulls fail if /var/lib/docker is full
+    risk_tier: recommend

--- a/oasisagent/config.py
+++ b/oasisagent/config.py
@@ -479,6 +479,25 @@ class ProxmoxHandlerConfig(BaseModel):
     verify_ssl: bool = False
 
 
+class PortainerHandlerConfig(BaseModel):
+    """Portainer handler configuration.
+
+    Proxies Docker operations through the Portainer REST API, which
+    routes requests to a specific environment (endpoint) via
+    ``/api/endpoints/{endpoint_id}/docker/...``.
+    """
+
+    model_config = ConfigDict(extra="forbid")
+
+    enabled: bool = False
+    url: str = "https://localhost:9443"
+    api_key: str = ""
+    endpoint_id: Annotated[int, Field(ge=1)] = 1
+    verify_ssl: bool = False
+    verify_timeout: Annotated[int, Field(ge=1)] = 30
+    verify_poll_interval: Annotated[float, Field(gt=0.0)] = 2.0
+
+
 class HandlersConfig(BaseModel):
     """All handler configurations."""
 
@@ -486,6 +505,7 @@ class HandlersConfig(BaseModel):
 
     homeassistant: HaHandlerConfig = Field(default_factory=HaHandlerConfig)
     docker: DockerHandlerConfig = Field(default_factory=DockerHandlerConfig)
+    portainer: PortainerHandlerConfig = Field(default_factory=PortainerHandlerConfig)
     proxmox: ProxmoxHandlerConfig = Field(default_factory=ProxmoxHandlerConfig)
 
 

--- a/oasisagent/db/registry.py
+++ b/oasisagent/db/registry.py
@@ -31,6 +31,7 @@ from oasisagent.config import (
     LlmOptionsConfig,
     MqttIngestionConfig,
     MqttNotificationConfig,
+    PortainerHandlerConfig,
     ProxmoxHandlerConfig,
     WebhookNotificationConfig,
     WebhookSourceConfig,
@@ -95,6 +96,10 @@ CORE_SERVICE_TYPES: dict[str, TypeMeta] = {
     ),
     "docker_handler": TypeMeta(
         model=DockerHandlerConfig,
+    ),
+    "portainer_handler": TypeMeta(
+        model=PortainerHandlerConfig,
+        secret_fields=frozenset({"api_key"}),
     ),
     "proxmox_handler": TypeMeta(
         model=ProxmoxHandlerConfig,

--- a/oasisagent/handlers/__init__.py
+++ b/oasisagent/handlers/__init__.py
@@ -3,11 +3,13 @@
 from oasisagent.handlers.base import Handler
 from oasisagent.handlers.docker import DockerHandler
 from oasisagent.handlers.homeassistant import HomeAssistantHandler
+from oasisagent.handlers.portainer import PortainerHandler
 from oasisagent.handlers.proxmox import ProxmoxHandler
 
 __all__ = [
     "DockerHandler",
     "Handler",
     "HomeAssistantHandler",
+    "PortainerHandler",
     "ProxmoxHandler",
 ]

--- a/oasisagent/handlers/portainer.py
+++ b/oasisagent/handlers/portainer.py
@@ -1,0 +1,424 @@
+"""Portainer handler — manages Docker containers via the Portainer REST API.
+
+Operations: notify, restart_container, stop_container, start_container,
+get_container_logs, get_container_stats, inspect_container, list_containers.
+
+Portainer proxies Docker API calls through its environment-scoped endpoints:
+``/api/endpoints/{endpoint_id}/docker/containers/...``
+
+Auth: API key via ``X-API-Key`` header.
+
+ARCHITECTURE.md §8 defines the handler interface.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import logging
+import ssl
+import time
+from typing import TYPE_CHECKING, Any
+
+import aiohttp
+
+from oasisagent.handlers.base import Handler
+from oasisagent.models import ActionResult, ActionStatus, VerifyResult
+
+if TYPE_CHECKING:
+    from oasisagent.config import PortainerHandlerConfig
+    from oasisagent.models import Event, RecommendedAction
+
+logger = logging.getLogger(__name__)
+
+# Operations this handler supports.
+_KNOWN_OPERATIONS: frozenset[str] = frozenset({
+    "notify",
+    "restart_container",
+    "stop_container",
+    "start_container",
+    "get_container_logs",
+    "get_container_stats",
+    "inspect_container",
+    "list_containers",
+})
+
+
+class HandlerNotStartedError(Exception):
+    """Raised when handler methods are called before start()."""
+
+
+class PortainerHandler(Handler):
+    """Manages Docker containers via the Portainer REST API.
+
+    Must be started with ``await handler.start()`` before use.
+    All container operations are proxied through Portainer's environment-scoped
+    Docker API at ``/api/endpoints/{endpoint_id}/docker/...``.
+    """
+
+    def __init__(self, config: PortainerHandlerConfig) -> None:
+        self._config = config
+        self._session: aiohttp.ClientSession | None = None
+        self._docker_prefix = (
+            f"/api/endpoints/{config.endpoint_id}/docker"
+        )
+
+    def name(self) -> str:
+        return "portainer"
+
+    async def start(self) -> None:
+        """Create the aiohttp session with API key auth."""
+        ssl_context: ssl.SSLContext | bool = False
+        if self._config.verify_ssl:
+            ssl_context = ssl.create_default_context()
+
+        headers = {"X-API-Key": self._config.api_key}
+        connector = aiohttp.TCPConnector(ssl=ssl_context)
+        self._session = aiohttp.ClientSession(
+            base_url=self._config.url,
+            connector=connector,
+            headers=headers,
+        )
+        logger.info(
+            "Portainer handler started (url=%s, endpoint_id=%d)",
+            self._config.url, self._config.endpoint_id,
+        )
+
+    async def stop(self) -> None:
+        """Close the aiohttp session."""
+        if self._session is not None:
+            await self._session.close()
+            self._session = None
+            logger.info("Portainer handler stopped")
+
+    async def can_handle(self, event: Event, action: RecommendedAction) -> bool:
+        return (
+            action.handler == "portainer"
+            and action.operation in _KNOWN_OPERATIONS
+        )
+
+    async def execute(
+        self, event: Event, action: RecommendedAction,
+    ) -> ActionResult:
+        """Dispatch to the appropriate operation method."""
+        self._ensure_started()
+
+        dispatch = {
+            "notify": self._op_notify,
+            "restart_container": self._op_restart_container,
+            "stop_container": self._op_stop_container,
+            "start_container": self._op_start_container,
+            "get_container_logs": self._op_get_container_logs,
+            "get_container_stats": self._op_get_container_stats,
+            "inspect_container": self._op_inspect_container,
+            "list_containers": self._op_list_containers,
+        }
+
+        handler_fn = dispatch.get(action.operation)
+        if handler_fn is None:
+            return ActionResult(
+                status=ActionStatus.FAILURE,
+                error_message=f"Unknown operation: {action.operation}",
+            )
+
+        start = time.monotonic()
+        try:
+            result = await handler_fn(event, action)
+            elapsed = (time.monotonic() - start) * 1000
+            return result.model_copy(update={"duration_ms": elapsed})
+        except aiohttp.ClientError as exc:
+            elapsed = (time.monotonic() - start) * 1000
+            logger.error(
+                "Portainer handler HTTP error for %s: %s", action.operation, exc,
+            )
+            return ActionResult(
+                status=ActionStatus.FAILURE,
+                error_message=f"HTTP error: {exc}",
+                duration_ms=elapsed,
+            )
+
+    async def verify(
+        self, event: Event, action: RecommendedAction, result: ActionResult,
+    ) -> VerifyResult:
+        """Verify a container lifecycle action had the desired effect.
+
+        restart_container and start_container poll for "running".
+        stop_container polls for "exited" or "stopped".
+        Other operations return verified=True immediately.
+        """
+        if action.operation not in (
+            "restart_container", "start_container", "stop_container",
+        ):
+            return VerifyResult(verified=True, message="No verification needed")
+
+        self._ensure_started()
+
+        container_id = (
+            result.details.get("container_id")
+            or action.params.get("container_id")
+            or event.entity_id
+        )
+
+        expected = ("exited", "stopped") if action.operation == "stop_container" else ("running",)
+
+        return await self._verify_container_status(container_id, expected)
+
+    async def get_context(self, event: Event) -> dict[str, Any]:
+        """Gather Docker-specific context via Portainer for T1/T2 diagnosis.
+
+        Fetches container inspect data and recent logs.
+        """
+        self._ensure_started()
+        context: dict[str, Any] = {}
+        container_id = event.entity_id
+
+        try:
+            assert self._session is not None
+            async with self._session.get(
+                f"{self._docker_prefix}/containers/{container_id}/json",
+            ) as resp:
+                resp.raise_for_status()
+                context["container_inspect"] = await resp.json()
+        except aiohttp.ClientError as exc:
+            context["container_inspect_error"] = str(exc)
+
+        try:
+            assert self._session is not None
+            async with self._session.get(
+                f"{self._docker_prefix}/containers/{container_id}/logs",
+                params={"tail": "100", "stdout": "true", "stderr": "true"},
+            ) as resp:
+                resp.raise_for_status()
+                context["container_logs"] = await resp.text()
+        except aiohttp.ClientError as exc:
+            context["container_logs_error"] = str(exc)
+
+        return context
+
+    # -------------------------------------------------------------------
+    # Operation implementations
+    # -------------------------------------------------------------------
+
+    async def _op_notify(
+        self, event: Event, action: RecommendedAction,
+    ) -> ActionResult:
+        """Notify — no system changes. Returns the diagnosis message."""
+        message = action.params.get("message", action.description)
+        logger.info("Portainer notify: %s (entity=%s)", message, event.entity_id)
+        return ActionResult(
+            status=ActionStatus.SUCCESS,
+            details={"message": message, "entity_id": event.entity_id},
+        )
+
+    async def _op_restart_container(
+        self, event: Event, action: RecommendedAction,
+    ) -> ActionResult:
+        """Restart a container via Portainer-proxied Docker API."""
+        container_id = action.params.get("container_id") or event.entity_id
+        if not container_id:
+            return ActionResult(
+                status=ActionStatus.FAILURE,
+                error_message="restart_container requires container_id in params or entity_id",
+            )
+
+        assert self._session is not None
+        async with self._session.post(
+            f"{self._docker_prefix}/containers/{container_id}/restart",
+        ) as resp:
+            resp.raise_for_status()
+
+        logger.info("Portainer restart_container: %s", container_id)
+        return ActionResult(
+            status=ActionStatus.SUCCESS,
+            details={"container_id": container_id},
+        )
+
+    async def _op_stop_container(
+        self, event: Event, action: RecommendedAction,
+    ) -> ActionResult:
+        """Stop a container via Portainer-proxied Docker API."""
+        container_id = action.params.get("container_id") or event.entity_id
+        if not container_id:
+            return ActionResult(
+                status=ActionStatus.FAILURE,
+                error_message="stop_container requires container_id in params or entity_id",
+            )
+
+        assert self._session is not None
+        params: dict[str, str] = {}
+        timeout = action.params.get("timeout")
+        if timeout is not None:
+            params["t"] = str(timeout)
+
+        async with self._session.post(
+            f"{self._docker_prefix}/containers/{container_id}/stop",
+            params=params,
+        ) as resp:
+            resp.raise_for_status()
+
+        logger.info("Portainer stop_container: %s", container_id)
+        return ActionResult(
+            status=ActionStatus.SUCCESS,
+            details={"container_id": container_id},
+        )
+
+    async def _op_start_container(
+        self, event: Event, action: RecommendedAction,
+    ) -> ActionResult:
+        """Start a container via Portainer-proxied Docker API."""
+        container_id = action.params.get("container_id") or event.entity_id
+        if not container_id:
+            return ActionResult(
+                status=ActionStatus.FAILURE,
+                error_message="start_container requires container_id in params or entity_id",
+            )
+
+        assert self._session is not None
+        async with self._session.post(
+            f"{self._docker_prefix}/containers/{container_id}/start",
+        ) as resp:
+            resp.raise_for_status()
+
+        logger.info("Portainer start_container: %s", container_id)
+        return ActionResult(
+            status=ActionStatus.SUCCESS,
+            details={"container_id": container_id},
+        )
+
+    async def _op_get_container_logs(
+        self, event: Event, action: RecommendedAction,
+    ) -> ActionResult:
+        """Fetch container logs via Portainer-proxied Docker API."""
+        container_id = action.params.get("container_id") or event.entity_id
+        if not container_id:
+            return ActionResult(
+                status=ActionStatus.FAILURE,
+                error_message="get_container_logs requires container_id in params or entity_id",
+            )
+
+        tail = action.params.get("tail", "100")
+        assert self._session is not None
+        async with self._session.get(
+            f"{self._docker_prefix}/containers/{container_id}/logs",
+            params={"tail": str(tail), "stdout": "true", "stderr": "true"},
+        ) as resp:
+            resp.raise_for_status()
+            logs = await resp.text()
+
+        return ActionResult(
+            status=ActionStatus.SUCCESS,
+            details={"container_id": container_id, "logs": logs},
+        )
+
+    async def _op_get_container_stats(
+        self, event: Event, action: RecommendedAction,
+    ) -> ActionResult:
+        """Fetch container stats via Portainer-proxied Docker API."""
+        container_id = action.params.get("container_id") or event.entity_id
+        if not container_id:
+            return ActionResult(
+                status=ActionStatus.FAILURE,
+                error_message="get_container_stats requires container_id in params or entity_id",
+            )
+
+        assert self._session is not None
+        async with self._session.get(
+            f"{self._docker_prefix}/containers/{container_id}/stats",
+            params={"stream": "false"},
+        ) as resp:
+            resp.raise_for_status()
+            stats = await resp.json()
+
+        return ActionResult(
+            status=ActionStatus.SUCCESS,
+            details={"container_id": container_id, "stats": stats},
+        )
+
+    async def _op_inspect_container(
+        self, event: Event, action: RecommendedAction,
+    ) -> ActionResult:
+        """Inspect a container via Portainer-proxied Docker API."""
+        container_id = action.params.get("container_id") or event.entity_id
+        if not container_id:
+            return ActionResult(
+                status=ActionStatus.FAILURE,
+                error_message="inspect_container requires container_id in params or entity_id",
+            )
+
+        assert self._session is not None
+        async with self._session.get(
+            f"{self._docker_prefix}/containers/{container_id}/json",
+        ) as resp:
+            resp.raise_for_status()
+            inspect_data = await resp.json()
+
+        return ActionResult(
+            status=ActionStatus.SUCCESS,
+            details={"container_id": container_id, "inspect": inspect_data},
+        )
+
+    async def _op_list_containers(
+        self, event: Event, action: RecommendedAction,
+    ) -> ActionResult:
+        """List containers in the Portainer environment."""
+        all_containers = action.params.get("all", "false")
+        assert self._session is not None
+        async with self._session.get(
+            f"{self._docker_prefix}/containers/json",
+            params={"all": str(all_containers).lower()},
+        ) as resp:
+            resp.raise_for_status()
+            containers = await resp.json()
+
+        return ActionResult(
+            status=ActionStatus.SUCCESS,
+            details={
+                "containers": containers,
+                "count": len(containers) if isinstance(containers, list) else 0,
+            },
+        )
+
+    # -------------------------------------------------------------------
+    # Internal helpers
+    # -------------------------------------------------------------------
+
+    def _ensure_started(self) -> None:
+        """Raise if the handler hasn't been started."""
+        if self._session is None:
+            raise HandlerNotStartedError(
+                "PortainerHandler.start() must be called before use",
+            )
+
+    async def _verify_container_status(
+        self, container_id: str, expected: tuple[str, ...],
+    ) -> VerifyResult:
+        """Poll container status until it matches one of the expected states."""
+        timeout = self._config.verify_timeout
+        interval = self._config.verify_poll_interval
+        deadline = time.monotonic() + timeout
+
+        while time.monotonic() < deadline:
+            try:
+                assert self._session is not None
+                async with self._session.get(
+                    f"{self._docker_prefix}/containers/{container_id}/json",
+                ) as resp:
+                    resp.raise_for_status()
+                    data = await resp.json()
+                    status = data.get("State", {}).get("Status", "unknown")
+                    if status in expected:
+                        return VerifyResult(
+                            verified=True,
+                            message=f"Container {container_id} is {status}",
+                        )
+            except aiohttp.ClientError:
+                pass  # Keep polling
+
+            await asyncio.sleep(interval)
+
+        return VerifyResult(
+            verified=False,
+            message=(
+                f"Container {container_id} did not reach "
+                f"{'/'.join(expected)} within {timeout}s"
+            ),
+        )

--- a/oasisagent/orchestrator.py
+++ b/oasisagent/orchestrator.py
@@ -236,6 +236,11 @@ class Orchestrator:
         if cfg.handlers.docker.enabled:
             docker = DockerHandler(cfg.handlers.docker)
             self._handlers[docker.name()] = docker
+        if cfg.handlers.portainer.enabled:
+            from oasisagent.handlers.portainer import PortainerHandler
+
+            portainer = PortainerHandler(cfg.handlers.portainer)
+            self._handlers[portainer.name()] = portainer
         if cfg.handlers.proxmox.enabled:
             from oasisagent.handlers.proxmox import ProxmoxHandler
 

--- a/tests/test_handlers/test_portainer.py
+++ b/tests/test_handlers/test_portainer.py
@@ -1,0 +1,771 @@
+"""Tests for the Portainer handler."""
+
+from __future__ import annotations
+
+from datetime import UTC, datetime
+from typing import Any
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import aiohttp
+import pytest
+
+from oasisagent.config import PortainerHandlerConfig
+from oasisagent.handlers.portainer import (
+    HandlerNotStartedError,
+    PortainerHandler,
+)
+from oasisagent.models import (
+    ActionResult,
+    ActionStatus,
+    Event,
+    EventMetadata,
+    RecommendedAction,
+    RiskTier,
+    Severity,
+)
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+_DOCKER_PREFIX = "/api/endpoints/1/docker"
+
+
+def _make_config(**overrides: Any) -> PortainerHandlerConfig:
+    defaults: dict[str, Any] = {
+        "enabled": True,
+        "url": "https://portainer.example.com:9443",
+        "api_key": "ptr_test_api_key_1234567890",
+        "endpoint_id": 1,
+        "verify_ssl": False,
+        "verify_timeout": 5,
+        "verify_poll_interval": 0.05,
+    }
+    defaults.update(overrides)
+    return PortainerHandlerConfig(**defaults)
+
+
+def _make_event(**overrides: Any) -> Event:
+    defaults: dict[str, Any] = {
+        "source": "test",
+        "system": "docker",
+        "event_type": "container_die",
+        "entity_id": "my_container",
+        "severity": Severity.WARNING,
+        "timestamp": datetime.now(UTC),
+        "payload": {},
+        "metadata": EventMetadata(),
+    }
+    defaults.update(overrides)
+    return Event(**defaults)
+
+
+def _make_action(**overrides: Any) -> RecommendedAction:
+    defaults: dict[str, Any] = {
+        "description": "Test action",
+        "handler": "portainer",
+        "operation": "restart_container",
+        "params": {"container_id": "my_container"},
+        "risk_tier": RiskTier.AUTO_FIX,
+    }
+    defaults.update(overrides)
+    return RecommendedAction(**defaults)
+
+
+def _mock_response(
+    status: int = 200,
+    json_data: dict[str, Any] | list[Any] | None = None,
+    text_data: str = "",
+) -> MagicMock:
+    """Create a mock aiohttp response."""
+    resp = MagicMock()
+    resp.status = status
+    resp.json = AsyncMock(return_value=json_data or {})
+    resp.text = AsyncMock(return_value=text_data)
+    if status >= 400:
+        resp.raise_for_status.side_effect = aiohttp.ClientResponseError(
+            request_info=MagicMock(),
+            history=(),
+            status=status,
+            message=f"HTTP {status}",
+        )
+    else:
+        resp.raise_for_status.return_value = None
+    return resp
+
+
+def _patch_session(
+    handler: PortainerHandler, responses: dict[str, MagicMock],
+) -> None:
+    """Replace the handler's session with a mock returning specified responses."""
+    session = MagicMock(spec=aiohttp.ClientSession)
+
+    def _make_cm(resp: MagicMock) -> MagicMock:
+        cm = MagicMock()
+        cm.__aenter__ = AsyncMock(return_value=resp)
+        cm.__aexit__ = AsyncMock(return_value=False)
+        return cm
+
+    def _get_handler(path: str, **kwargs: Any) -> MagicMock:
+        key = f"get:{path}"
+        resp = responses.get(key, _mock_response())
+        return _make_cm(resp)
+
+    def _post_handler(path: str, **kwargs: Any) -> MagicMock:
+        key = f"post:{path}"
+        resp = responses.get(key, _mock_response())
+        return _make_cm(resp)
+
+    session.get = MagicMock(side_effect=_get_handler)
+    session.post = MagicMock(side_effect=_post_handler)
+    session.close = AsyncMock()
+
+    handler._session = session
+
+
+def _started_handler(**config_overrides: Any) -> PortainerHandler:
+    """Create a handler with a mocked session (skipping real HTTP)."""
+    handler = PortainerHandler(_make_config(**config_overrides))
+    handler._session = MagicMock(spec=aiohttp.ClientSession)
+    return handler
+
+
+# ---------------------------------------------------------------------------
+# Lifecycle
+# ---------------------------------------------------------------------------
+
+
+class TestLifecycle:
+    async def test_start_creates_session(self) -> None:
+        handler = PortainerHandler(_make_config())
+        with (
+            patch("oasisagent.handlers.portainer.aiohttp.TCPConnector") as mock_conn,
+            patch("oasisagent.handlers.portainer.aiohttp.ClientSession") as mock_cls,
+        ):
+            mock_cls.return_value = MagicMock()
+            await handler.start()
+
+            mock_conn.assert_called_once_with(ssl=False)
+            mock_cls.assert_called_once()
+            assert handler._session is not None
+
+    async def test_start_with_verify_ssl(self) -> None:
+        handler = PortainerHandler(_make_config(verify_ssl=True))
+        with (
+            patch("oasisagent.handlers.portainer.aiohttp.TCPConnector") as mock_conn,
+            patch("oasisagent.handlers.portainer.aiohttp.ClientSession") as mock_cls,
+        ):
+            mock_cls.return_value = MagicMock()
+            await handler.start()
+
+            call_kwargs = mock_conn.call_args
+            ssl_arg = (
+                call_kwargs[1]["ssl"]
+                if "ssl" in call_kwargs[1]
+                else call_kwargs[0][0]
+            )
+            import ssl
+
+            assert isinstance(ssl_arg, ssl.SSLContext)
+
+    async def test_start_api_key_header(self) -> None:
+        handler = PortainerHandler(_make_config(api_key="my-secret-key"))
+        with (
+            patch("oasisagent.handlers.portainer.aiohttp.TCPConnector"),
+            patch("oasisagent.handlers.portainer.aiohttp.ClientSession") as mock_cls,
+        ):
+            mock_cls.return_value = MagicMock()
+            await handler.start()
+
+            call_kwargs = mock_cls.call_args[1]
+            assert call_kwargs["headers"]["X-API-Key"] == "my-secret-key"
+
+    async def test_stop_closes_session(self) -> None:
+        handler = _started_handler()
+        mock_session = AsyncMock()
+        handler._session = mock_session
+
+        await handler.stop()
+
+        mock_session.close.assert_called_once()
+        assert handler._session is None
+
+    async def test_stop_without_start_is_noop(self) -> None:
+        handler = PortainerHandler(_make_config())
+        await handler.stop()  # Should not raise
+
+    async def test_execute_before_start_raises(self) -> None:
+        handler = PortainerHandler(_make_config())
+        with pytest.raises(HandlerNotStartedError):
+            await handler.execute(_make_event(), _make_action())
+
+    async def test_get_context_before_start_raises(self) -> None:
+        handler = PortainerHandler(_make_config())
+        with pytest.raises(HandlerNotStartedError):
+            await handler.get_context(_make_event())
+
+    async def test_verify_before_start_raises_for_restart(self) -> None:
+        handler = PortainerHandler(_make_config())
+        action = _make_action(operation="restart_container")
+        result = ActionResult(
+            status=ActionStatus.SUCCESS,
+            details={"container_id": "my_container"},
+        )
+        with pytest.raises(HandlerNotStartedError):
+            await handler.verify(_make_event(), action, result)
+
+
+# ---------------------------------------------------------------------------
+# name() and can_handle()
+# ---------------------------------------------------------------------------
+
+
+class TestNameAndCanHandle:
+    def test_name_is_portainer(self) -> None:
+        handler = PortainerHandler(_make_config())
+        assert handler.name() == "portainer"
+
+    def test_docker_prefix_includes_endpoint_id(self) -> None:
+        handler = PortainerHandler(_make_config(endpoint_id=5))
+        assert handler._docker_prefix == "/api/endpoints/5/docker"
+
+    async def test_known_operations_accepted(self) -> None:
+        handler = PortainerHandler(_make_config())
+        event = _make_event()
+        for op in [
+            "notify", "restart_container", "stop_container",
+            "start_container", "get_container_logs", "get_container_stats",
+            "inspect_container", "list_containers",
+        ]:
+            action = _make_action(operation=op)
+            assert await handler.can_handle(event, action) is True
+
+    async def test_unknown_operation_rejected(self) -> None:
+        handler = PortainerHandler(_make_config())
+        action = _make_action(operation="delete_container")
+        assert await handler.can_handle(_make_event(), action) is False
+
+    async def test_wrong_handler_rejected(self) -> None:
+        handler = PortainerHandler(_make_config())
+        action = _make_action(handler="docker", operation="restart_container")
+        assert await handler.can_handle(_make_event(), action) is False
+
+
+# ---------------------------------------------------------------------------
+# execute: notify
+# ---------------------------------------------------------------------------
+
+
+class TestNotify:
+    async def test_notify_returns_message(self) -> None:
+        handler = _started_handler()
+        _patch_session(handler, {})
+        action = _make_action(
+            operation="notify",
+            params={"message": "Container OOM — restarted"},
+        )
+
+        result = await handler.execute(_make_event(), action)
+
+        assert result.status == ActionStatus.SUCCESS
+        assert result.details["message"] == "Container OOM — restarted"
+
+
+# ---------------------------------------------------------------------------
+# execute: restart_container
+# ---------------------------------------------------------------------------
+
+
+class TestRestartContainer:
+    async def test_success(self) -> None:
+        handler = _started_handler()
+        _patch_session(handler, {
+            f"post:{_DOCKER_PREFIX}/containers/my_container/restart": _mock_response(
+                status=204,
+            ),
+        })
+        action = _make_action(
+            operation="restart_container",
+            params={"container_id": "my_container"},
+        )
+
+        result = await handler.execute(_make_event(), action)
+
+        assert result.status == ActionStatus.SUCCESS
+        assert result.details["container_id"] == "my_container"
+
+    async def test_uses_event_entity_id_as_fallback(self) -> None:
+        handler = _started_handler()
+        _patch_session(handler, {
+            f"post:{_DOCKER_PREFIX}/containers/nginx/restart": _mock_response(
+                status=204,
+            ),
+        })
+        action = _make_action(operation="restart_container", params={})
+
+        result = await handler.execute(_make_event(entity_id="nginx"), action)
+
+        assert result.status == ActionStatus.SUCCESS
+        assert result.details["container_id"] == "nginx"
+
+    async def test_missing_container_id_fails(self) -> None:
+        handler = _started_handler()
+        _patch_session(handler, {})
+        action = _make_action(operation="restart_container", params={})
+
+        result = await handler.execute(_make_event(entity_id=""), action)
+
+        assert result.status == ActionStatus.FAILURE
+        assert "container_id" in (result.error_message or "")
+
+    async def test_http_error_returns_failure(self) -> None:
+        handler = _started_handler()
+        _patch_session(handler, {
+            f"post:{_DOCKER_PREFIX}/containers/my_container/restart": _mock_response(
+                status=500,
+            ),
+        })
+        action = _make_action(
+            operation="restart_container",
+            params={"container_id": "my_container"},
+        )
+
+        result = await handler.execute(_make_event(), action)
+
+        assert result.status == ActionStatus.FAILURE
+        assert "HTTP error" in (result.error_message or "")
+
+    async def test_portainer_url_path(self) -> None:
+        """Verify requests go through Portainer's endpoint-scoped Docker proxy."""
+        handler = _started_handler(endpoint_id=3)
+        _patch_session(handler, {
+            "/api/endpoints/3/docker/containers/abc/restart": _mock_response(
+                status=204,
+            ),
+        })
+        action = _make_action(
+            operation="restart_container",
+            params={"container_id": "abc"},
+        )
+
+        await handler.execute(_make_event(), action)
+
+        handler._session.post.assert_called()
+        call_path = handler._session.post.call_args[0][0]
+        assert call_path == "/api/endpoints/3/docker/containers/abc/restart"
+
+
+# ---------------------------------------------------------------------------
+# execute: stop_container
+# ---------------------------------------------------------------------------
+
+
+class TestStopContainer:
+    async def test_success(self) -> None:
+        handler = _started_handler()
+        _patch_session(handler, {
+            f"post:{_DOCKER_PREFIX}/containers/my_container/stop": _mock_response(
+                status=204,
+            ),
+        })
+        action = _make_action(
+            operation="stop_container",
+            params={"container_id": "my_container"},
+        )
+
+        result = await handler.execute(_make_event(), action)
+
+        assert result.status == ActionStatus.SUCCESS
+
+    async def test_missing_container_id_fails(self) -> None:
+        handler = _started_handler()
+        _patch_session(handler, {})
+        action = _make_action(operation="stop_container", params={})
+
+        result = await handler.execute(_make_event(entity_id=""), action)
+
+        assert result.status == ActionStatus.FAILURE
+
+
+# ---------------------------------------------------------------------------
+# execute: start_container
+# ---------------------------------------------------------------------------
+
+
+class TestStartContainer:
+    async def test_success(self) -> None:
+        handler = _started_handler()
+        _patch_session(handler, {
+            f"post:{_DOCKER_PREFIX}/containers/my_container/start": _mock_response(
+                status=204,
+            ),
+        })
+        action = _make_action(
+            operation="start_container",
+            params={"container_id": "my_container"},
+        )
+
+        result = await handler.execute(_make_event(), action)
+
+        assert result.status == ActionStatus.SUCCESS
+
+    async def test_missing_container_id_fails(self) -> None:
+        handler = _started_handler()
+        _patch_session(handler, {})
+        action = _make_action(operation="start_container", params={})
+
+        result = await handler.execute(_make_event(entity_id=""), action)
+
+        assert result.status == ActionStatus.FAILURE
+
+
+# ---------------------------------------------------------------------------
+# execute: get_container_logs
+# ---------------------------------------------------------------------------
+
+
+class TestGetContainerLogs:
+    async def test_success(self) -> None:
+        handler = _started_handler()
+        _patch_session(handler, {
+            f"get:{_DOCKER_PREFIX}/containers/my_container/logs": _mock_response(
+                text_data="2024-01-01 Error: something failed\n",
+            ),
+        })
+        action = _make_action(
+            operation="get_container_logs",
+            params={"container_id": "my_container"},
+        )
+
+        result = await handler.execute(_make_event(), action)
+
+        assert result.status == ActionStatus.SUCCESS
+        assert "something failed" in result.details["logs"]
+
+    async def test_missing_container_id_fails(self) -> None:
+        handler = _started_handler()
+        _patch_session(handler, {})
+        action = _make_action(operation="get_container_logs", params={})
+
+        result = await handler.execute(_make_event(entity_id=""), action)
+
+        assert result.status == ActionStatus.FAILURE
+
+
+# ---------------------------------------------------------------------------
+# execute: get_container_stats
+# ---------------------------------------------------------------------------
+
+
+class TestGetContainerStats:
+    async def test_success(self) -> None:
+        stats_data = {"cpu_stats": {"total_usage": 100}, "memory_stats": {"usage": 1024}}
+        handler = _started_handler()
+        _patch_session(handler, {
+            f"get:{_DOCKER_PREFIX}/containers/my_container/stats": _mock_response(
+                json_data=stats_data,
+            ),
+        })
+        action = _make_action(
+            operation="get_container_stats",
+            params={"container_id": "my_container"},
+        )
+
+        result = await handler.execute(_make_event(), action)
+
+        assert result.status == ActionStatus.SUCCESS
+        assert result.details["stats"] == stats_data
+
+    async def test_missing_container_id_fails(self) -> None:
+        handler = _started_handler()
+        _patch_session(handler, {})
+        action = _make_action(operation="get_container_stats", params={})
+
+        result = await handler.execute(_make_event(entity_id=""), action)
+
+        assert result.status == ActionStatus.FAILURE
+
+
+# ---------------------------------------------------------------------------
+# execute: inspect_container
+# ---------------------------------------------------------------------------
+
+
+class TestInspectContainer:
+    async def test_success(self) -> None:
+        inspect_data = {
+            "Id": "abc123",
+            "State": {"Status": "running", "OOMKilled": False},
+            "Config": {"Image": "nginx:latest"},
+        }
+        handler = _started_handler()
+        _patch_session(handler, {
+            f"get:{_DOCKER_PREFIX}/containers/my_container/json": _mock_response(
+                json_data=inspect_data,
+            ),
+        })
+        action = _make_action(
+            operation="inspect_container",
+            params={"container_id": "my_container"},
+        )
+
+        result = await handler.execute(_make_event(), action)
+
+        assert result.status == ActionStatus.SUCCESS
+        assert result.details["inspect"]["Id"] == "abc123"
+
+    async def test_missing_container_id_fails(self) -> None:
+        handler = _started_handler()
+        _patch_session(handler, {})
+        action = _make_action(operation="inspect_container", params={})
+
+        result = await handler.execute(_make_event(entity_id=""), action)
+
+        assert result.status == ActionStatus.FAILURE
+
+
+# ---------------------------------------------------------------------------
+# execute: list_containers
+# ---------------------------------------------------------------------------
+
+
+class TestListContainers:
+    async def test_success(self) -> None:
+        containers = [
+            {"Id": "abc", "Names": ["/nginx"], "State": "running"},
+            {"Id": "def", "Names": ["/postgres"], "State": "running"},
+        ]
+        handler = _started_handler()
+        _patch_session(handler, {
+            f"get:{_DOCKER_PREFIX}/containers/json": _mock_response(
+                json_data=containers,
+            ),
+        })
+        action = _make_action(operation="list_containers", params={})
+
+        result = await handler.execute(_make_event(), action)
+
+        assert result.status == ActionStatus.SUCCESS
+        assert result.details["count"] == 2
+
+
+# ---------------------------------------------------------------------------
+# execute: misc
+# ---------------------------------------------------------------------------
+
+
+class TestExecuteMisc:
+    async def test_unknown_operation_returns_failure(self) -> None:
+        handler = _started_handler()
+        _patch_session(handler, {})
+        action = _make_action(operation="delete_container")
+
+        result = await handler.execute(_make_event(), action)
+
+        assert result.status == ActionStatus.FAILURE
+        assert "Unknown operation" in (result.error_message or "")
+
+    async def test_duration_ms_set_on_success(self) -> None:
+        handler = _started_handler()
+        _patch_session(handler, {})
+        action = _make_action(
+            operation="notify", params={"message": "test"},
+        )
+
+        result = await handler.execute(_make_event(), action)
+
+        assert result.duration_ms is not None
+        assert result.duration_ms >= 0
+
+    async def test_duration_ms_set_on_http_error(self) -> None:
+        handler = _started_handler()
+        _patch_session(handler, {
+            f"post:{_DOCKER_PREFIX}/containers/my_container/restart": _mock_response(
+                status=500,
+            ),
+        })
+        action = _make_action(
+            operation="restart_container",
+            params={"container_id": "my_container"},
+        )
+
+        result = await handler.execute(_make_event(), action)
+
+        assert result.duration_ms is not None
+
+
+# ---------------------------------------------------------------------------
+# verify
+# ---------------------------------------------------------------------------
+
+
+class TestVerify:
+    async def test_non_lifecycle_returns_verified(self) -> None:
+        handler = PortainerHandler(_make_config())
+        action = _make_action(operation="inspect_container")
+        result = ActionResult(status=ActionStatus.SUCCESS)
+
+        verify = await handler.verify(_make_event(), action, result)
+
+        assert verify.verified is True
+
+    async def test_restart_verified_when_running(self) -> None:
+        handler = _started_handler()
+        _patch_session(handler, {
+            f"get:{_DOCKER_PREFIX}/containers/my_container/json": _mock_response(
+                json_data={"State": {"Status": "running"}},
+            ),
+        })
+        action = _make_action(operation="restart_container")
+        result = ActionResult(
+            status=ActionStatus.SUCCESS,
+            details={"container_id": "my_container"},
+        )
+
+        verify = await handler.verify(_make_event(), action, result)
+
+        assert verify.verified is True
+        assert "running" in verify.message
+
+    async def test_stop_verified_when_exited(self) -> None:
+        handler = _started_handler()
+        _patch_session(handler, {
+            f"get:{_DOCKER_PREFIX}/containers/my_container/json": _mock_response(
+                json_data={"State": {"Status": "exited"}},
+            ),
+        })
+        action = _make_action(operation="stop_container")
+        result = ActionResult(
+            status=ActionStatus.SUCCESS,
+            details={"container_id": "my_container"},
+        )
+
+        verify = await handler.verify(_make_event(), action, result)
+
+        assert verify.verified is True
+        assert "exited" in verify.message
+
+    async def test_restart_not_verified_when_still_exited(self) -> None:
+        handler = _started_handler(verify_timeout=1, verify_poll_interval=0.02)
+        _patch_session(handler, {
+            f"get:{_DOCKER_PREFIX}/containers/my_container/json": _mock_response(
+                json_data={"State": {"Status": "exited"}},
+            ),
+        })
+        action = _make_action(operation="restart_container")
+        result = ActionResult(
+            status=ActionStatus.SUCCESS,
+            details={"container_id": "my_container"},
+        )
+
+        verify = await handler.verify(_make_event(), action, result)
+
+        assert verify.verified is False
+        assert "did not reach" in verify.message
+
+
+# ---------------------------------------------------------------------------
+# get_context
+# ---------------------------------------------------------------------------
+
+
+class TestGetContext:
+    async def test_gathers_inspect_and_logs(self) -> None:
+        handler = _started_handler()
+        inspect_data = {"State": {"Status": "exited", "OOMKilled": True}}
+        _patch_session(handler, {
+            f"get:{_DOCKER_PREFIX}/containers/my_container/json": _mock_response(
+                json_data=inspect_data,
+            ),
+            f"get:{_DOCKER_PREFIX}/containers/my_container/logs": _mock_response(
+                text_data="Error: out of memory\n",
+            ),
+        })
+
+        context = await handler.get_context(_make_event(entity_id="my_container"))
+
+        assert "container_inspect" in context
+        assert context["container_inspect"]["State"]["OOMKilled"] is True
+        assert "container_logs" in context
+        assert "out of memory" in context["container_logs"]
+
+    async def test_handles_inspect_error_gracefully(self) -> None:
+        handler = _started_handler()
+        _patch_session(handler, {
+            f"get:{_DOCKER_PREFIX}/containers/my_container/json": _mock_response(
+                status=404,
+            ),
+            f"get:{_DOCKER_PREFIX}/containers/my_container/logs": _mock_response(
+                text_data="logs",
+            ),
+        })
+
+        context = await handler.get_context(_make_event(entity_id="my_container"))
+
+        assert "container_inspect_error" in context
+        assert "container_logs" in context
+
+    async def test_handles_logs_error_gracefully(self) -> None:
+        handler = _started_handler()
+        inspect_data = {"State": {"Status": "running"}}
+        _patch_session(handler, {
+            f"get:{_DOCKER_PREFIX}/containers/my_container/json": _mock_response(
+                json_data=inspect_data,
+            ),
+            f"get:{_DOCKER_PREFIX}/containers/my_container/logs": _mock_response(
+                status=500,
+            ),
+        })
+
+        context = await handler.get_context(_make_event(entity_id="my_container"))
+
+        assert "container_inspect" in context
+        assert "container_logs_error" in context
+
+
+# ---------------------------------------------------------------------------
+# Known fixes YAML
+# ---------------------------------------------------------------------------
+
+
+class TestKnownFixes:
+    def test_docker_yaml_has_expected_fixes(self) -> None:
+        from pathlib import Path
+
+        import yaml
+
+        fixes_path = (
+            Path(__file__).parent.parent.parent / "known_fixes" / "docker.yaml"
+        )
+        with fixes_path.open() as f:
+            data = yaml.safe_load(f)
+
+        fix_ids = {fix["id"] for fix in data["fixes"]}
+
+        expected_ids = {
+            "docker-oomkilled",
+            "docker-healthcheck-failure",
+            "docker-exit-137",
+            "docker-crash-loop",
+            "docker-volume-mount-failed",
+            "docker-image-pull-failed",
+        }
+        assert expected_ids == fix_ids
+
+    def test_all_fixes_have_required_fields(self) -> None:
+        from pathlib import Path
+
+        import yaml
+
+        fixes_path = (
+            Path(__file__).parent.parent.parent / "known_fixes" / "docker.yaml"
+        )
+        with fixes_path.open() as f:
+            data = yaml.safe_load(f)
+
+        for fix in data["fixes"]:
+            assert "id" in fix, f"Fix missing 'id': {fix}"
+            assert "match" in fix, f"Fix {fix['id']} missing 'match'"
+            assert "diagnosis" in fix, f"Fix {fix['id']} missing 'diagnosis'"
+            assert "action" in fix, f"Fix {fix['id']} missing 'action'"
+            assert "risk_tier" in fix, f"Fix {fix['id']} missing 'risk_tier'"


### PR DESCRIPTION
## Summary
- **New handler**: `PortainerHandler` — manages Docker containers via the Portainer REST API, separate from the existing raw `DockerHandler`
- **Environment routing**: All requests go through `/api/endpoints/{endpoint_id}/docker/...`, Portainer's environment-scoped Docker proxy
- **Auth**: API key via `X-API-Key` header, `api_key` registered as secret field in type registry
- **8 operations**: `notify`, `restart_container`, `stop_container`, `start_container`, `get_container_logs`, `get_container_stats`, `inspect_container`, `list_containers`
- **Verification**: `restart_container`/`start_container` poll for "running", `stop_container` polls for "exited"/"stopped"
- **Config model**: `PortainerHandlerConfig` with `url`, `api_key`, `endpoint_id`, `verify_ssl`, verify timeout/interval
- **Known fixes**: Added `docker-volume-mount-failed` and `docker-image-pull-failed` to `known_fixes/docker.yaml` (now 6 total)
- **Orchestrator wiring**: Creates `PortainerHandler` when `cfg.handlers.portainer.enabled`

## Test plan
- [x] 42 new tests covering lifecycle, API key auth, endpoint routing, all 8 operations, missing params, HTTP errors, verification polling, get_context, known fixes YAML validation
- [x] Full test suite passes (999 tests, 0 failures)
- [x] Ruff lint clean
- [ ] Manual verification against real Portainer instance (deferred to integration testing)

🤖 Generated with [Claude Code](https://claude.com/claude-code)