### PR TITLE
Add scanner config page with handler dependency warnings

### DIFF
--- a/oasisagent/ui/routes/connectors.py
+++ b/oasisagent/ui/routes/connectors.py
@@ -610,12 +610,13 @@ async def scanner_save(
 
     form = await request.form()
     form_data = dict(form)
-    scanner_config = _parse_scanner_form(form_data)
 
     rows = await store.list_services()
     scanner_row = _find_scanner_row(rows)
+    scanner_config: dict[str, Any] = {}
 
     try:
+        scanner_config = _parse_scanner_form(form_data)
         if scanner_row:
             # Update existing scanner row — replace entire config
             enabled = scanner_config.pop("enabled")
@@ -635,8 +636,10 @@ async def scanner_save(
             if isinstance(exc, ValidationError)
             else [str(exc)]
         )
-        # Re-render with errors — put enabled back for display
-        scanner_config["enabled"] = form_data.get("enabled") is not None
+        # Re-render with errors — use defaults if parse itself failed
+        if not scanner_config:
+            scanner_config = _default_scanner_config()
+        scanner_config["enabled"] = "enabled" in form_data
         ha_enabled = await _handler_enabled(store, "ha_handler")
         docker_enabled = await _handler_enabled(store, "docker_handler")
         return templates.TemplateResponse(

--- a/oasisagent/ui/templates/services/scanners.html
+++ b/oasisagent/ui/templates/services/scanners.html
@@ -204,6 +204,7 @@
         <div class="px-6 pb-6">
             <p class="text-sm text-amber-600 bg-amber-50 rounded p-3">
                 Enable the Home Assistant handler first to use this scanner.
+                HA health scanning is paused while this handler is off.
                 <a href="/ui/services" class="underline hover:text-amber-800">Go to Services</a>
             </p>
         </div>
@@ -252,6 +253,7 @@
         <div class="px-6 pb-6">
             <p class="text-sm text-amber-600 bg-amber-50 rounded p-3">
                 Enable the Docker handler first to use this scanner.
+                Docker health scanning is paused while this handler is off.
                 <a href="/ui/services" class="underline hover:text-amber-800">Go to Services</a>
             </p>
         </div>

--- a/tests/test_ui/test_scanner_page.py
+++ b/tests/test_ui/test_scanner_page.py
@@ -175,6 +175,26 @@ class TestScannerSave:
         )
         assert resp.status_code == 422
 
+    async def test_save_non_numeric_interval_returns_422(
+        self, auth_client: AsyncClient,
+    ) -> None:
+        """Non-numeric interval should return 422, not 500."""
+        resp = await auth_client.post(
+            "/ui/services/scanners",
+            data={
+                "interval": "abc",
+                "cert_warning_days": "30",
+                "cert_critical_days": "7",
+                "cert_interval": "900",
+                "disk_warning_pct": "85",
+                "disk_critical_pct": "95",
+                "disk_interval": "900",
+                "ha_interval": "900",
+                "docker_interval": "900",
+            },
+        )
+        assert resp.status_code == 422
+
 
 class TestScannerFormParsing:
     """Direct tests for _parse_scanner_form."""


### PR DESCRIPTION
## Summary
- Implements **PR 2 of #101** — dedicated scanner config page at `/ui/services/scanners`
- **Four collapsible sections**: Certificate Expiry, Disk Space, HA Integration Health, Docker Health
- **Global settings**: enabled toggle + default scan interval at top
- **Handler dependency warnings**: HA health section disabled with amber banner when HA handler is not enabled; same for Docker health ↔ Docker handler
- **Route ordering fix**: scanner routes registered before the services CRUD factory to prevent FastAPI matching `/services/scanners` as `/services/{row_id}` (int parse failure → 422)
- Each section has its own enabled toggle, type-specific fields, and interval override
- Form parses flat HTML field names into nested `ScannerConfig`-shaped dict for Pydantic validation

## Test plan
- [x] `ruff check .` — zero errors
- [x] Full test suite: **1682 tests passing** (14 new)
- [x] Scanner page renders with all 4 sections
- [x] HA/Docker sections show dependency warnings when handlers not enabled
- [x] HA/Docker sections become editable when handlers are enabled
- [x] Save creates scanner row, save again updates it
- [x] Invalid interval (< 60) returns 422
- [x] Viewer cannot access or save (403)
- [x] Form parsing: checkbox handling, list_str splitting, defaults on empty
- [ ] Manual: navigate to `/ui/services` → click Configure on scanner row → page loads
- [ ] Manual: enable cert scanner, add endpoints, save → verify stored
- [ ] Manual: verify HA section shows warning when HA handler disabled

Completes #101.

🤖 Generated with [Claude Code](https://claude.com/claude-code)