### PR TITLE
Add Pillow dependency for QR code generation

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -41,7 +41,7 @@ dependencies = [
     "sse-starlette>=2.0",
     "pyjwt>=2.8",
     "pyotp>=2.9",
-    "qrcode>=7.4",
+    "qrcode[pil]>=7.4",
     "python-multipart>=0.0.9",
     "argon2-cffi>=23.1",
 ]


### PR DESCRIPTION
## Summary

- Changes `qrcode>=7.4` to `qrcode[pil]>=7.4` in pyproject.toml
- Fixes `ModuleNotFoundError: No module named 'PIL'` when the setup wizard generates TOTP QR codes
- Found during deployment testing of v0.3.1 beta

## Test plan

- [ ] Deploy `:beta` image, complete setup wizard — QR code renders on TOTP enrollment page

🤖 Generated with [Claude Code](https://claude.com/claude-code)