### PR TITLE
Add UniFi handler + address PR #92 review feedback (#61)

### DIFF
--- a/oasisagent/config.py
+++ b/oasisagent/config.py
@@ -388,6 +388,8 @@ class UnifiAdapterConfig(BaseModel):
     poll_alarms: bool = True
     poll_health: bool = True
     timeout: int = 10
+    cpu_threshold: float = 90.0
+    memory_threshold: float = 90.0
 
 
 # -- Ingestion (top-level) --------------------------------------------------
@@ -520,6 +522,27 @@ class PortainerHandlerConfig(BaseModel):
     verify_poll_interval: Annotated[float, Field(gt=0.0)] = 2.0
 
 
+class UnifiHandlerConfig(BaseModel):
+    """UniFi Network handler configuration.
+
+    Executes actions against the UniFi controller: restart devices,
+    block/unblock clients, gather device context.
+    """
+
+    model_config = ConfigDict(extra="forbid")
+
+    enabled: bool = False
+    url: str = "https://192.168.1.1"
+    username: str = ""
+    password: str = ""
+    site: str = "default"
+    verify_ssl: bool = False
+    is_udm: bool = True
+    timeout: int = 10
+    verify_timeout: Annotated[int, Field(ge=1)] = 30
+    verify_poll_interval: Annotated[float, Field(gt=0.0)] = 2.0
+
+
 class HandlersConfig(BaseModel):
     """All handler configurations."""
 
@@ -529,6 +552,7 @@ class HandlersConfig(BaseModel):
     docker: DockerHandlerConfig = Field(default_factory=DockerHandlerConfig)
     portainer: PortainerHandlerConfig = Field(default_factory=PortainerHandlerConfig)
     proxmox: ProxmoxHandlerConfig = Field(default_factory=ProxmoxHandlerConfig)
+    unifi: UnifiHandlerConfig = Field(default_factory=UnifiHandlerConfig)
 
 
 # -- Guardrails -------------------------------------------------------------

--- a/oasisagent/db/registry.py
+++ b/oasisagent/db/registry.py
@@ -35,6 +35,7 @@ from oasisagent.config import (
     ProxmoxHandlerConfig,
     TelegramNotificationConfig,
     UnifiAdapterConfig,
+    UnifiHandlerConfig,
     WebhookNotificationConfig,
     WebhookSourceConfig,
 )
@@ -110,6 +111,10 @@ CORE_SERVICE_TYPES: dict[str, TypeMeta] = {
     "proxmox_handler": TypeMeta(
         model=ProxmoxHandlerConfig,
         secret_fields=frozenset({"token_value"}),
+    ),
+    "unifi_handler": TypeMeta(
+        model=UnifiHandlerConfig,
+        secret_fields=frozenset({"password"}),
     ),
     "influxdb": TypeMeta(
         model=InfluxDbConfig,

--- a/oasisagent/handlers/__init__.py
+++ b/oasisagent/handlers/__init__.py
@@ -5,6 +5,7 @@ from oasisagent.handlers.docker import DockerHandler
 from oasisagent.handlers.homeassistant import HomeAssistantHandler
 from oasisagent.handlers.portainer import PortainerHandler
 from oasisagent.handlers.proxmox import ProxmoxHandler
+from oasisagent.handlers.unifi import UnifiHandler
 
 __all__ = [
     "DockerHandler",
@@ -12,4 +13,5 @@ __all__ = [
     "HomeAssistantHandler",
     "PortainerHandler",
     "ProxmoxHandler",
+    "UnifiHandler",
 ]

--- a/oasisagent/handlers/unifi.py
+++ b/oasisagent/handlers/unifi.py
@@ -1,0 +1,298 @@
+"""UniFi Network handler — executes actions via the UniFi controller API.
+
+Operations: notify, restart_device, block_client, unblock_client.
+
+Uses the shared UnifiClient for session cookie auth and automatic
+re-auth on 401.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import logging
+import time
+from typing import TYPE_CHECKING, Any
+
+import aiohttp
+
+from oasisagent.clients.unifi import UnifiClient
+from oasisagent.handlers.base import Handler
+from oasisagent.models import ActionResult, ActionStatus, VerifyResult
+
+if TYPE_CHECKING:
+    from oasisagent.config import UnifiHandlerConfig
+    from oasisagent.models import Event, RecommendedAction
+
+logger = logging.getLogger(__name__)
+
+_KNOWN_OPERATIONS: frozenset[str] = frozenset({
+    "notify",
+    "restart_device",
+    "block_client",
+    "unblock_client",
+})
+
+
+class UnifiHandler(Handler):
+    """Executes actions against UniFi Network controller.
+
+    Must be started with ``await handler.start()`` before use.
+    The UnifiClient session is created in start() and closed in stop().
+    """
+
+    def __init__(self, config: UnifiHandlerConfig) -> None:
+        self._config = config
+        self._client: UnifiClient | None = None
+
+    def name(self) -> str:
+        return "unifi"
+
+    async def start(self) -> None:
+        """Create the UniFi client and authenticate."""
+        self._client = UnifiClient(
+            url=self._config.url,
+            username=self._config.username,
+            password=self._config.password,
+            site=self._config.site,
+            is_udm=self._config.is_udm,
+            verify_ssl=self._config.verify_ssl,
+            timeout=self._config.timeout,
+        )
+        await self._client.connect()
+        logger.info("UniFi handler started (url=%s)", self._config.url)
+
+    async def stop(self) -> None:
+        """Close the UniFi client session."""
+        if self._client is not None:
+            await self._client.close()
+            self._client = None
+            logger.info("UniFi handler stopped")
+
+    async def can_handle(
+        self, event: Event, action: RecommendedAction,
+    ) -> bool:
+        return (
+            action.handler == "unifi"
+            and action.operation in _KNOWN_OPERATIONS
+        )
+
+    async def execute(
+        self, event: Event, action: RecommendedAction,
+    ) -> ActionResult:
+        """Dispatch to the appropriate operation method."""
+        self._ensure_started()
+
+        dispatch = {
+            "notify": self._op_notify,
+            "restart_device": self._op_restart_device,
+            "block_client": self._op_block_client,
+            "unblock_client": self._op_unblock_client,
+        }
+
+        handler_fn = dispatch.get(action.operation)
+        if handler_fn is None:
+            return ActionResult(
+                status=ActionStatus.FAILURE,
+                error_message=f"Unknown operation: {action.operation}",
+            )
+
+        start = time.monotonic()
+        try:
+            result = await handler_fn(event, action)
+            elapsed = (time.monotonic() - start) * 1000
+            return result.model_copy(update={"duration_ms": elapsed})
+        except aiohttp.ClientError as exc:
+            elapsed = (time.monotonic() - start) * 1000
+            logger.error(
+                "UniFi handler HTTP error for %s: %s",
+                action.operation, exc,
+            )
+            return ActionResult(
+                status=ActionStatus.FAILURE,
+                error_message=f"HTTP error: {exc}",
+                duration_ms=elapsed,
+            )
+
+    async def verify(
+        self, event: Event, action: RecommendedAction, result: ActionResult,
+    ) -> VerifyResult:
+        """Verify an action had the desired effect.
+
+        Only restart_device has real verification (polls device state).
+        Other operations return verified=True immediately.
+        """
+        if action.operation != "restart_device":
+            return VerifyResult(
+                verified=True, message="No verification needed",
+            )
+
+        self._ensure_started()
+        mac = action.params.get("mac", event.entity_id)
+        return await self._verify_device_recovery(mac)
+
+    async def get_context(self, event: Event) -> dict[str, Any]:
+        """Gather UniFi-specific context for diagnosis."""
+        self._ensure_started()
+        assert self._client is not None
+        context: dict[str, Any] = {}
+
+        try:
+            data = await self._client.get("stat/device")
+            devices = data.get("data", [])
+            for device in devices:
+                if device.get("mac") == event.entity_id:
+                    context["device"] = {
+                        "name": device.get("name", ""),
+                        "type": device.get("type", ""),
+                        "model": device.get("model", ""),
+                        "version": device.get("version", ""),
+                        "state": device.get("state"),
+                        "uptime": device.get("uptime"),
+                        "system_stats": device.get("system-stats", {}),
+                    }
+                    break
+        except aiohttp.ClientError as exc:
+            context["device_error"] = str(exc)
+
+        try:
+            data = await self._client.get("stat/health")
+            subsystems = data.get("data", [])
+            context["health"] = {
+                sub.get("subsystem", ""): sub.get("status", "unknown")
+                for sub in subsystems
+                if sub.get("subsystem")
+            }
+        except aiohttp.ClientError as exc:
+            context["health_error"] = str(exc)
+
+        return context
+
+    # -------------------------------------------------------------------
+    # Operation implementations
+    # -------------------------------------------------------------------
+
+    async def _op_notify(
+        self, event: Event, action: RecommendedAction,
+    ) -> ActionResult:
+        """Notify — no system changes. Returns the diagnosis message."""
+        message = action.params.get("message", action.description)
+        logger.info(
+            "UniFi notify: %s (entity=%s)", message, event.entity_id,
+        )
+        return ActionResult(
+            status=ActionStatus.SUCCESS,
+            details={"message": message, "entity_id": event.entity_id},
+        )
+
+    async def _op_restart_device(
+        self, event: Event, action: RecommendedAction,
+    ) -> ActionResult:
+        """Restart a UniFi device via cmd/devmgr."""
+        assert self._client is not None
+        mac = action.params.get("mac", event.entity_id)
+        if not mac:
+            return ActionResult(
+                status=ActionStatus.FAILURE,
+                error_message="restart_device requires 'mac' in params or event.entity_id",
+            )
+
+        await self._client.post(
+            "cmd/devmgr",
+            {"cmd": "restart", "mac": mac},
+        )
+
+        logger.info("UniFi restart_device: mac=%s", mac)
+        return ActionResult(
+            status=ActionStatus.SUCCESS,
+            details={"mac": mac, "operation": "restart_device"},
+        )
+
+    async def _op_block_client(
+        self, event: Event, action: RecommendedAction,
+    ) -> ActionResult:
+        """Block a client via cmd/stamgr."""
+        assert self._client is not None
+        mac = action.params.get("mac")
+        if not mac:
+            return ActionResult(
+                status=ActionStatus.FAILURE,
+                error_message="block_client requires 'mac' in params",
+            )
+
+        await self._client.post(
+            "cmd/stamgr",
+            {"cmd": "block-sta", "mac": mac},
+        )
+
+        logger.info("UniFi block_client: mac=%s", mac)
+        return ActionResult(
+            status=ActionStatus.SUCCESS,
+            details={"mac": mac, "operation": "block_client"},
+        )
+
+    async def _op_unblock_client(
+        self, event: Event, action: RecommendedAction,
+    ) -> ActionResult:
+        """Unblock a client via cmd/stamgr."""
+        assert self._client is not None
+        mac = action.params.get("mac")
+        if not mac:
+            return ActionResult(
+                status=ActionStatus.FAILURE,
+                error_message="unblock_client requires 'mac' in params",
+            )
+
+        await self._client.post(
+            "cmd/stamgr",
+            {"cmd": "unblock-sta", "mac": mac},
+        )
+
+        logger.info("UniFi unblock_client: mac=%s", mac)
+        return ActionResult(
+            status=ActionStatus.SUCCESS,
+            details={"mac": mac, "operation": "unblock_client"},
+        )
+
+    # -------------------------------------------------------------------
+    # Internal helpers
+    # -------------------------------------------------------------------
+
+    def _ensure_started(self) -> None:
+        """Raise if the handler hasn't been started."""
+        if self._client is None:
+            msg = "UnifiHandler.start() must be called before use"
+            raise RuntimeError(msg)
+
+    async def _verify_device_recovery(self, mac: str) -> VerifyResult:
+        """Poll device state to check if it recovers after restart."""
+        assert self._client is not None
+        timeout = self._config.verify_timeout
+        interval = self._config.verify_poll_interval
+        deadline = time.monotonic() + timeout
+
+        while time.monotonic() < deadline:
+            try:
+                data = await self._client.get("stat/device")
+                devices = data.get("data", [])
+                for device in devices:
+                    if device.get("mac") == mac:
+                        state = device.get("state", 0)
+                        if state == 1:
+                            name = device.get("name", mac)
+                            return VerifyResult(
+                                verified=True,
+                                message=f"Device {name} ({mac}) recovered (state=1)",
+                            )
+                        break
+            except aiohttp.ClientError:
+                pass  # Keep polling
+
+            await asyncio.sleep(interval)
+
+        return VerifyResult(
+            verified=False,
+            message=(
+                f"Device {mac} did not recover within "
+                f"{timeout}s (still not state=1)"
+            ),
+        )

--- a/oasisagent/ingestion/unifi.py
+++ b/oasisagent/ingestion/unifi.py
@@ -26,9 +26,6 @@ if TYPE_CHECKING:
 
 logger = logging.getLogger(__name__)
 
-# Thresholds for resource alerts
-_CPU_THRESHOLD = 90.0
-_MEMORY_THRESHOLD = 90.0
 
 
 class UnifiAdapter(IngestAdapter):
@@ -201,12 +198,12 @@ class UnifiAdapter(IngestAdapter):
             sys_stats = device.get("system-stats", {})
             self._check_resource(
                 mac, device_name, "cpu",
-                sys_stats.get("cpu"), _CPU_THRESHOLD,
+                sys_stats.get("cpu"), self._config.cpu_threshold,
                 self._device_cpu_alert,
             )
             self._check_resource(
                 mac, device_name, "mem",
-                sys_stats.get("mem"), _MEMORY_THRESHOLD,
+                sys_stats.get("mem"), self._config.memory_threshold,
                 self._device_mem_alert,
             )
 
@@ -302,6 +299,10 @@ class UnifiAdapter(IngestAdapter):
                     dedup_key=f"unifi:alarm:{alarm_id}",
                 ),
             ))
+
+        # Evict cleared/archived alarms to prevent unbounded growth
+        current_ids = {a.get("_id", "") for a in alarms} - {""}
+        self._seen_alarms &= current_ids
 
     # -----------------------------------------------------------------
     # Health polling

--- a/tests/test_handlers/test_unifi.py
+++ b/tests/test_handlers/test_unifi.py
@@ -1,0 +1,521 @@
+"""Tests for the UniFi Network handler."""
+
+from __future__ import annotations
+
+from datetime import UTC, datetime
+from typing import Any
+from unittest.mock import AsyncMock, patch
+
+import aiohttp
+import pytest
+
+from oasisagent.config import UnifiHandlerConfig
+from oasisagent.handlers.unifi import UnifiHandler
+from oasisagent.models import (
+    ActionResult,
+    ActionStatus,
+    Event,
+    EventMetadata,
+    RecommendedAction,
+    RiskTier,
+    Severity,
+)
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _make_config(**overrides: Any) -> UnifiHandlerConfig:
+    defaults: dict[str, Any] = {
+        "enabled": True,
+        "url": "https://192.168.1.1",
+        "username": "admin",
+        "password": "secret",
+        "site": "default",
+        "is_udm": True,
+        "verify_ssl": False,
+        "timeout": 10,
+        "verify_timeout": 5,
+        "verify_poll_interval": 0.1,
+    }
+    defaults.update(overrides)
+    return UnifiHandlerConfig(**defaults)
+
+
+def _make_event(**overrides: Any) -> Event:
+    defaults: dict[str, Any] = {
+        "source": "unifi",
+        "system": "unifi",
+        "event_type": "device_disconnected",
+        "entity_id": "aa:bb:cc:dd:ee:ff",
+        "severity": Severity.ERROR,
+        "timestamp": datetime.now(UTC),
+        "payload": {},
+        "metadata": EventMetadata(),
+    }
+    defaults.update(overrides)
+    return Event(**defaults)
+
+
+def _make_action(**overrides: Any) -> RecommendedAction:
+    defaults: dict[str, Any] = {
+        "description": "Test action",
+        "handler": "unifi",
+        "operation": "notify",
+        "params": {},
+        "risk_tier": RiskTier.RECOMMEND,
+    }
+    defaults.update(overrides)
+    return RecommendedAction(**defaults)
+
+
+def _make_handler(**overrides: Any) -> UnifiHandler:
+    """Create a handler with a mocked UnifiClient."""
+    config = _make_config(**overrides)
+    handler = UnifiHandler(config)
+    # Mock the client so we don't need real connections
+    mock_client = AsyncMock()
+    handler._client = mock_client
+    return handler
+
+
+# ---------------------------------------------------------------------------
+# Identity & lifecycle
+# ---------------------------------------------------------------------------
+
+
+class TestLifecycle:
+    def test_name(self) -> None:
+        handler = UnifiHandler(_make_config())
+        assert handler.name() == "unifi"
+
+    @pytest.mark.asyncio
+    async def test_start_creates_client(self) -> None:
+        with patch("oasisagent.handlers.unifi.UnifiClient") as mock_cls:
+            mock_client = AsyncMock()
+            mock_cls.return_value = mock_client
+
+            handler = UnifiHandler(_make_config())
+            await handler.start()
+
+            mock_client.connect.assert_called_once()
+            assert handler._client is mock_client
+
+    @pytest.mark.asyncio
+    async def test_stop_closes_client(self) -> None:
+        handler = _make_handler()
+        mock_client = handler._client
+        await handler.stop()
+
+        mock_client.close.assert_called_once()
+        assert handler._client is None
+
+    @pytest.mark.asyncio
+    async def test_stop_when_not_started(self) -> None:
+        handler = UnifiHandler(_make_config())
+        await handler.stop()  # should not raise
+
+    @pytest.mark.asyncio
+    async def test_ensure_started_raises(self) -> None:
+        handler = UnifiHandler(_make_config())
+        with pytest.raises(RuntimeError, match="start\\(\\) must be called"):
+            await handler.execute(_make_event(), _make_action())
+
+
+# ---------------------------------------------------------------------------
+# can_handle
+# ---------------------------------------------------------------------------
+
+
+class TestCanHandle:
+    @pytest.mark.asyncio
+    async def test_known_operations(self) -> None:
+        handler = _make_handler()
+        for op in ("notify", "restart_device", "block_client", "unblock_client"):
+            action = _make_action(operation=op)
+            assert await handler.can_handle(_make_event(), action)
+
+    @pytest.mark.asyncio
+    async def test_unknown_operation(self) -> None:
+        handler = _make_handler()
+        action = _make_action(operation="delete_everything")
+        assert not await handler.can_handle(_make_event(), action)
+
+    @pytest.mark.asyncio
+    async def test_wrong_handler(self) -> None:
+        handler = _make_handler()
+        action = _make_action(handler="docker")
+        assert not await handler.can_handle(_make_event(), action)
+
+
+# ---------------------------------------------------------------------------
+# notify operation
+# ---------------------------------------------------------------------------
+
+
+class TestNotifyOp:
+    @pytest.mark.asyncio
+    async def test_notify_success(self) -> None:
+        handler = _make_handler()
+        event = _make_event()
+        action = _make_action(
+            operation="notify",
+            params={"message": "Device is offline"},
+        )
+
+        result = await handler.execute(event, action)
+
+        assert result.status == ActionStatus.SUCCESS
+        assert result.details["message"] == "Device is offline"
+        assert result.details["entity_id"] == "aa:bb:cc:dd:ee:ff"
+        assert result.duration_ms is not None
+
+    @pytest.mark.asyncio
+    async def test_notify_uses_description_as_fallback(self) -> None:
+        handler = _make_handler()
+        action = _make_action(
+            operation="notify",
+            description="AP disconnected",
+            params={},
+        )
+
+        result = await handler.execute(_make_event(), action)
+
+        assert result.details["message"] == "AP disconnected"
+
+
+# ---------------------------------------------------------------------------
+# restart_device operation
+# ---------------------------------------------------------------------------
+
+
+class TestRestartDeviceOp:
+    @pytest.mark.asyncio
+    async def test_restart_device_success(self) -> None:
+        handler = _make_handler()
+        handler._client.post = AsyncMock(return_value={"meta": {"rc": "ok"}})
+
+        action = _make_action(
+            operation="restart_device",
+            params={"mac": "aa:bb:cc:dd:ee:ff"},
+        )
+
+        result = await handler.execute(_make_event(), action)
+
+        assert result.status == ActionStatus.SUCCESS
+        assert result.details["mac"] == "aa:bb:cc:dd:ee:ff"
+        handler._client.post.assert_called_once_with(
+            "cmd/devmgr",
+            {"cmd": "restart", "mac": "aa:bb:cc:dd:ee:ff"},
+        )
+
+    @pytest.mark.asyncio
+    async def test_restart_device_uses_entity_id_fallback(self) -> None:
+        handler = _make_handler()
+        handler._client.post = AsyncMock(return_value={"meta": {"rc": "ok"}})
+
+        event = _make_event(entity_id="11:22:33:44:55:66")
+        action = _make_action(operation="restart_device", params={})
+
+        result = await handler.execute(event, action)
+
+        assert result.status == ActionStatus.SUCCESS
+        assert result.details["mac"] == "11:22:33:44:55:66"
+
+    @pytest.mark.asyncio
+    async def test_restart_device_no_mac_fails(self) -> None:
+        handler = _make_handler()
+        event = _make_event(entity_id="")
+        action = _make_action(operation="restart_device", params={})
+
+        result = await handler.execute(event, action)
+
+        assert result.status == ActionStatus.FAILURE
+        assert "mac" in result.error_message
+
+    @pytest.mark.asyncio
+    async def test_restart_device_http_error(self) -> None:
+        handler = _make_handler()
+        handler._client.post = AsyncMock(
+            side_effect=aiohttp.ClientError("connection refused"),
+        )
+
+        action = _make_action(
+            operation="restart_device",
+            params={"mac": "aa:bb:cc"},
+        )
+
+        result = await handler.execute(_make_event(), action)
+
+        assert result.status == ActionStatus.FAILURE
+        assert "HTTP error" in result.error_message
+        assert result.duration_ms is not None
+
+
+# ---------------------------------------------------------------------------
+# block_client / unblock_client operations
+# ---------------------------------------------------------------------------
+
+
+class TestBlockClientOps:
+    @pytest.mark.asyncio
+    async def test_block_client_success(self) -> None:
+        handler = _make_handler()
+        handler._client.post = AsyncMock(return_value={"meta": {"rc": "ok"}})
+
+        action = _make_action(
+            operation="block_client",
+            params={"mac": "dd:ee:ff:00:11:22"},
+        )
+
+        result = await handler.execute(_make_event(), action)
+
+        assert result.status == ActionStatus.SUCCESS
+        handler._client.post.assert_called_once_with(
+            "cmd/stamgr",
+            {"cmd": "block-sta", "mac": "dd:ee:ff:00:11:22"},
+        )
+
+    @pytest.mark.asyncio
+    async def test_block_client_no_mac_fails(self) -> None:
+        handler = _make_handler()
+        action = _make_action(operation="block_client", params={})
+
+        result = await handler.execute(_make_event(), action)
+
+        assert result.status == ActionStatus.FAILURE
+        assert "mac" in result.error_message
+
+    @pytest.mark.asyncio
+    async def test_unblock_client_success(self) -> None:
+        handler = _make_handler()
+        handler._client.post = AsyncMock(return_value={"meta": {"rc": "ok"}})
+
+        action = _make_action(
+            operation="unblock_client",
+            params={"mac": "dd:ee:ff:00:11:22"},
+        )
+
+        result = await handler.execute(_make_event(), action)
+
+        assert result.status == ActionStatus.SUCCESS
+        handler._client.post.assert_called_once_with(
+            "cmd/stamgr",
+            {"cmd": "unblock-sta", "mac": "dd:ee:ff:00:11:22"},
+        )
+
+    @pytest.mark.asyncio
+    async def test_unblock_client_no_mac_fails(self) -> None:
+        handler = _make_handler()
+        action = _make_action(operation="unblock_client", params={})
+
+        result = await handler.execute(_make_event(), action)
+
+        assert result.status == ActionStatus.FAILURE
+
+
+# ---------------------------------------------------------------------------
+# Unknown operation
+# ---------------------------------------------------------------------------
+
+
+class TestUnknownOp:
+    @pytest.mark.asyncio
+    async def test_unknown_operation_returns_failure(self) -> None:
+        handler = _make_handler()
+        action = _make_action(operation="delete_site")
+
+        result = await handler.execute(_make_event(), action)
+
+        assert result.status == ActionStatus.FAILURE
+        assert "Unknown operation" in result.error_message
+
+
+# ---------------------------------------------------------------------------
+# verify
+# ---------------------------------------------------------------------------
+
+
+class TestVerify:
+    @pytest.mark.asyncio
+    async def test_verify_non_restart_returns_true(self) -> None:
+        handler = _make_handler()
+        action = _make_action(operation="notify")
+        result = ActionResult(status=ActionStatus.SUCCESS)
+
+        verify = await handler.verify(_make_event(), action, result)
+
+        assert verify.verified is True
+
+    @pytest.mark.asyncio
+    async def test_verify_restart_device_recovered(self) -> None:
+        handler = _make_handler()
+        handler._client.get = AsyncMock(return_value={
+            "data": [{"mac": "aa:bb:cc:dd:ee:ff", "state": 1, "name": "AP-1"}],
+        })
+
+        action = _make_action(
+            operation="restart_device",
+            params={"mac": "aa:bb:cc:dd:ee:ff"},
+        )
+        exec_result = ActionResult(status=ActionStatus.SUCCESS)
+
+        verify = await handler.verify(_make_event(), action, exec_result)
+
+        assert verify.verified is True
+        assert "recovered" in verify.message
+
+    @pytest.mark.asyncio
+    async def test_verify_restart_device_not_recovered(self) -> None:
+        handler = _make_handler(verify_timeout=1, verify_poll_interval=0.1)
+        handler._client.get = AsyncMock(return_value={
+            "data": [{"mac": "aa:bb:cc:dd:ee:ff", "state": 0}],
+        })
+
+        action = _make_action(
+            operation="restart_device",
+            params={"mac": "aa:bb:cc:dd:ee:ff"},
+        )
+        exec_result = ActionResult(status=ActionStatus.SUCCESS)
+
+        verify = await handler.verify(_make_event(), action, exec_result)
+
+        assert verify.verified is False
+        assert "did not recover" in verify.message
+
+    @pytest.mark.asyncio
+    async def test_verify_restart_survives_http_error(self) -> None:
+        """HTTP errors during verification should not crash, just keep polling."""
+        handler = _make_handler(verify_timeout=1, verify_poll_interval=0.1)
+        # First call errors, second returns recovered
+        handler._client.get = AsyncMock(side_effect=[
+            aiohttp.ClientError("timeout"),
+            {"data": [{"mac": "aa:bb:cc:dd:ee:ff", "state": 1, "name": "AP-1"}]},
+        ])
+
+        action = _make_action(
+            operation="restart_device",
+            params={"mac": "aa:bb:cc:dd:ee:ff"},
+        )
+        exec_result = ActionResult(status=ActionStatus.SUCCESS)
+
+        verify = await handler.verify(_make_event(), action, exec_result)
+
+        assert verify.verified is True
+
+
+# ---------------------------------------------------------------------------
+# get_context
+# ---------------------------------------------------------------------------
+
+
+class TestGetContext:
+    @pytest.mark.asyncio
+    async def test_get_context_device_found(self) -> None:
+        handler = _make_handler()
+        handler._client.get = AsyncMock(side_effect=[
+            # stat/device
+            {"data": [{
+                "mac": "aa:bb:cc:dd:ee:ff",
+                "name": "AP-Living-Room",
+                "type": "uap",
+                "model": "U6-Lite",
+                "version": "6.5.0",
+                "state": 1,
+                "uptime": 86400,
+                "system-stats": {"cpu": "15.0", "mem": "40.0"},
+            }]},
+            # stat/health
+            {"data": [
+                {"subsystem": "wlan", "status": "ok"},
+                {"subsystem": "wan", "status": "ok"},
+            ]},
+        ])
+
+        context = await handler.get_context(_make_event())
+
+        assert context["device"]["name"] == "AP-Living-Room"
+        assert context["device"]["model"] == "U6-Lite"
+        assert context["health"]["wlan"] == "ok"
+        assert context["health"]["wan"] == "ok"
+
+    @pytest.mark.asyncio
+    async def test_get_context_device_not_found(self) -> None:
+        handler = _make_handler()
+        handler._client.get = AsyncMock(side_effect=[
+            {"data": [{"mac": "other:mac", "name": "Other"}]},
+            {"data": []},
+        ])
+
+        context = await handler.get_context(_make_event())
+
+        assert "device" not in context
+        assert context["health"] == {}
+
+    @pytest.mark.asyncio
+    async def test_get_context_device_error(self) -> None:
+        handler = _make_handler()
+        handler._client.get = AsyncMock(side_effect=[
+            aiohttp.ClientError("connection refused"),
+            {"data": [{"subsystem": "wlan", "status": "ok"}]},
+        ])
+
+        context = await handler.get_context(_make_event())
+
+        assert "device_error" in context
+        assert context["health"]["wlan"] == "ok"
+
+    @pytest.mark.asyncio
+    async def test_get_context_health_error(self) -> None:
+        handler = _make_handler()
+        handler._client.get = AsyncMock(side_effect=[
+            {"data": [{"mac": "aa:bb:cc:dd:ee:ff", "name": "AP", "type": "uap",
+                       "model": "", "version": "", "state": 1, "uptime": 0,
+                       "system-stats": {}}]},
+            aiohttp.ClientError("timeout"),
+        ])
+
+        context = await handler.get_context(_make_event())
+
+        assert "device" in context
+        assert "health_error" in context
+
+
+# ---------------------------------------------------------------------------
+# Config & registry
+# ---------------------------------------------------------------------------
+
+
+class TestConfigAndRegistry:
+    def test_config_defaults(self) -> None:
+        config = UnifiHandlerConfig()
+        assert config.enabled is False
+        assert config.is_udm is True
+        assert config.verify_timeout == 30
+
+    def test_config_extra_forbidden(self) -> None:
+        from pydantic import ValidationError
+
+        with pytest.raises(ValidationError, match="Extra inputs"):
+            _make_config(bogus="nope")
+
+    def test_handlers_config_has_unifi(self) -> None:
+        from oasisagent.config import HandlersConfig
+
+        config = HandlersConfig()
+        assert hasattr(config, "unifi")
+        assert isinstance(config.unifi, UnifiHandlerConfig)
+
+    def test_registry_entry(self) -> None:
+        from oasisagent.db.registry import CORE_SERVICE_TYPES
+
+        assert "unifi_handler" in CORE_SERVICE_TYPES
+        meta = CORE_SERVICE_TYPES["unifi_handler"]
+        assert meta.model is UnifiHandlerConfig
+        assert "password" in meta.secret_fields
+
+    def test_handler_exported_from_init(self) -> None:
+        from oasisagent.handlers import UnifiHandler as Exported
+
+        assert Exported is UnifiHandler

--- a/tests/test_ingestion/test_unifi.py
+++ b/tests/test_ingestion/test_unifi.py
@@ -457,6 +457,107 @@ class TestAlarmPolling:
 
         queue.put_nowait.assert_not_called()
 
+    @pytest.mark.asyncio
+    async def test_cleared_alarms_evicted_from_tracker(self) -> None:
+        """Alarms no longer in the response are evicted from _seen_alarms."""
+        adapter, _queue = _make_adapter()
+        adapter._seen_alarms = {"old-alarm-1", "old-alarm-2"}
+
+        # Only old-alarm-1 still present in response
+        adapter._client.get = AsyncMock(return_value={
+            "data": [{"_id": "old-alarm-1", "key": "EVT_1", "msg": ""}],
+        })
+
+        await adapter._poll_alarms()
+
+        assert "old-alarm-1" in adapter._seen_alarms
+        assert "old-alarm-2" not in adapter._seen_alarms
+
+    @pytest.mark.asyncio
+    async def test_empty_response_clears_all_seen(self) -> None:
+        """Empty alarm response evicts all tracked alarms."""
+        adapter, _queue = _make_adapter()
+        adapter._seen_alarms = {"a1", "a2", "a3"}
+
+        adapter._client.get = AsyncMock(return_value={"data": []})
+
+        await adapter._poll_alarms()
+
+        assert len(adapter._seen_alarms) == 0
+
+
+# ---------------------------------------------------------------------------
+# Configurable thresholds
+# ---------------------------------------------------------------------------
+
+
+class TestConfigurableThresholds:
+    @pytest.mark.asyncio
+    async def test_custom_cpu_threshold(self) -> None:
+        """Custom CPU threshold triggers at configured value."""
+        adapter, queue = _make_adapter(cpu_threshold=80.0)
+        adapter._device_states["aa:bb:cc"] = 1
+
+        devices = [{
+            "mac": "aa:bb:cc",
+            "state": 1,
+            "name": "AP-1",
+            "type": "uap",
+            "adopted": True,
+            "system-stats": {"cpu": "85.0", "mem": "30.0"},
+        }]
+        adapter._client.get = AsyncMock(return_value={"data": devices})
+
+        await adapter._poll_devices()
+
+        queue.put_nowait.assert_called_once()
+        event = queue.put_nowait.call_args[0][0]
+        assert event.event_type == "device_high_cpu"
+        assert event.payload["threshold"] == 80.0
+
+    @pytest.mark.asyncio
+    async def test_custom_memory_threshold(self) -> None:
+        """Custom memory threshold triggers at configured value."""
+        adapter, queue = _make_adapter(memory_threshold=70.0)
+        adapter._device_states["aa:bb:cc"] = 1
+
+        devices = [{
+            "mac": "aa:bb:cc",
+            "state": 1,
+            "name": "AP-1",
+            "type": "uap",
+            "adopted": True,
+            "system-stats": {"cpu": "10.0", "mem": "75.0"},
+        }]
+        adapter._client.get = AsyncMock(return_value={"data": devices})
+
+        await adapter._poll_devices()
+
+        queue.put_nowait.assert_called_once()
+        event = queue.put_nowait.call_args[0][0]
+        assert event.event_type == "device_high_mem"
+        assert event.payload["threshold"] == 70.0
+
+    @pytest.mark.asyncio
+    async def test_default_threshold_85_no_alert(self) -> None:
+        """At default 90% threshold, 85% CPU should not alert."""
+        adapter, queue = _make_adapter()
+        adapter._device_states["aa:bb:cc"] = 1
+
+        devices = [{
+            "mac": "aa:bb:cc",
+            "state": 1,
+            "name": "AP-1",
+            "type": "uap",
+            "adopted": True,
+            "system-stats": {"cpu": "85.0", "mem": "30.0"},
+        }]
+        adapter._client.get = AsyncMock(return_value={"data": devices})
+
+        await adapter._poll_devices()
+
+        queue.put_nowait.assert_not_called()
+
 
 # ---------------------------------------------------------------------------
 # Health subsystem polling


### PR DESCRIPTION
## Summary
- **UniFi handler** (`oasisagent/handlers/unifi.py`): 4 operations — `notify`, `restart_device`, `block_client`, `unblock_client`. Uses shared `UnifiClient` for session cookie auth. Device recovery verification polls `stat/device` until state=1 or timeout. Context gathering fetches device info + health subsystem status.
- **PR #92 M1 fix**: `_seen_alarms` now evicts cleared/archived alarm IDs after each poll cycle (`self._seen_alarms &= current_ids`), preventing unbounded memory growth
- **PR #92 S1 fix**: CPU/memory thresholds moved from hardcoded constants to `UnifiAdapterConfig` fields (`cpu_threshold: float = 90.0`, `memory_threshold: float = 90.0`)
- **Config + registry**: `UnifiHandlerConfig` with verify_timeout/verify_poll_interval, registered as `unifi_handler` core service with `password` secret field, added to `HandlersConfig`
- **32 handler tests + 5 new adapter tests** = 37 new tests

PR B of the UniFi integration (Issue #61). Completes the UniFi integration alongside PR #92 (client + adapter).

## Test plan
- [x] 99 UniFi tests passing (22 client + 45 adapter + 32 handler)
- [x] Full suite: 1249 tests passing
- [x] Ruff lint clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)