### PR TITLE
Fix logout redirect and unauthenticated UI page handling

### DIFF
--- a/oasisagent/ui/templates/base.html
+++ b/oasisagent/ui/templates/base.html
@@ -61,7 +61,7 @@
                 <span>{{ current_user.username }}</span>
                 <span class="px-1.5 py-0.5 rounded bg-gray-700 text-gray-400">{{ current_user.role }}</span>
             </div>
-            <form hx-post="/ui/logout" hx-swap="none" class="mt-2">
+            <form method="post" action="/ui/logout" class="mt-2">
                 <button type="submit" class="text-gray-500 hover:text-gray-300 text-xs">Sign out</button>
             </form>
         </div>

--- a/oasisagent/web/middleware.py
+++ b/oasisagent/web/middleware.py
@@ -48,6 +48,9 @@ async def setup_guard_middleware(
     - API setup endpoints are allowed through
     - Health/metrics are allowed through
     - All other paths redirect to setup (UI) or return 403 (API)
+
+    Post-setup: redirects unauthenticated UI requests to the login page
+    instead of returning raw JSON 401 errors.
     """
     # Check if the config store is available (not during tests with mocked state)
     store = getattr(request.app.state, "config_store", None)
@@ -76,7 +79,17 @@ async def setup_guard_middleware(
             },
         )
 
-    return await call_next(request)
+    response = await call_next(request)
+
+    # Redirect unauthenticated UI requests to login instead of showing JSON 401
+    if (
+        response.status_code == 401
+        and path.startswith("/ui/")
+        and "hx-request" not in request.headers
+    ):
+        return RedirectResponse(url="/ui/login", status_code=303)
+
+    return response
 
 
 async def sliding_window_middleware(


### PR DESCRIPTION
## Summary

- **Logout button didn't redirect**: `hx-post="/ui/logout"` with `hx-swap="none"` swallowed the 303 redirect — page title changed but content stayed on dashboard. Changed to plain `<form method="post" action="/ui/logout">` so the browser follows the redirect naturally.
- **Unauthenticated UI pages showed raw JSON**: Hitting `/ui/dashboard` without auth returned `{"detail":"Not authenticated"}` instead of redirecting to login. Added middleware logic to catch 401 responses on `/ui/` paths and redirect to `/ui/login` (HTMX requests excluded so they get the status code directly).

Both bugs found during local UAT of the full onboarding flow.

## Test plan

- [x] 1084 tests passing locally
- [x] UAT: Logout redirects to login page
- [x] UAT: Unauthenticated `/ui/dashboard` redirects to `/ui/login`
- [x] UAT: API endpoints still return JSON 401 (not redirect)
- [x] UAT: Full setup wizard → TOTP → backup codes → core services → login → dashboard flow works end-to-end

🤖 Generated with [Claude Code](https://claude.com/claude-code)