### PR TITLE
Create /data directory with correct ownership in Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -19,7 +19,8 @@ LABEL org.opencontainers.image.description="Autonomous infrastructure operations
 LABEL org.opencontainers.image.licenses="MIT"
 
 RUN groupadd --gid 1000 oasis && \
-    useradd --uid 1000 --gid oasis --create-home oasis
+    useradd --uid 1000 --gid oasis --create-home oasis && \
+    mkdir -p /data && chown oasis:oasis /data
 
 COPY --from=builder /install /usr/local
 COPY --from=builder /build/known_fixes /app/known_fixes


### PR DESCRIPTION
## Summary

- Adds `mkdir -p /data && chown oasis:oasis /data` to the Dockerfile runtime stage
- Without this, the container crashes on startup when the oasis user (uid 1000) tries to write the SQLite DB or auto-generated secret key to `/data`
- Required for v0.3.1 web UI which persists state to `OASIS_DATA_DIR` (default `/data`)

## Test plan

- [ ] Build image locally: `docker build -t oasisagent:test .`
- [ ] Run with volume: `docker run -v /tmp/oasis-test:/data oasisagent:test`
- [ ] Verify `/data/oasisagent.db` is created and owned by uid 1000
- [ ] Verify setup wizard loads at `http://localhost:8080/`

🤖 Generated with [Claude Code](https://claude.com/claude-code)