### PR TITLE
Fix CI lint failures and upgrade Actions to Node 22

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,10 +12,10 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
 
       - name: Set up Python
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@v6
         with:
           python-version: "3.12"
 

--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -19,7 +19,7 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
 
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3

--- a/oasisagent/ui/routes/auth_routes.py
+++ b/oasisagent/ui/routes/auth_routes.py
@@ -208,7 +208,10 @@ async def login_2fa(
 
     # Validate pending token
     try:
-        payload = pyjwt.decode(pending_token, signing_key, algorithms=[_JWT_ALGORITHM], options={"verify_sub": False})
+        payload = pyjwt.decode(
+            pending_token, signing_key,
+            algorithms=[_JWT_ALGORITHM], options={"verify_sub": False},
+        )
         if payload.get("purpose") != "2fa_pending":
             raise ValueError("Wrong token purpose")
     except Exception:
@@ -302,7 +305,10 @@ async def login_totp_enroll_confirm(
         )
 
     try:
-        payload = pyjwt.decode(pending_token, signing_key, algorithms=[_JWT_ALGORITHM], options={"verify_sub": False})
+        payload = pyjwt.decode(
+            pending_token, signing_key,
+            algorithms=[_JWT_ALGORITHM], options={"verify_sub": False},
+        )
         if payload.get("purpose") != "totp_enroll":
             raise ValueError("Wrong token purpose")
         user = await store.get_user_by_id(payload["sub"])
@@ -353,7 +359,10 @@ async def logout(request: Request) -> RedirectResponse:
     token = request.cookies.get(_COOKIE_NAME)
     if token:
         try:
-            payload = pyjwt.decode(token, signing_key, algorithms=[_JWT_ALGORITHM], options={"verify_sub": False})
+            payload = pyjwt.decode(
+                token, signing_key,
+                algorithms=[_JWT_ALGORITHM], options={"verify_sub": False},
+            )
             user = await store.get_user_by_id(payload["sub"])
             if user:
                 await store.update_user(

--- a/oasisagent/ui/routes/setup_routes.py
+++ b/oasisagent/ui/routes/setup_routes.py
@@ -167,7 +167,10 @@ async def setup_totp_confirm(
     user_id = None
     if pending_token:
         try:
-            payload = pyjwt.decode(pending_token, signing_key, algorithms=[_JWT_ALGORITHM], options={"verify_sub": False})
+            payload = pyjwt.decode(
+                pending_token, signing_key,
+                algorithms=[_JWT_ALGORITHM], options={"verify_sub": False},
+            )
             user_id = payload["sub"]
         except Exception:
             pass

--- a/tests/test_ingestion/test_http_poller.py
+++ b/tests/test_ingestion/test_http_poller.py
@@ -72,7 +72,7 @@ class TestConfigValidation:
         assert target.threshold.critical == 95.0
 
     def test_threshold_critical_must_exceed_warning(self) -> None:
-        with pytest.raises(ValidationError, match="critical.*must be greater than warning"):
+        with pytest.raises(ValidationError, match=r"critical.*must be greater than warning"):
             _make_target(
                 mode="threshold",
                 threshold={


### PR DESCRIPTION
## Summary

- Fix 4x E501 (line too long) in `auth_routes.py` and `setup_routes.py` — long `pyjwt.decode()` calls wrapped to multi-line
- Fix 1x RUF043 in `test_http_poller.py` — regex pattern needs raw string prefix
- Bump `actions/checkout` v4 → v5 and `actions/setup-python` v5 → v6 in both CI and Docker workflows to resolve Node.js 20 deprecation warning

These pre-existing lint issues have been failing CI since at least PR #92 (all runs in the screenshot are red).

## Test plan

- [x] `ruff check .` passes locally (0 errors)
- [x] Affected tests pass (100 passed)
- [ ] CI run on this PR passes (verifies the fix end-to-end)

🤖 Generated with [Claude Code](https://claude.com/claude-code)