### PR TITLE
Fix wizard template ignoring step variable from route

### DIFF
--- a/oasisagent/ui/templates/setup/wizard.html
+++ b/oasisagent/ui/templates/setup/wizard.html
@@ -1,7 +1,7 @@
 {% extends "base_minimal.html" %}
 {% block title %}Setup Wizard — OasisAgent{% endblock %}
 {% block content %}
-<div class="bg-white rounded-lg shadow-md p-8 max-w-lg mx-auto" x-data="{ step: 1 }">
+<div class="bg-white rounded-lg shadow-md p-8 max-w-lg mx-auto" x-data="{ step: {{ step | default(1) }} }">
     <div class="text-center mb-6">
         <h1 class="text-2xl font-bold text-gray-900">Welcome to OasisAgent</h1>
         <p class="text-sm text-gray-500 mt-1">Let's get your agent configured</p>


### PR DESCRIPTION
## Summary

- Changes `x-data="{ step: 1 }"` to `x-data="{ step: {{ step | default(1) }} }"` in `wizard.html`
- Alpine.js was always starting at step 1, ignoring the `step: 3` passed by `setup_core_services_page()`
- After TOTP enrollment + backup codes, the "I have copied" link goes to `/ui/setup/core-services` which rendered the admin creation form instead of the core services form

## Test plan

- [ ] Complete setup wizard: admin → TOTP → backup codes → should show MQTT/InfluxDB form (step 3)
- [ ] Verify step 1 still renders on initial `/ui/setup` visit

🤖 Generated with [Claude Code](https://claude.com/claude-code)