### PR TITLE
Add adaptive scanner intervals (#64)

### DIFF
--- a/config.example.yaml
+++ b/config.example.yaml
@@ -206,6 +206,9 @@ ingestion:
 scanner:
   enabled: false
   interval: 900                    # Global default interval (seconds); per-check overrides below
+  adaptive_enabled: true           # Shorten interval after detecting issues, restore after clean scans
+  adaptive_fast_factor: 0.25       # Multiply interval by this when in fast mode (900s → 225s)
+  adaptive_recovery_scans: 3       # Consecutive clean scans before restoring normal interval
 
   # TLS certificate expiry — checks cert validity from OasisAgent's vantage point
   certificate_expiry:

--- a/oasisagent/config.py
+++ b/oasisagent/config.py
@@ -484,6 +484,9 @@ class ScannerConfig(BaseModel):
 
     enabled: bool = False
     interval: Annotated[int, Field(ge=60)] = 900
+    adaptive_enabled: bool = True
+    adaptive_fast_factor: Annotated[float, Field(gt=0.0, lt=1.0)] = 0.25
+    adaptive_recovery_scans: Annotated[int, Field(ge=1)] = 3
     certificate_expiry: CertExpiryCheckConfig = Field(default_factory=CertExpiryCheckConfig)
     disk_space: DiskSpaceCheckConfig = Field(default_factory=DiskSpaceCheckConfig)
     ha_health: HaHealthCheckConfig = Field(default_factory=HaHealthCheckConfig)

--- a/oasisagent/orchestrator.py
+++ b/oasisagent/orchestrator.py
@@ -329,12 +329,18 @@ class Orchestrator:
 
         # 14b. Scanner adapters (each scanner is its own adapter)
         if cfg.scanner.enabled:
+            adaptive_kw = {
+                "adaptive_enabled": cfg.scanner.adaptive_enabled,
+                "adaptive_fast_factor": cfg.scanner.adaptive_fast_factor,
+                "adaptive_recovery_scans": cfg.scanner.adaptive_recovery_scans,
+            }
             if cfg.scanner.certificate_expiry.enabled:
                 from oasisagent.scanner.cert_expiry import CertExpiryScannerAdapter
 
                 interval = cfg.scanner.certificate_expiry.interval or cfg.scanner.interval
                 self._adapters.append(CertExpiryScannerAdapter(
                     cfg.scanner.certificate_expiry, self._queue, interval,
+                    **adaptive_kw,
                 ))
             if cfg.scanner.disk_space.enabled:
                 from oasisagent.scanner.disk_space import DiskSpaceScannerAdapter
@@ -342,6 +348,7 @@ class Orchestrator:
                 interval = cfg.scanner.disk_space.interval or cfg.scanner.interval
                 self._adapters.append(DiskSpaceScannerAdapter(
                     cfg.scanner.disk_space, self._queue, interval,
+                    **adaptive_kw,
                 ))
             if cfg.scanner.ha_health.enabled and cfg.handlers.homeassistant.enabled:
                 from oasisagent.scanner.ha_health import HaHealthScannerAdapter
@@ -350,6 +357,7 @@ class Orchestrator:
                 self._adapters.append(HaHealthScannerAdapter(
                     cfg.scanner.ha_health, self._queue, interval,
                     ha_config=cfg.handlers.homeassistant,
+                    **adaptive_kw,
                 ))
             if cfg.scanner.docker_health.enabled and cfg.handlers.docker.enabled:
                 from oasisagent.scanner.docker_health import DockerHealthScannerAdapter
@@ -358,6 +366,7 @@ class Orchestrator:
                 self._adapters.append(DockerHealthScannerAdapter(
                     cfg.scanner.docker_health, self._queue, interval,
                     docker_config=cfg.handlers.docker,
+                    **adaptive_kw,
                 ))
 
         # 15. Metrics server (Prometheus)

--- a/oasisagent/scanner/base.py
+++ b/oasisagent/scanner/base.py
@@ -29,12 +29,34 @@ class ScannerIngestAdapter(IngestAdapter):
     Subclasses must implement ``_scan()`` and the ``name`` property.
     """
 
-    def __init__(self, queue: EventQueue, interval: int) -> None:
+    def __init__(
+        self,
+        queue: EventQueue,
+        interval: int,
+        *,
+        adaptive_enabled: bool = True,
+        adaptive_fast_factor: float = 0.25,
+        adaptive_recovery_scans: int = 3,
+    ) -> None:
         super().__init__(queue)
         self._interval = interval
         self._stopping = False
         self._task: asyncio.Task[None] | None = None
         self._connected = True
+
+        # Adaptive interval state
+        self._adaptive_enabled = adaptive_enabled
+        self._adaptive_fast_factor = adaptive_fast_factor
+        self._adaptive_recovery_scans = adaptive_recovery_scans
+        self._consecutive_clean: int = 0
+        self._adapted: bool = False
+
+    @property
+    def _effective_interval(self) -> int:
+        """Return the current polling interval, shortened when in fast mode."""
+        if self._adaptive_enabled and self._adapted:
+            return max(60, int(self._interval * self._adaptive_fast_factor))
+        return self._interval
 
     @abstractmethod
     async def _scan(self) -> list[Event]:
@@ -59,13 +81,19 @@ class ScannerIngestAdapter(IngestAdapter):
         return self._connected
 
     async def _poll_loop(self) -> None:
-        """Poll at fixed intervals, emitting events from each scan cycle."""
+        """Poll at intervals, emitting events from each scan cycle.
+
+        When adaptive intervals are enabled, the scanner switches to a faster
+        polling rate after detecting WARNING+ events, then restores the normal
+        interval after consecutive clean scans.
+        """
         while not self._stopping:
             try:
                 events = await self._scan()
                 for event in events:
                     self._enqueue(event)
                 self._connected = True
+                self._update_adaptive_state(events)
             except asyncio.CancelledError:
                 return
             except Exception as exc:
@@ -73,10 +101,41 @@ class ScannerIngestAdapter(IngestAdapter):
                 self._connected = False
 
             # 1-second sleep increments for responsive shutdown
-            for _ in range(self._interval):
+            for _ in range(self._effective_interval):
                 if self._stopping:
                     return
                 await asyncio.sleep(1)
+
+    def _update_adaptive_state(self, events: list[Event]) -> None:
+        """Update adaptive interval state based on scan results."""
+        if not self._adaptive_enabled:
+            return
+
+        from oasisagent.models import Severity
+
+        has_issues = any(
+            e.severity in (Severity.WARNING, Severity.ERROR, Severity.CRITICAL)
+            for e in events
+        )
+
+        if has_issues:
+            if not self._adapted:
+                old_interval = self._interval
+                self._adapted = True
+                logger.info(
+                    "Scanner %s: entering fast mode (%ds -> %ds)",
+                    self.name, old_interval, self._effective_interval,
+                )
+            self._consecutive_clean = 0
+        elif self._adapted:
+            self._consecutive_clean += 1
+            if self._consecutive_clean >= self._adaptive_recovery_scans:
+                logger.info(
+                    "Scanner %s: exiting fast mode (%ds -> %ds)",
+                    self.name, self._effective_interval, self._interval,
+                )
+                self._adapted = False
+                self._consecutive_clean = 0
 
     def _enqueue(self, event: Event) -> None:
         """Enqueue an event, logging on failure."""

--- a/oasisagent/scanner/cert_expiry.py
+++ b/oasisagent/scanner/cert_expiry.py
@@ -23,7 +23,7 @@ import asyncio
 import logging
 import ssl
 from datetime import UTC, datetime
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, Any
 
 from oasisagent.models import Event, EventMetadata, Severity
 from oasisagent.scanner.base import ScannerIngestAdapter
@@ -46,9 +46,13 @@ class CertExpiryScannerAdapter(ScannerIngestAdapter):
     """
 
     def __init__(
-        self, config: CertExpiryCheckConfig, queue: EventQueue, interval: int,
+        self,
+        config: CertExpiryCheckConfig,
+        queue: EventQueue,
+        interval: int,
+        **kwargs: Any,
     ) -> None:
-        super().__init__(queue, interval)
+        super().__init__(queue, interval, **kwargs)
         self._config = config
         # State tracking: endpoint -> "ok" | "warning" | "critical"
         self._states: dict[str, str] = {}

--- a/oasisagent/scanner/disk_space.py
+++ b/oasisagent/scanner/disk_space.py
@@ -12,7 +12,7 @@ from __future__ import annotations
 import logging
 import shutil
 from datetime import UTC, datetime
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, Any
 
 from oasisagent.models import Event, EventMetadata, Severity
 from oasisagent.scanner.base import ScannerIngestAdapter
@@ -32,9 +32,13 @@ class DiskSpaceScannerAdapter(ScannerIngestAdapter):
     """
 
     def __init__(
-        self, config: DiskSpaceCheckConfig, queue: EventQueue, interval: int,
+        self,
+        config: DiskSpaceCheckConfig,
+        queue: EventQueue,
+        interval: int,
+        **kwargs: Any,
     ) -> None:
-        super().__init__(queue, interval)
+        super().__init__(queue, interval, **kwargs)
         self._config = config
         # State tracking: path -> "ok" | "warning" | "critical"
         self._states: dict[str, str] = {}

--- a/oasisagent/scanner/docker_health.py
+++ b/oasisagent/scanner/docker_health.py
@@ -51,8 +51,9 @@ class DockerHealthScannerAdapter(ScannerIngestAdapter):
         queue: EventQueue,
         interval: int,
         docker_config: DockerHandlerConfig,
+        **kwargs: Any,
     ) -> None:
-        super().__init__(queue, interval)
+        super().__init__(queue, interval, **kwargs)
         self._config = config
         self._docker_config = docker_config
         self._session: aiohttp.ClientSession | None = None

--- a/oasisagent/scanner/ha_health.py
+++ b/oasisagent/scanner/ha_health.py
@@ -55,8 +55,9 @@ class HaHealthScannerAdapter(ScannerIngestAdapter):
         queue: EventQueue,
         interval: int,
         ha_config: HaHandlerConfig,
+        **kwargs: Any,
     ) -> None:
-        super().__init__(queue, interval)
+        super().__init__(queue, interval, **kwargs)
         self._config = config
         self._ha_url = ha_config.url.rstrip("/")
         self._ha_token = ha_config.token

--- a/oasisagent/ui/form_specs.py
+++ b/oasisagent/ui/form_specs.py
@@ -929,7 +929,8 @@ DEFERRED_FIELDS: dict[str, frozenset[str]] = {
     "guardrails": frozenset({"circuit_breaker"}),
     # Scanner uses a custom page (PR 2) — all fields deferred
     "scanner": frozenset({
-        "interval", "certificate_expiry", "disk_space",
+        "interval", "adaptive_enabled", "adaptive_fast_factor",
+        "adaptive_recovery_scans", "certificate_expiry", "disk_space",
         "ha_health", "docker_health",
     }),
 }

--- a/tests/test_scanner/test_base.py
+++ b/tests/test_scanner/test_base.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import asyncio
+from typing import Any
 from unittest.mock import MagicMock
 
 import pytest
@@ -20,11 +21,16 @@ class _StubScanner(ScannerIngestAdapter):
         interval: int = 1,
         events: list[Event] | None = None,
         error: Exception | None = None,
+        **kwargs: Any,
     ) -> None:
-        super().__init__(queue, interval)
+        super().__init__(queue, interval, **kwargs)
         self._events_to_return = events or []
         self._error = error
         self.scan_count = 0
+
+    def set_events(self, events: list[Event]) -> None:
+        """Update events returned by subsequent scans."""
+        self._events_to_return = events
 
     @property
     def name(self) -> str:
@@ -139,3 +145,119 @@ class TestScannerBase:
         # Should not raise
         scanner._enqueue(event)
         queue.put_nowait.assert_called_once_with(event)
+
+
+# ---------------------------------------------------------------------------
+# Adaptive interval tests
+# ---------------------------------------------------------------------------
+
+
+class TestAdaptiveIntervals:
+    def test_effective_interval_normal(self) -> None:
+        """Without issues, effective interval equals configured interval."""
+        scanner = _StubScanner(_mock_queue(), interval=900)
+        assert scanner._effective_interval == 900
+
+    def test_effective_interval_fast_mode(self) -> None:
+        """After detecting issues, interval is reduced by fast factor."""
+        scanner = _StubScanner(
+            _mock_queue(), interval=900,
+            adaptive_enabled=True, adaptive_fast_factor=0.25,
+        )
+        scanner._adapted = True
+        assert scanner._effective_interval == 225
+
+    def test_effective_interval_minimum_60(self) -> None:
+        """Fast mode interval is clamped to at least 60 seconds."""
+        scanner = _StubScanner(
+            _mock_queue(), interval=100,
+            adaptive_enabled=True, adaptive_fast_factor=0.1,
+        )
+        scanner._adapted = True
+        # 100 * 0.1 = 10, but should be clamped to 60
+        assert scanner._effective_interval == 60
+
+    def test_adaptive_disabled(self) -> None:
+        """When adaptive is disabled, interval never changes."""
+        scanner = _StubScanner(
+            _mock_queue(), interval=900,
+            adaptive_enabled=False,
+        )
+        warning_event = _make_event(severity=Severity.WARNING)
+        scanner._update_adaptive_state([warning_event])
+        assert scanner._effective_interval == 900
+        assert scanner._adapted is False
+
+    def test_warning_event_enters_fast_mode(self) -> None:
+        """WARNING+ events should trigger fast mode."""
+        scanner = _StubScanner(_mock_queue(), interval=900)
+        warning_event = _make_event(severity=Severity.WARNING)
+        scanner._update_adaptive_state([warning_event])
+        assert scanner._adapted is True
+        assert scanner._consecutive_clean == 0
+
+    def test_info_event_does_not_enter_fast_mode(self) -> None:
+        """INFO events (recovery) should not trigger fast mode."""
+        scanner = _StubScanner(_mock_queue(), interval=900)
+        info_event = _make_event(severity=Severity.INFO)
+        scanner._update_adaptive_state([info_event])
+        assert scanner._adapted is False
+
+    def test_clean_scans_restore_normal(self) -> None:
+        """After enough clean scans, fast mode is exited."""
+        scanner = _StubScanner(
+            _mock_queue(), interval=900,
+            adaptive_recovery_scans=3,
+        )
+        # Enter fast mode
+        warning_event = _make_event(severity=Severity.WARNING)
+        scanner._update_adaptive_state([warning_event])
+        assert scanner._adapted is True
+
+        # 2 clean scans — still in fast mode
+        scanner._update_adaptive_state([])
+        assert scanner._adapted is True
+        assert scanner._consecutive_clean == 1
+        scanner._update_adaptive_state([])
+        assert scanner._adapted is True
+        assert scanner._consecutive_clean == 2
+
+        # 3rd clean scan — exits fast mode
+        scanner._update_adaptive_state([])
+        assert scanner._adapted is False
+        assert scanner._consecutive_clean == 0
+
+    def test_issue_during_recovery_resets_count(self) -> None:
+        """A new issue during recovery resets the clean scan counter."""
+        scanner = _StubScanner(
+            _mock_queue(), interval=900,
+            adaptive_recovery_scans=3,
+        )
+        warning_event = _make_event(severity=Severity.WARNING)
+
+        # Enter fast mode and start recovering
+        scanner._update_adaptive_state([warning_event])
+        scanner._update_adaptive_state([])  # clean 1
+        scanner._update_adaptive_state([])  # clean 2
+
+        # New issue resets counter
+        scanner._update_adaptive_state([warning_event])
+        assert scanner._adapted is True
+        assert scanner._consecutive_clean == 0
+
+    def test_error_severity_enters_fast_mode(self) -> None:
+        """ERROR severity should also trigger fast mode."""
+        scanner = _StubScanner(_mock_queue(), interval=900)
+        error_event = _make_event(severity=Severity.ERROR)
+        scanner._update_adaptive_state([error_event])
+        assert scanner._adapted is True
+
+    def test_mixed_info_and_warning_enters_fast_mode(self) -> None:
+        """If any event is WARNING+, fast mode is triggered."""
+        scanner = _StubScanner(_mock_queue(), interval=900)
+        events = [
+            _make_event(severity=Severity.INFO),
+            _make_event(severity=Severity.WARNING),
+        ]
+        scanner._update_adaptive_state(events)
+        assert scanner._adapted is True


### PR DESCRIPTION
## Summary
- Scanners automatically shorten their polling interval after detecting WARNING+ severity events, then restore normal interval after consecutive clean scans
- Three new `ScannerConfig` fields: `adaptive_enabled` (default `true`), `adaptive_fast_factor` (default `0.25`, so 900s → 225s), `adaptive_recovery_scans` (default `3`)
- Logic lives in `ScannerIngestAdapter` base class — all 4 existing scanners benefit without scanner-specific code changes
- Logs at INFO when entering/exiting fast mode with old→new interval

## Test plan
- [x] `ruff check .` — zero errors
- [x] `pytest --tb=short -q` — 1760 tests passing
- [x] New tests: 9 adaptive interval tests covering fast mode entry, exit, minimum clamp, disabled mode, recovery counter reset, mixed severity
- [ ] Manual: enable a scanner with short interval, trigger an issue, verify fast mode logged

🤖 Generated with [Claude Code](https://claude.com/claude-code)