### PR TITLE
Add Cloudflare handler (#62)

### DIFF
--- a/oasisagent/config.py
+++ b/oasisagent/config.py
@@ -567,6 +567,22 @@ class UnifiHandlerConfig(BaseModel):
     verify_poll_interval: Annotated[float, Field(gt=0.0)] = 2.0
 
 
+class CloudflareHandlerConfig(BaseModel):
+    """Cloudflare handler configuration.
+
+    Executes actions against the Cloudflare API: purge cache,
+    block/unblock IPs via firewall rules, gather zone context.
+    """
+
+    model_config = ConfigDict(extra="forbid")
+
+    enabled: bool = False
+    api_token: str = ""
+    zone_id: str = ""
+    account_id: str = ""
+    timeout: int = 30
+
+
 class HandlersConfig(BaseModel):
     """All handler configurations."""
 
@@ -577,6 +593,9 @@ class HandlersConfig(BaseModel):
     portainer: PortainerHandlerConfig = Field(default_factory=PortainerHandlerConfig)
     proxmox: ProxmoxHandlerConfig = Field(default_factory=ProxmoxHandlerConfig)
     unifi: UnifiHandlerConfig = Field(default_factory=UnifiHandlerConfig)
+    cloudflare: CloudflareHandlerConfig = Field(
+        default_factory=CloudflareHandlerConfig,
+    )
 
 
 # -- Guardrails -------------------------------------------------------------

--- a/oasisagent/db/registry.py
+++ b/oasisagent/db/registry.py
@@ -20,6 +20,7 @@ from pydantic import BaseModel  # noqa: TC002 — used at runtime in TypeMeta
 from oasisagent.config import (
     CircuitBreakerConfig,
     CloudflareAdapterConfig,
+    CloudflareHandlerConfig,
     DockerHandlerConfig,
     EmailNotificationConfig,
     GuardrailsConfig,
@@ -120,6 +121,10 @@ CORE_SERVICE_TYPES: dict[str, TypeMeta] = {
     "unifi_handler": TypeMeta(
         model=UnifiHandlerConfig,
         secret_fields=frozenset({"password"}),
+    ),
+    "cloudflare_handler": TypeMeta(
+        model=CloudflareHandlerConfig,
+        secret_fields=frozenset({"api_token"}),
     ),
     "influxdb": TypeMeta(
         model=InfluxDbConfig,

--- a/oasisagent/handlers/__init__.py
+++ b/oasisagent/handlers/__init__.py
@@ -1,6 +1,7 @@
 """System handlers — execute actions against managed infrastructure."""
 
 from oasisagent.handlers.base import Handler
+from oasisagent.handlers.cloudflare import CloudflareHandler
 from oasisagent.handlers.docker import DockerHandler
 from oasisagent.handlers.homeassistant import HomeAssistantHandler
 from oasisagent.handlers.portainer import PortainerHandler
@@ -8,6 +9,7 @@ from oasisagent.handlers.proxmox import ProxmoxHandler
 from oasisagent.handlers.unifi import UnifiHandler
 
 __all__ = [
+    "CloudflareHandler",
     "DockerHandler",
     "Handler",
     "HomeAssistantHandler",

--- a/oasisagent/handlers/cloudflare.py
+++ b/oasisagent/handlers/cloudflare.py
@@ -1,0 +1,346 @@
+"""Cloudflare handler — executes actions via the Cloudflare API v4.
+
+Operations: notify, purge_cache, purge_urls, block_ip, unblock_ip.
+
+Uses the shared CloudflareClient for bearer token auth.
+"""
+
+from __future__ import annotations
+
+import logging
+import time
+from typing import TYPE_CHECKING, Any
+
+import aiohttp
+
+from oasisagent.clients.cloudflare import CloudflareClient
+from oasisagent.handlers.base import Handler
+from oasisagent.models import ActionResult, ActionStatus, VerifyResult
+
+if TYPE_CHECKING:
+    from oasisagent.config import CloudflareHandlerConfig
+    from oasisagent.models import Event, RecommendedAction
+
+logger = logging.getLogger(__name__)
+
+_KNOWN_OPERATIONS: frozenset[str] = frozenset({
+    "notify",
+    "purge_cache",
+    "purge_urls",
+    "block_ip",
+    "unblock_ip",
+})
+
+
+class CloudflareHandler(Handler):
+    """Executes actions against the Cloudflare API v4.
+
+    Must be started with ``await handler.start()`` before use.
+    The CloudflareClient session is created in start() and closed in stop().
+    """
+
+    def __init__(self, config: CloudflareHandlerConfig) -> None:
+        self._config = config
+        self._client: CloudflareClient | None = None
+
+    def name(self) -> str:
+        return "cloudflare"
+
+    async def start(self) -> None:
+        """Create the Cloudflare client and open the HTTP session."""
+        self._client = CloudflareClient(
+            api_token=self._config.api_token,
+            timeout=self._config.timeout,
+        )
+        await self._client.start()
+        logger.info("Cloudflare handler started")
+
+    async def stop(self) -> None:
+        """Close the Cloudflare client session."""
+        if self._client is not None:
+            await self._client.close()
+            self._client = None
+            logger.info("Cloudflare handler stopped")
+
+    async def can_handle(
+        self, event: Event, action: RecommendedAction,
+    ) -> bool:
+        return (
+            action.handler == "cloudflare"
+            and action.operation in _KNOWN_OPERATIONS
+        )
+
+    async def execute(
+        self, event: Event, action: RecommendedAction,
+    ) -> ActionResult:
+        """Dispatch to the appropriate operation method."""
+        self._ensure_started()
+
+        dispatch = {
+            "notify": self._op_notify,
+            "purge_cache": self._op_purge_cache,
+            "purge_urls": self._op_purge_urls,
+            "block_ip": self._op_block_ip,
+            "unblock_ip": self._op_unblock_ip,
+        }
+
+        handler_fn = dispatch.get(action.operation)
+        if handler_fn is None:
+            return ActionResult(
+                status=ActionStatus.FAILURE,
+                error_message=f"Unknown operation: {action.operation}",
+            )
+
+        start = time.monotonic()
+        try:
+            result = await handler_fn(event, action)
+            elapsed = (time.monotonic() - start) * 1000
+            return result.model_copy(update={"duration_ms": elapsed})
+        except aiohttp.ClientError as exc:
+            elapsed = (time.monotonic() - start) * 1000
+            logger.error(
+                "Cloudflare handler HTTP error for %s: %s",
+                action.operation, exc,
+            )
+            return ActionResult(
+                status=ActionStatus.FAILURE,
+                error_message=f"HTTP error: {exc}",
+                duration_ms=elapsed,
+            )
+
+    async def verify(
+        self, event: Event, action: RecommendedAction, result: ActionResult,
+    ) -> VerifyResult:
+        """Verify an action had the desired effect.
+
+        Cloudflare operations are fire-and-forget — no polling verification.
+        purge_cache and purge_urls return verified=True on success.
+        block_ip verifies the rule exists in the firewall.
+        """
+        if action.operation == "block_ip" and result.status == ActionStatus.SUCCESS:
+            return await self._verify_block_ip(result)
+
+        return VerifyResult(
+            verified=True, message="No verification needed",
+        )
+
+    async def get_context(self, event: Event) -> dict[str, Any]:
+        """Gather Cloudflare-specific context for diagnosis."""
+        self._ensure_started()
+        assert self._client is not None
+        context: dict[str, Any] = {}
+
+        # Zone details
+        if self._config.zone_id:
+            try:
+                data = await self._client.get(
+                    f"/zones/{self._config.zone_id}",
+                )
+                zone = data.get("result", {})
+                context["zone"] = {
+                    "name": zone.get("name", ""),
+                    "status": zone.get("status", ""),
+                    "paused": zone.get("paused", False),
+                    "plan": zone.get("plan", {}).get("name", ""),
+                }
+            except aiohttp.ClientError as exc:
+                context["zone_error"] = str(exc)
+
+        # Tunnel status
+        if self._config.account_id:
+            try:
+                data = await self._client.get(
+                    f"/accounts/{self._config.account_id}/cfd_tunnel",
+                )
+                tunnels = data.get("result", [])
+                context["tunnels"] = [
+                    {
+                        "id": t.get("id", ""),
+                        "name": t.get("name", ""),
+                        "status": t.get("status", ""),
+                    }
+                    for t in tunnels
+                ]
+            except aiohttp.ClientError as exc:
+                context["tunnel_error"] = str(exc)
+
+        return context
+
+    # -------------------------------------------------------------------
+    # Operation implementations
+    # -------------------------------------------------------------------
+
+    async def _op_notify(
+        self, event: Event, action: RecommendedAction,
+    ) -> ActionResult:
+        """Notify — no system changes. Returns the diagnosis message."""
+        message = action.params.get("message", action.description)
+        logger.info(
+            "Cloudflare notify: %s (entity=%s)", message, event.entity_id,
+        )
+        return ActionResult(
+            status=ActionStatus.SUCCESS,
+            details={"message": message, "entity_id": event.entity_id},
+        )
+
+    async def _op_purge_cache(
+        self, event: Event, action: RecommendedAction,
+    ) -> ActionResult:
+        """Purge entire cache for the configured zone."""
+        assert self._client is not None
+        zone_id = action.params.get("zone_id", self._config.zone_id)
+        if not zone_id:
+            return ActionResult(
+                status=ActionStatus.FAILURE,
+                error_message="purge_cache requires 'zone_id' in params or config",
+            )
+
+        await self._client.post(
+            f"/zones/{zone_id}/purge_cache",
+            {"purge_everything": True},
+        )
+
+        logger.info("Cloudflare purge_cache: zone=%s", zone_id)
+        return ActionResult(
+            status=ActionStatus.SUCCESS,
+            details={"zone_id": zone_id, "operation": "purge_cache"},
+        )
+
+    async def _op_purge_urls(
+        self, event: Event, action: RecommendedAction,
+    ) -> ActionResult:
+        """Purge specific URLs from the cache."""
+        assert self._client is not None
+        zone_id = action.params.get("zone_id", self._config.zone_id)
+        if not zone_id:
+            return ActionResult(
+                status=ActionStatus.FAILURE,
+                error_message="purge_urls requires 'zone_id' in params or config",
+            )
+
+        urls = action.params.get("urls", [])
+        if not urls:
+            return ActionResult(
+                status=ActionStatus.FAILURE,
+                error_message="purge_urls requires 'urls' list in params",
+            )
+
+        await self._client.post(
+            f"/zones/{zone_id}/purge_cache",
+            {"files": urls},
+        )
+
+        logger.info(
+            "Cloudflare purge_urls: zone=%s, count=%d", zone_id, len(urls),
+        )
+        return ActionResult(
+            status=ActionStatus.SUCCESS,
+            details={
+                "zone_id": zone_id,
+                "operation": "purge_urls",
+                "url_count": len(urls),
+            },
+        )
+
+    async def _op_block_ip(
+        self, event: Event, action: RecommendedAction,
+    ) -> ActionResult:
+        """Block an IP via Cloudflare firewall access rule."""
+        assert self._client is not None
+        ip = action.params.get("ip")
+        if not ip:
+            return ActionResult(
+                status=ActionStatus.FAILURE,
+                error_message="block_ip requires 'ip' in params",
+            )
+
+        note = action.params.get(
+            "note", f"Blocked by OasisAgent: {action.description}",
+        )
+
+        data = await self._client.post(
+            f"/accounts/{self._config.account_id}/firewall/access_rules/rules",
+            {
+                "mode": "block",
+                "configuration": {"target": "ip", "value": ip},
+                "notes": note,
+            },
+        )
+
+        rule_id = data.get("result", {}).get("id", "")
+        logger.info("Cloudflare block_ip: ip=%s, rule_id=%s", ip, rule_id)
+        return ActionResult(
+            status=ActionStatus.SUCCESS,
+            details={
+                "ip": ip,
+                "operation": "block_ip",
+                "rule_id": rule_id,
+            },
+        )
+
+    async def _op_unblock_ip(
+        self, event: Event, action: RecommendedAction,
+    ) -> ActionResult:
+        """Remove a firewall access rule to unblock an IP."""
+        assert self._client is not None
+        rule_id = action.params.get("rule_id")
+        if not rule_id:
+            return ActionResult(
+                status=ActionStatus.FAILURE,
+                error_message="unblock_ip requires 'rule_id' in params",
+            )
+
+        await self._client.delete(
+            f"/accounts/{self._config.account_id}/firewall/access_rules/rules/{rule_id}",
+        )
+
+        logger.info("Cloudflare unblock_ip: rule_id=%s", rule_id)
+        return ActionResult(
+            status=ActionStatus.SUCCESS,
+            details={
+                "rule_id": rule_id,
+                "operation": "unblock_ip",
+            },
+        )
+
+    # -------------------------------------------------------------------
+    # Internal helpers
+    # -------------------------------------------------------------------
+
+    def _ensure_started(self) -> None:
+        """Raise if the handler hasn't been started."""
+        if self._client is None:
+            msg = "CloudflareHandler.start() must be called before use"
+            raise RuntimeError(msg)
+
+    async def _verify_block_ip(self, result: ActionResult) -> VerifyResult:
+        """Verify a block_ip rule was created by checking it exists."""
+        assert self._client is not None
+        rule_id = (result.details or {}).get("rule_id", "")
+        if not rule_id:
+            return VerifyResult(
+                verified=False,
+                message="No rule_id returned from block_ip",
+            )
+
+        try:
+            data = await self._client.get(
+                f"/accounts/{self._config.account_id}"
+                f"/firewall/access_rules/rules/{rule_id}",
+            )
+            rule = data.get("result", {})
+            if rule.get("id") == rule_id:
+                return VerifyResult(
+                    verified=True,
+                    message=f"Firewall rule {rule_id} confirmed",
+                )
+        except aiohttp.ClientError as exc:
+            return VerifyResult(
+                verified=False,
+                message=f"Failed to verify rule {rule_id}: {exc}",
+            )
+
+        return VerifyResult(
+            verified=False,
+            message=f"Rule {rule_id} not found after creation",
+        )

--- a/tests/test_handlers/test_cloudflare.py
+++ b/tests/test_handlers/test_cloudflare.py
@@ -1,0 +1,672 @@
+"""Tests for the Cloudflare handler."""
+
+from __future__ import annotations
+
+from datetime import UTC, datetime
+from typing import Any
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import aiohttp
+import pytest
+
+from oasisagent.config import CloudflareHandlerConfig
+from oasisagent.handlers.cloudflare import CloudflareHandler
+from oasisagent.models import (
+    ActionResult,
+    ActionStatus,
+    Event,
+    EventMetadata,
+    RecommendedAction,
+    RiskTier,
+    Severity,
+)
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _make_config(**overrides: Any) -> CloudflareHandlerConfig:
+    defaults: dict[str, Any] = {
+        "enabled": True,
+        "api_token": "test-token-123",
+        "zone_id": "zone-abc",
+        "account_id": "account-xyz",
+        "timeout": 10,
+    }
+    defaults.update(overrides)
+    return CloudflareHandlerConfig(**defaults)
+
+
+def _make_event(**overrides: Any) -> Event:
+    defaults: dict[str, Any] = {
+        "source": "cloudflare",
+        "system": "cloudflare",
+        "event_type": "tunnel_disconnected",
+        "entity_id": "my-tunnel",
+        "severity": Severity.ERROR,
+        "timestamp": datetime.now(UTC),
+        "payload": {},
+        "metadata": EventMetadata(),
+    }
+    defaults.update(overrides)
+    return Event(**defaults)
+
+
+def _make_action(**overrides: Any) -> RecommendedAction:
+    defaults: dict[str, Any] = {
+        "description": "Test action",
+        "handler": "cloudflare",
+        "operation": "notify",
+        "params": {},
+        "risk_tier": RiskTier.RECOMMEND,
+    }
+    defaults.update(overrides)
+    return RecommendedAction(**defaults)
+
+
+def _mock_resp(
+    json_data: dict[str, Any] | None = None,
+) -> MagicMock:
+    """Create a mock aiohttp response for async context managers."""
+    resp = MagicMock()
+    resp.status = 200
+    resp.json = AsyncMock(
+        return_value=json_data or {"success": True, "result": {}},
+    )
+    resp.request_info = MagicMock()
+    resp.history = ()
+    return resp
+
+
+def _make_handler(**overrides: Any) -> CloudflareHandler:
+    """Create a handler with a mocked CloudflareClient."""
+    config = _make_config(**overrides)
+    handler = CloudflareHandler(config)
+    mock_client = AsyncMock()
+    handler._client = mock_client
+    return handler
+
+
+# ---------------------------------------------------------------------------
+# Identity & lifecycle
+# ---------------------------------------------------------------------------
+
+
+class TestLifecycle:
+    def test_name(self) -> None:
+        handler = CloudflareHandler(_make_config())
+        assert handler.name() == "cloudflare"
+
+    @pytest.mark.asyncio
+    async def test_start_creates_client(self) -> None:
+        with patch("oasisagent.handlers.cloudflare.CloudflareClient") as mock_cls:
+            mock_client = AsyncMock()
+            mock_cls.return_value = mock_client
+
+            handler = CloudflareHandler(_make_config())
+            await handler.start()
+
+            mock_client.start.assert_called_once()
+            assert handler._client is mock_client
+
+    @pytest.mark.asyncio
+    async def test_stop_closes_client(self) -> None:
+        handler = _make_handler()
+        mock_client = handler._client
+        await handler.stop()
+
+        mock_client.close.assert_called_once()
+        assert handler._client is None
+
+    @pytest.mark.asyncio
+    async def test_stop_when_not_started(self) -> None:
+        handler = CloudflareHandler(_make_config())
+        await handler.stop()  # should not raise
+
+    @pytest.mark.asyncio
+    async def test_ensure_started_raises(self) -> None:
+        handler = CloudflareHandler(_make_config())
+        with pytest.raises(RuntimeError, match="start\\(\\) must be called"):
+            await handler.execute(_make_event(), _make_action())
+
+
+# ---------------------------------------------------------------------------
+# can_handle
+# ---------------------------------------------------------------------------
+
+
+class TestCanHandle:
+    @pytest.mark.asyncio
+    async def test_known_operations(self) -> None:
+        handler = _make_handler()
+        for op in ("notify", "purge_cache", "purge_urls", "block_ip", "unblock_ip"):
+            action = _make_action(operation=op)
+            assert await handler.can_handle(_make_event(), action)
+
+    @pytest.mark.asyncio
+    async def test_unknown_operation(self) -> None:
+        handler = _make_handler()
+        action = _make_action(operation="delete_zone")
+        assert not await handler.can_handle(_make_event(), action)
+
+    @pytest.mark.asyncio
+    async def test_wrong_handler(self) -> None:
+        handler = _make_handler()
+        action = _make_action(handler="docker")
+        assert not await handler.can_handle(_make_event(), action)
+
+
+# ---------------------------------------------------------------------------
+# notify operation
+# ---------------------------------------------------------------------------
+
+
+class TestNotifyOp:
+    @pytest.mark.asyncio
+    async def test_notify_success(self) -> None:
+        handler = _make_handler()
+        event = _make_event()
+        action = _make_action(
+            operation="notify",
+            params={"message": "Tunnel is down"},
+        )
+
+        result = await handler.execute(event, action)
+
+        assert result.status == ActionStatus.SUCCESS
+        assert result.details["message"] == "Tunnel is down"
+        assert result.details["entity_id"] == "my-tunnel"
+        assert result.duration_ms is not None
+
+    @pytest.mark.asyncio
+    async def test_notify_uses_description_as_fallback(self) -> None:
+        handler = _make_handler()
+        action = _make_action(
+            operation="notify",
+            description="WAF spike detected",
+            params={},
+        )
+
+        result = await handler.execute(_make_event(), action)
+
+        assert result.details["message"] == "WAF spike detected"
+
+
+# ---------------------------------------------------------------------------
+# purge_cache operation
+# ---------------------------------------------------------------------------
+
+
+class TestPurgeCacheOp:
+    @pytest.mark.asyncio
+    async def test_purge_cache_success(self) -> None:
+        handler = _make_handler()
+        handler._client.post = AsyncMock(
+            return_value={"success": True, "result": {"id": "purge-1"}},
+        )
+
+        action = _make_action(operation="purge_cache")
+
+        result = await handler.execute(_make_event(), action)
+
+        assert result.status == ActionStatus.SUCCESS
+        assert result.details["zone_id"] == "zone-abc"
+        handler._client.post.assert_called_once_with(
+            "/zones/zone-abc/purge_cache",
+            {"purge_everything": True},
+        )
+
+    @pytest.mark.asyncio
+    async def test_purge_cache_uses_param_zone_id(self) -> None:
+        handler = _make_handler()
+        handler._client.post = AsyncMock(
+            return_value={"success": True, "result": {}},
+        )
+
+        action = _make_action(
+            operation="purge_cache",
+            params={"zone_id": "override-zone"},
+        )
+
+        result = await handler.execute(_make_event(), action)
+
+        assert result.status == ActionStatus.SUCCESS
+        assert result.details["zone_id"] == "override-zone"
+
+    @pytest.mark.asyncio
+    async def test_purge_cache_no_zone_fails(self) -> None:
+        handler = _make_handler(zone_id="")
+        action = _make_action(operation="purge_cache")
+
+        result = await handler.execute(_make_event(), action)
+
+        assert result.status == ActionStatus.FAILURE
+        assert "zone_id" in result.error_message
+
+    @pytest.mark.asyncio
+    async def test_purge_cache_http_error(self) -> None:
+        handler = _make_handler()
+        handler._client.post = AsyncMock(
+            side_effect=aiohttp.ClientError("connection refused"),
+        )
+
+        action = _make_action(operation="purge_cache")
+
+        result = await handler.execute(_make_event(), action)
+
+        assert result.status == ActionStatus.FAILURE
+        assert "HTTP error" in result.error_message
+        assert result.duration_ms is not None
+
+
+# ---------------------------------------------------------------------------
+# purge_urls operation
+# ---------------------------------------------------------------------------
+
+
+class TestPurgeUrlsOp:
+    @pytest.mark.asyncio
+    async def test_purge_urls_success(self) -> None:
+        handler = _make_handler()
+        handler._client.post = AsyncMock(
+            return_value={"success": True, "result": {}},
+        )
+
+        action = _make_action(
+            operation="purge_urls",
+            params={"urls": ["https://example.com/page1", "https://example.com/page2"]},
+        )
+
+        result = await handler.execute(_make_event(), action)
+
+        assert result.status == ActionStatus.SUCCESS
+        assert result.details["url_count"] == 2
+        handler._client.post.assert_called_once_with(
+            "/zones/zone-abc/purge_cache",
+            {"files": ["https://example.com/page1", "https://example.com/page2"]},
+        )
+
+    @pytest.mark.asyncio
+    async def test_purge_urls_no_zone_fails(self) -> None:
+        handler = _make_handler(zone_id="")
+        action = _make_action(
+            operation="purge_urls",
+            params={"urls": ["https://example.com"]},
+        )
+
+        result = await handler.execute(_make_event(), action)
+
+        assert result.status == ActionStatus.FAILURE
+        assert "zone_id" in result.error_message
+
+    @pytest.mark.asyncio
+    async def test_purge_urls_no_urls_fails(self) -> None:
+        handler = _make_handler()
+        action = _make_action(operation="purge_urls", params={})
+
+        result = await handler.execute(_make_event(), action)
+
+        assert result.status == ActionStatus.FAILURE
+        assert "urls" in result.error_message
+
+    @pytest.mark.asyncio
+    async def test_purge_urls_empty_list_fails(self) -> None:
+        handler = _make_handler()
+        action = _make_action(
+            operation="purge_urls",
+            params={"urls": []},
+        )
+
+        result = await handler.execute(_make_event(), action)
+
+        assert result.status == ActionStatus.FAILURE
+        assert "urls" in result.error_message
+
+
+# ---------------------------------------------------------------------------
+# block_ip operation
+# ---------------------------------------------------------------------------
+
+
+class TestBlockIpOp:
+    @pytest.mark.asyncio
+    async def test_block_ip_success(self) -> None:
+        handler = _make_handler()
+        handler._client.post = AsyncMock(return_value={
+            "success": True,
+            "result": {"id": "rule-123"},
+        })
+
+        action = _make_action(
+            operation="block_ip",
+            params={"ip": "192.168.1.100"},
+        )
+
+        result = await handler.execute(_make_event(), action)
+
+        assert result.status == ActionStatus.SUCCESS
+        assert result.details["ip"] == "192.168.1.100"
+        assert result.details["rule_id"] == "rule-123"
+        handler._client.post.assert_called_once_with(
+            "/accounts/account-xyz/firewall/access_rules/rules",
+            {
+                "mode": "block",
+                "configuration": {"target": "ip", "value": "192.168.1.100"},
+                "notes": "Blocked by OasisAgent: Test action",
+            },
+        )
+
+    @pytest.mark.asyncio
+    async def test_block_ip_custom_note(self) -> None:
+        handler = _make_handler()
+        handler._client.post = AsyncMock(return_value={
+            "success": True,
+            "result": {"id": "rule-456"},
+        })
+
+        action = _make_action(
+            operation="block_ip",
+            params={"ip": "10.0.0.1", "note": "Suspicious traffic"},
+        )
+
+        result = await handler.execute(_make_event(), action)
+
+        assert result.status == ActionStatus.SUCCESS
+        call_json = handler._client.post.call_args[0][1]
+        assert call_json["notes"] == "Suspicious traffic"
+
+    @pytest.mark.asyncio
+    async def test_block_ip_no_ip_fails(self) -> None:
+        handler = _make_handler()
+        action = _make_action(operation="block_ip", params={})
+
+        result = await handler.execute(_make_event(), action)
+
+        assert result.status == ActionStatus.FAILURE
+        assert "ip" in result.error_message
+
+
+# ---------------------------------------------------------------------------
+# unblock_ip operation
+# ---------------------------------------------------------------------------
+
+
+class TestUnblockIpOp:
+    @pytest.mark.asyncio
+    async def test_unblock_ip_success(self) -> None:
+        handler = _make_handler()
+        handler._client.delete = AsyncMock(return_value={
+            "success": True,
+            "result": {"id": "rule-123"},
+        })
+
+        action = _make_action(
+            operation="unblock_ip",
+            params={"rule_id": "rule-123"},
+        )
+
+        result = await handler.execute(_make_event(), action)
+
+        assert result.status == ActionStatus.SUCCESS
+        assert result.details["rule_id"] == "rule-123"
+        handler._client.delete.assert_called_once_with(
+            "/accounts/account-xyz/firewall/access_rules/rules/rule-123",
+        )
+
+    @pytest.mark.asyncio
+    async def test_unblock_ip_no_rule_id_fails(self) -> None:
+        handler = _make_handler()
+        action = _make_action(operation="unblock_ip", params={})
+
+        result = await handler.execute(_make_event(), action)
+
+        assert result.status == ActionStatus.FAILURE
+        assert "rule_id" in result.error_message
+
+
+# ---------------------------------------------------------------------------
+# Unknown operation
+# ---------------------------------------------------------------------------
+
+
+class TestUnknownOp:
+    @pytest.mark.asyncio
+    async def test_unknown_operation_returns_failure(self) -> None:
+        handler = _make_handler()
+        action = _make_action(operation="delete_zone")
+
+        result = await handler.execute(_make_event(), action)
+
+        assert result.status == ActionStatus.FAILURE
+        assert "Unknown operation" in result.error_message
+
+
+# ---------------------------------------------------------------------------
+# verify
+# ---------------------------------------------------------------------------
+
+
+class TestVerify:
+    @pytest.mark.asyncio
+    async def test_verify_non_block_returns_true(self) -> None:
+        handler = _make_handler()
+        action = _make_action(operation="notify")
+        result = ActionResult(status=ActionStatus.SUCCESS)
+
+        verify = await handler.verify(_make_event(), action, result)
+
+        assert verify.verified is True
+
+    @pytest.mark.asyncio
+    async def test_verify_purge_cache_returns_true(self) -> None:
+        handler = _make_handler()
+        action = _make_action(operation="purge_cache")
+        result = ActionResult(status=ActionStatus.SUCCESS)
+
+        verify = await handler.verify(_make_event(), action, result)
+
+        assert verify.verified is True
+
+    @pytest.mark.asyncio
+    async def test_verify_block_ip_confirmed(self) -> None:
+        handler = _make_handler()
+        handler._client.get = AsyncMock(return_value={
+            "success": True,
+            "result": {"id": "rule-123", "mode": "block"},
+        })
+
+        action = _make_action(operation="block_ip")
+        result = ActionResult(
+            status=ActionStatus.SUCCESS,
+            details={"rule_id": "rule-123", "ip": "1.2.3.4"},
+        )
+
+        verify = await handler.verify(_make_event(), action, result)
+
+        assert verify.verified is True
+        assert "rule-123" in verify.message
+
+    @pytest.mark.asyncio
+    async def test_verify_block_ip_not_found(self) -> None:
+        handler = _make_handler()
+        handler._client.get = AsyncMock(return_value={
+            "success": True,
+            "result": {"id": "different-rule"},
+        })
+
+        action = _make_action(operation="block_ip")
+        result = ActionResult(
+            status=ActionStatus.SUCCESS,
+            details={"rule_id": "rule-123"},
+        )
+
+        verify = await handler.verify(_make_event(), action, result)
+
+        assert verify.verified is False
+
+    @pytest.mark.asyncio
+    async def test_verify_block_ip_http_error(self) -> None:
+        handler = _make_handler()
+        handler._client.get = AsyncMock(
+            side_effect=aiohttp.ClientError("timeout"),
+        )
+
+        action = _make_action(operation="block_ip")
+        result = ActionResult(
+            status=ActionStatus.SUCCESS,
+            details={"rule_id": "rule-123"},
+        )
+
+        verify = await handler.verify(_make_event(), action, result)
+
+        assert verify.verified is False
+        assert "Failed to verify" in verify.message
+
+    @pytest.mark.asyncio
+    async def test_verify_block_ip_no_rule_id(self) -> None:
+        handler = _make_handler()
+        action = _make_action(operation="block_ip")
+        result = ActionResult(
+            status=ActionStatus.SUCCESS,
+            details={},
+        )
+
+        verify = await handler.verify(_make_event(), action, result)
+
+        assert verify.verified is False
+        assert "No rule_id" in verify.message
+
+    @pytest.mark.asyncio
+    async def test_verify_block_ip_failed_result(self) -> None:
+        """block_ip with FAILURE status skips verification."""
+        handler = _make_handler()
+        action = _make_action(operation="block_ip")
+        result = ActionResult(status=ActionStatus.FAILURE)
+
+        verify = await handler.verify(_make_event(), action, result)
+
+        assert verify.verified is True
+        assert "No verification needed" in verify.message
+
+
+# ---------------------------------------------------------------------------
+# get_context
+# ---------------------------------------------------------------------------
+
+
+class TestGetContext:
+    @pytest.mark.asyncio
+    async def test_get_context_zone_and_tunnels(self) -> None:
+        handler = _make_handler()
+        handler._client.get = AsyncMock(side_effect=[
+            # /zones/{zone_id}
+            {"result": {
+                "name": "example.com",
+                "status": "active",
+                "paused": False,
+                "plan": {"name": "Pro"},
+            }},
+            # /accounts/{account_id}/cfd_tunnel
+            {"result": [
+                {"id": "t1", "name": "main-tunnel", "status": "active"},
+                {"id": "t2", "name": "backup-tunnel", "status": "inactive"},
+            ]},
+        ])
+
+        context = await handler.get_context(_make_event())
+
+        assert context["zone"]["name"] == "example.com"
+        assert context["zone"]["plan"] == "Pro"
+        assert len(context["tunnels"]) == 2
+        assert context["tunnels"][0]["name"] == "main-tunnel"
+
+    @pytest.mark.asyncio
+    async def test_get_context_zone_error(self) -> None:
+        handler = _make_handler()
+        handler._client.get = AsyncMock(side_effect=[
+            aiohttp.ClientError("connection refused"),
+            {"result": [{"id": "t1", "name": "tunnel", "status": "active"}]},
+        ])
+
+        context = await handler.get_context(_make_event())
+
+        assert "zone_error" in context
+        assert len(context["tunnels"]) == 1
+
+    @pytest.mark.asyncio
+    async def test_get_context_tunnel_error(self) -> None:
+        handler = _make_handler()
+        handler._client.get = AsyncMock(side_effect=[
+            {"result": {"name": "example.com", "status": "active",
+                        "paused": False, "plan": {"name": "Free"}}},
+            aiohttp.ClientError("timeout"),
+        ])
+
+        context = await handler.get_context(_make_event())
+
+        assert context["zone"]["name"] == "example.com"
+        assert "tunnel_error" in context
+
+    @pytest.mark.asyncio
+    async def test_get_context_no_zone_id(self) -> None:
+        handler = _make_handler(zone_id="")
+        handler._client.get = AsyncMock(return_value={
+            "result": [{"id": "t1", "name": "tunnel", "status": "active"}],
+        })
+
+        context = await handler.get_context(_make_event())
+
+        assert "zone" not in context
+        assert "tunnels" in context
+
+    @pytest.mark.asyncio
+    async def test_get_context_no_account_id(self) -> None:
+        handler = _make_handler(account_id="")
+        handler._client.get = AsyncMock(return_value={
+            "result": {"name": "example.com", "status": "active",
+                        "paused": False, "plan": {"name": "Free"}},
+        })
+
+        context = await handler.get_context(_make_event())
+
+        assert "zone" in context
+        assert "tunnels" not in context
+
+
+# ---------------------------------------------------------------------------
+# Config & registry
+# ---------------------------------------------------------------------------
+
+
+class TestConfigAndRegistry:
+    def test_config_defaults(self) -> None:
+        config = CloudflareHandlerConfig()
+        assert config.enabled is False
+        assert config.timeout == 30
+
+    def test_config_extra_forbidden(self) -> None:
+        from pydantic import ValidationError
+
+        with pytest.raises(ValidationError, match="Extra inputs"):
+            _make_config(bogus="nope")
+
+    def test_handlers_config_has_cloudflare(self) -> None:
+        from oasisagent.config import HandlersConfig
+
+        config = HandlersConfig()
+        assert hasattr(config, "cloudflare")
+        assert isinstance(config.cloudflare, CloudflareHandlerConfig)
+
+    def test_registry_entry(self) -> None:
+        from oasisagent.db.registry import CORE_SERVICE_TYPES
+
+        assert "cloudflare_handler" in CORE_SERVICE_TYPES
+        meta = CORE_SERVICE_TYPES["cloudflare_handler"]
+        assert meta.model is CloudflareHandlerConfig
+        assert "api_token" in meta.secret_fields
+
+    def test_handler_exported_from_init(self) -> None:
+        from oasisagent.handlers import CloudflareHandler as Exported
+
+        assert Exported is CloudflareHandler


### PR DESCRIPTION
## Summary

- Implements `CloudflareHandler` with five operations: `notify`, `purge_cache`, `purge_urls`, `block_ip`, `unblock_ip`
- `block_ip` creates account-level firewall access rules; `verify()` confirms the rule exists after creation
- `purge_cache`/`purge_urls` use the zone purge_cache API (full purge vs. selective file list)
- `unblock_ip` deletes firewall rules by `rule_id` (must be explicit — same pattern as UniFi `block_client`)
- `get_context()` gathers zone details and tunnel status for T1/T2 diagnosis
- Registers `cloudflare_handler` in `db/registry.py` with `api_token` as secret field
- Adds `CloudflareHandlerConfig` to `HandlersConfig` and exports `CloudflareHandler` from `handlers/__init__`
- 41 tests covering all operations, verification, context gathering, error handling, config, and registry

## Test plan

- [x] All 41 handler tests pass (`pytest tests/test_handlers/test_cloudflare.py`)
- [x] Full suite passes (1337 tests)
- [x] Lint clean (`ruff check`)
- [ ] Review: `block_ip`/`unblock_ip` should be `approval_required` in guardrails (backlog item)
- [ ] Review: Verify handler pattern matches UniFi handler conventions

🤖 Generated with [Claude Code](https://claude.com/claude-code)