### PR TITLE
Fix PyJWT sub validation on pending tokens

### DIFF
--- a/oasisagent/ui/routes/auth_routes.py
+++ b/oasisagent/ui/routes/auth_routes.py
@@ -208,7 +208,7 @@ async def login_2fa(
 
     # Validate pending token
     try:
-        payload = pyjwt.decode(pending_token, signing_key, algorithms=[_JWT_ALGORITHM])
+        payload = pyjwt.decode(pending_token, signing_key, algorithms=[_JWT_ALGORITHM], options={"verify_sub": False})
         if payload.get("purpose") != "2fa_pending":
             raise ValueError("Wrong token purpose")
     except Exception:
@@ -302,7 +302,7 @@ async def login_totp_enroll_confirm(
         )
 
     try:
-        payload = pyjwt.decode(pending_token, signing_key, algorithms=[_JWT_ALGORITHM])
+        payload = pyjwt.decode(pending_token, signing_key, algorithms=[_JWT_ALGORITHM], options={"verify_sub": False})
         if payload.get("purpose") != "totp_enroll":
             raise ValueError("Wrong token purpose")
         user = await store.get_user_by_id(payload["sub"])
@@ -353,7 +353,7 @@ async def logout(request: Request) -> RedirectResponse:
     token = request.cookies.get(_COOKIE_NAME)
     if token:
         try:
-            payload = pyjwt.decode(token, signing_key, algorithms=[_JWT_ALGORITHM])
+            payload = pyjwt.decode(token, signing_key, algorithms=[_JWT_ALGORITHM], options={"verify_sub": False})
             user = await store.get_user_by_id(payload["sub"])
             if user:
                 await store.update_user(

--- a/oasisagent/ui/routes/setup_routes.py
+++ b/oasisagent/ui/routes/setup_routes.py
@@ -167,7 +167,7 @@ async def setup_totp_confirm(
     user_id = None
     if pending_token:
         try:
-            payload = pyjwt.decode(pending_token, signing_key, algorithms=[_JWT_ALGORITHM])
+            payload = pyjwt.decode(pending_token, signing_key, algorithms=[_JWT_ALGORITHM], options={"verify_sub": False})
             user_id = payload["sub"]
         except Exception:
             pass


### PR DESCRIPTION
## Summary

- Adds `options={"verify_sub": False}` to all 4 `pyjwt.decode()` calls in `setup_routes.py` and `auth_routes.py`
- Fixes the setup wizard TOTP enrollment silently failing — the pending token decode rejected `sub` as integer (PyJWT 2.10+ requires string), the `except Exception: pass` swallowed it, and the user got redirected to login without TOTP being saved
- Same fix was applied to `decode_token()` in PR #84 (S1) but missed in the route-level pending token handling
- Found during live deployment testing

## Test plan

- [ ] Deploy `:beta`, delete existing DB, run setup wizard end-to-end
- [ ] Verify TOTP QR code → enter code → backup codes page → login works
- [ ] Verify login with TOTP verification works

🤖 Generated with [Claude Code](https://claude.com/claude-code)