### PR TITLE
Add backup freshness scanner (#64)

### DIFF
--- a/config.example.yaml
+++ b/config.example.yaml
@@ -243,6 +243,26 @@ scanner:
     ignore_containers: []          # Container names to skip (e.g., ["temp-builder"])
     interval: 900                  # Check interval (seconds); min 60
 
+  # Backup freshness — detects stale backups from PBS or local files
+  backup_freshness:
+    enabled: false
+    interval: 3600                 # Check interval (seconds); min 60
+    sources:
+      # Proxmox Backup Server example
+      - name: pbs-nightly
+        type: pbs
+        url: https://pbs.example.com:8007
+        token_id: "${PBS_TOKEN_ID:-}"
+        token_secret: "${PBS_TOKEN_SECRET:-}"
+        datastore: backups
+        verify_ssl: false
+        max_age_hours: 26          # Just over 1 day — allows for scheduling drift
+      # Local file example (glob pattern)
+      - name: local-tarball
+        type: file
+        path: /backup/daily/*.tar.gz
+        max_age_hours: 26
+
 # -----------------------------------------------------------------------------
 # LLM — Language model configuration
 # OasisAgent is provider-agnostic. Any OpenAI-compatible endpoint works:

--- a/oasisagent/config.py
+++ b/oasisagent/config.py
@@ -477,6 +477,35 @@ class DockerHealthCheckConfig(BaseModel):
     interval: Annotated[int, Field(ge=60)] = 900
 
 
+class BackupSourceConfig(BaseModel):
+    """Configuration for a single backup source to monitor."""
+
+    model_config = ConfigDict(extra="forbid")
+
+    name: str
+    type: Literal["pbs", "file"]
+    # PBS fields
+    url: str = ""
+    token_id: str = ""
+    token_secret: str = ""
+    datastore: str = ""
+    verify_ssl: bool = True
+    # File fields
+    path: str = ""  # glob pattern, e.g. "/backup/daily/*.tar.gz"
+    # Common
+    max_age_hours: int = 26  # just over 1 day
+
+
+class BackupFreshnessCheckConfig(BaseModel):
+    """Backup freshness scanner configuration."""
+
+    model_config = ConfigDict(extra="forbid")
+
+    enabled: bool = False
+    interval: Annotated[int, Field(ge=60)] = 3600
+    sources: list[BackupSourceConfig] = Field(default_factory=list)
+
+
 class ScannerConfig(BaseModel):
     """Preventive scanning framework configuration."""
 
@@ -491,6 +520,9 @@ class ScannerConfig(BaseModel):
     disk_space: DiskSpaceCheckConfig = Field(default_factory=DiskSpaceCheckConfig)
     ha_health: HaHealthCheckConfig = Field(default_factory=HaHealthCheckConfig)
     docker_health: DockerHealthCheckConfig = Field(default_factory=DockerHealthCheckConfig)
+    backup_freshness: BackupFreshnessCheckConfig = Field(
+        default_factory=BackupFreshnessCheckConfig,
+    )
 
 
 # -- Ingestion (top-level) --------------------------------------------------

--- a/oasisagent/orchestrator.py
+++ b/oasisagent/orchestrator.py
@@ -465,6 +465,17 @@ class Orchestrator:
                     docker_config=cfg.handlers.docker,
                     **adaptive_kw,
                 ))
+            if cfg.scanner.backup_freshness.enabled:
+                from oasisagent.scanner.backup_freshness import (
+                    BackupFreshnessScannerAdapter,
+                )
+
+                interval = (
+                    cfg.scanner.backup_freshness.interval or cfg.scanner.interval
+                )
+                self._adapters.append(BackupFreshnessScannerAdapter(
+                    cfg.scanner.backup_freshness, self._queue, interval,
+                ))
 
         # 15. Metrics server (Prometheus)
         if cfg.agent.metrics_port > 0:

--- a/oasisagent/scanner/__init__.py
+++ b/oasisagent/scanner/__init__.py
@@ -5,6 +5,7 @@ their lifecycle alongside other adapters. The ScannerIngestAdapter base
 provides the polling loop and enqueue helper.
 """
 
+from oasisagent.scanner.backup_freshness import BackupFreshnessScannerAdapter
 from oasisagent.scanner.base import ScannerIngestAdapter
 from oasisagent.scanner.cert_expiry import CertExpiryScannerAdapter
 from oasisagent.scanner.disk_space import DiskSpaceScannerAdapter
@@ -12,6 +13,7 @@ from oasisagent.scanner.docker_health import DockerHealthScannerAdapter
 from oasisagent.scanner.ha_health import HaHealthScannerAdapter
 
 __all__ = [
+    "BackupFreshnessScannerAdapter",
     "CertExpiryScannerAdapter",
     "DiskSpaceScannerAdapter",
     "DockerHealthScannerAdapter",

--- a/oasisagent/scanner/backup_freshness.py
+++ b/oasisagent/scanner/backup_freshness.py
@@ -1,0 +1,231 @@
+"""Backup freshness scanner.
+
+Checks backup sources (Proxmox Backup Server API and local file timestamps)
+to detect stale backups. Emits events on state transitions: fresh -> stale,
+stale -> fresh, and on check errors.
+
+Supports two source types:
+- **pbs**: Queries ``GET /api2/json/admin/datastore/{store}/snapshots``
+  on a Proxmox Backup Server instance.
+- **file**: Checks newest file matching a glob pattern against max_age_hours.
+
+Backblaze B2 support is deferred to a future PR.
+"""
+
+from __future__ import annotations
+
+import logging
+import ssl
+import time
+from datetime import UTC, datetime
+from pathlib import Path
+from typing import TYPE_CHECKING, Any
+
+import aiohttp
+
+from oasisagent.models import Event, EventMetadata, Severity
+from oasisagent.scanner.base import ScannerIngestAdapter
+
+if TYPE_CHECKING:
+    from oasisagent.config import BackupFreshnessCheckConfig, BackupSourceConfig
+    from oasisagent.engine.queue import EventQueue
+
+logger = logging.getLogger(__name__)
+
+
+class _PbsChecker:
+    """Checks backup freshness against a Proxmox Backup Server API."""
+
+    def __init__(self, source: BackupSourceConfig) -> None:
+        self._url = source.url.rstrip("/")
+        self._token_id = source.token_id
+        self._token_secret = source.token_secret
+        self._datastore = source.datastore
+        self._verify_ssl = source.verify_ssl
+
+    async def newest_backup_age_hours(self) -> float:
+        """Return hours since the newest backup in the datastore.
+
+        Raises on API errors so the caller can emit check_error events.
+        """
+        ssl_ctx: ssl.SSLContext | bool = (
+            ssl.create_default_context() if self._verify_ssl else False
+        )
+        url = (
+            f"{self._url}/api2/json/admin/datastore"
+            f"/{self._datastore}/snapshots"
+        )
+        headers = {
+            "Authorization": (
+                f"PBSAPIToken={self._token_id}:{self._token_secret}"
+            ),
+        }
+        async with (
+            aiohttp.ClientSession() as session,
+            session.get(url, headers=headers, ssl=ssl_ctx) as resp,
+        ):
+            resp.raise_for_status()
+            data: dict[str, Any] = await resp.json()
+
+        snapshots = data.get("data", [])
+        if not snapshots:
+            msg = f"No snapshots found in datastore '{self._datastore}'"
+            raise ValueError(msg)
+
+        newest_epoch = max(s["backup-time"] for s in snapshots)
+        age_seconds = time.time() - newest_epoch
+        return age_seconds / 3600.0
+
+
+class _FileChecker:
+    """Checks backup freshness by file modification time."""
+
+    def __init__(self, source: BackupSourceConfig) -> None:
+        self._pattern = source.path
+
+    def newest_backup_age_hours(self) -> float:
+        """Return hours since the newest file matching the glob pattern.
+
+        Raises FileNotFoundError if no files match.
+        """
+        p = Path(self._pattern)
+        parent = p.parent
+        pattern = p.name
+        matches = list(parent.glob(pattern))
+        if not matches:
+            msg = f"No files match pattern '{self._pattern}'"
+            raise FileNotFoundError(msg)
+
+        newest_mtime = max(f.stat().st_mtime for f in matches)
+        age_seconds = time.time() - newest_mtime
+        return age_seconds / 3600.0
+
+
+class BackupFreshnessScannerAdapter(ScannerIngestAdapter):
+    """Scanner that checks backup freshness across configured sources.
+
+    State-based dedup: only emits events on transitions (fresh -> stale,
+    stale -> fresh). API errors do not clear stale state.
+    """
+
+    def __init__(
+        self,
+        config: BackupFreshnessCheckConfig,
+        queue: EventQueue,
+        interval: int,
+        **kwargs: Any,
+    ) -> None:
+        super().__init__(queue, interval, **kwargs)
+        self._config = config
+        self._stale_sources: set[str] = set()
+        self._error_sources: set[str] = set()
+
+    @property
+    def name(self) -> str:
+        return "scanner.backup_freshness"
+
+    async def _scan(self) -> list[Event]:
+        """Check all backup sources and return events for state transitions."""
+        events: list[Event] = []
+        for source in self._config.sources:
+            try:
+                age_hours = await self._check_source(source)
+                events.extend(self._evaluate(source, age_hours))
+                self._error_sources.discard(source.name)
+            except Exception as exc:
+                logger.warning(
+                    "Backup check failed for %s: %s", source.name, exc,
+                )
+                events.extend(self._emit_check_error(source, exc))
+        return events
+
+    async def _check_source(self, source: BackupSourceConfig) -> float:
+        """Return hours since newest backup for the given source."""
+        if source.type == "pbs":
+            checker = _PbsChecker(source)
+            return await checker.newest_backup_age_hours()
+        # file
+        checker_file = _FileChecker(source)
+        return checker_file.newest_backup_age_hours()
+
+    def _evaluate(
+        self, source: BackupSourceConfig, age_hours: float,
+    ) -> list[Event]:
+        """Evaluate age against threshold, emit on state change."""
+        is_stale = age_hours > source.max_age_hours
+        was_stale = source.name in self._stale_sources
+        now = datetime.now(tz=UTC)
+
+        if is_stale and not was_stale:
+            self._stale_sources.add(source.name)
+            return [Event(
+                source=self.name,
+                system="backup",
+                event_type="backup_stale",
+                entity_id=source.name,
+                severity=Severity.WARNING,
+                timestamp=now,
+                payload={
+                    "source_type": source.type,
+                    "age_hours": round(age_hours, 1),
+                    "max_age_hours": source.max_age_hours,
+                },
+                metadata=EventMetadata(
+                    dedup_key=(
+                        f"scanner.backup_freshness:{source.name}"
+                    ),
+                ),
+            )]
+
+        if not is_stale and was_stale:
+            self._stale_sources.discard(source.name)
+            return [Event(
+                source=self.name,
+                system="backup",
+                event_type="backup_recovered",
+                entity_id=source.name,
+                severity=Severity.INFO,
+                timestamp=now,
+                payload={
+                    "source_type": source.type,
+                    "age_hours": round(age_hours, 1),
+                    "max_age_hours": source.max_age_hours,
+                },
+                metadata=EventMetadata(
+                    dedup_key=(
+                        f"scanner.backup_freshness:{source.name}"
+                    ),
+                ),
+            )]
+
+        return []
+
+    def _emit_check_error(
+        self, source: BackupSourceConfig, exc: Exception,
+    ) -> list[Event]:
+        """Emit an error event when the backup check itself fails.
+
+        API failures must NOT clear stale state (D4).
+        """
+        if source.name in self._error_sources:
+            return []
+        self._error_sources.add(source.name)
+
+        return [Event(
+            source=self.name,
+            system="backup",
+            event_type="backup_check_error",
+            entity_id=source.name,
+            severity=Severity.ERROR,
+            timestamp=datetime.now(tz=UTC),
+            payload={
+                "source_type": source.type,
+                "error": str(exc),
+                "error_type": type(exc).__name__,
+            },
+            metadata=EventMetadata(
+                dedup_key=(
+                    f"scanner.backup_freshness:{source.name}:error"
+                ),
+            ),
+        )]

--- a/oasisagent/ui/form_specs.py
+++ b/oasisagent/ui/form_specs.py
@@ -931,7 +931,7 @@ DEFERRED_FIELDS: dict[str, frozenset[str]] = {
     "scanner": frozenset({
         "interval", "adaptive_enabled", "adaptive_fast_factor",
         "adaptive_recovery_scans", "certificate_expiry", "disk_space",
-        "ha_health", "docker_health",
+        "ha_health", "docker_health", "backup_freshness",
     }),
 }
 

--- a/tests/test_scanner/test_backup_freshness.py
+++ b/tests/test_scanner/test_backup_freshness.py
@@ -1,0 +1,270 @@
+"""Tests for the backup freshness scanner."""
+
+from __future__ import annotations
+
+import time
+from pathlib import Path
+from typing import Any
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from oasisagent.config import BackupFreshnessCheckConfig, BackupSourceConfig
+from oasisagent.models import Severity
+from oasisagent.scanner.backup_freshness import (
+    BackupFreshnessScannerAdapter,
+    _FileChecker,
+)
+
+
+def _make_source(**overrides: Any) -> BackupSourceConfig:
+    defaults: dict[str, Any] = {
+        "name": "test-backup",
+        "type": "file",
+        "path": "/backup/*.tar.gz",
+        "max_age_hours": 26,
+    }
+    defaults.update(overrides)
+    return BackupSourceConfig(**defaults)
+
+
+def _make_pbs_source(**overrides: Any) -> BackupSourceConfig:
+    defaults: dict[str, Any] = {
+        "name": "pbs-nightly",
+        "type": "pbs",
+        "url": "https://pbs.example.com:8007",
+        "token_id": "user@pbs!agent",
+        "token_secret": "secret-token",
+        "datastore": "backups",
+        "verify_ssl": False,
+        "max_age_hours": 26,
+    }
+    defaults.update(overrides)
+    return BackupSourceConfig(**defaults)
+
+
+def _make_config(
+    sources: list[BackupSourceConfig] | None = None,
+) -> BackupFreshnessCheckConfig:
+    return BackupFreshnessCheckConfig(
+        enabled=True,
+        interval=60,
+        sources=sources or [_make_source()],
+    )
+
+
+def _mock_queue() -> MagicMock:
+    return MagicMock()
+
+
+def _make_scanner(
+    config: BackupFreshnessCheckConfig | None = None,
+    queue: MagicMock | None = None,
+) -> BackupFreshnessScannerAdapter:
+    return BackupFreshnessScannerAdapter(
+        config=config or _make_config(),
+        queue=queue or _mock_queue(),
+        interval=60,
+    )
+
+
+# ---------------------------------------------------------------------------
+# Config validation
+# ---------------------------------------------------------------------------
+
+
+class TestBackupFreshnessConfig:
+    def test_defaults(self) -> None:
+        cfg = BackupFreshnessCheckConfig()
+        assert cfg.enabled is False
+        assert cfg.interval == 3600
+        assert cfg.sources == []
+
+    def test_minimum_interval(self) -> None:
+        from pydantic import ValidationError
+
+        with pytest.raises(ValidationError):
+            BackupFreshnessCheckConfig(interval=10)
+
+    def test_source_types(self) -> None:
+        pbs = _make_pbs_source()
+        assert pbs.type == "pbs"
+        file_src = _make_source()
+        assert file_src.type == "file"
+
+
+# ---------------------------------------------------------------------------
+# Scanner basics
+# ---------------------------------------------------------------------------
+
+
+class TestScannerBasics:
+    def test_name(self) -> None:
+        scanner = _make_scanner()
+        assert scanner.name == "scanner.backup_freshness"
+
+
+# ---------------------------------------------------------------------------
+# State-based dedup (evaluate logic)
+# ---------------------------------------------------------------------------
+
+
+class TestEvaluateLogic:
+    def test_fresh_first_scan_no_event(self) -> None:
+        scanner = _make_scanner()
+        source = _make_source()
+        events = scanner._evaluate(source, 10.0)
+        assert events == []
+
+    def test_stale_first_scan_emits(self) -> None:
+        scanner = _make_scanner()
+        source = _make_source(max_age_hours=26)
+        events = scanner._evaluate(source, 30.0)
+        assert len(events) == 1
+        assert events[0].event_type == "backup_stale"
+        assert events[0].severity == Severity.WARNING
+        assert events[0].payload["age_hours"] == 30.0
+        assert events[0].payload["max_age_hours"] == 26
+
+    def test_stale_dedup(self) -> None:
+        scanner = _make_scanner()
+        source = _make_source(max_age_hours=26)
+        scanner._evaluate(source, 30.0)
+        events = scanner._evaluate(source, 35.0)
+        assert events == []  # still stale, no new event
+
+    def test_stale_to_fresh_recovery(self) -> None:
+        scanner = _make_scanner()
+        source = _make_source(max_age_hours=26)
+        scanner._evaluate(source, 30.0)  # stale
+        events = scanner._evaluate(source, 1.0)  # fresh
+        assert len(events) == 1
+        assert events[0].event_type == "backup_recovered"
+        assert events[0].severity == Severity.INFO
+
+    def test_dedup_key_includes_source_name(self) -> None:
+        scanner = _make_scanner()
+        source = _make_source(name="my-backup", max_age_hours=26)
+        events = scanner._evaluate(source, 30.0)
+        assert "scanner.backup_freshness:my-backup" in (
+            events[0].metadata.dedup_key
+        )
+
+    def test_multiple_sources_independent(self) -> None:
+        s1 = _make_source(name="src-a", max_age_hours=26)
+        s2 = _make_source(name="src-b", max_age_hours=26)
+        scanner = _make_scanner(config=_make_config(sources=[s1, s2]))
+        events_a = scanner._evaluate(s1, 30.0)  # stale
+        events_b = scanner._evaluate(s2, 10.0)  # fresh
+        assert len(events_a) == 1
+        assert len(events_b) == 0
+
+
+# ---------------------------------------------------------------------------
+# Error handling
+# ---------------------------------------------------------------------------
+
+
+class TestErrorHandling:
+    def test_check_error_emits_once(self) -> None:
+        scanner = _make_scanner()
+        source = _make_source()
+        err = RuntimeError("connection refused")
+        events1 = scanner._emit_check_error(source, err)
+        events2 = scanner._emit_check_error(source, err)
+        assert len(events1) == 1
+        assert len(events2) == 0
+        assert events1[0].event_type == "backup_check_error"
+        assert events1[0].severity == Severity.ERROR
+
+    def test_error_does_not_clear_stale_state(self) -> None:
+        """D4: API failure must NOT clear stale state."""
+        scanner = _make_scanner()
+        source = _make_source(max_age_hours=26)
+        scanner._evaluate(source, 30.0)  # mark as stale
+        scanner._emit_check_error(source, RuntimeError("timeout"))
+        # Source should still be in stale set
+        assert source.name in scanner._stale_sources
+
+    def test_error_clears_on_successful_check(self) -> None:
+        scanner = _make_scanner()
+        source = _make_source()
+        scanner._emit_check_error(source, RuntimeError("timeout"))
+        assert source.name in scanner._error_sources
+        # Simulate successful scan clearing error state
+        scanner._error_sources.discard(source.name)
+        assert source.name not in scanner._error_sources
+
+
+# ---------------------------------------------------------------------------
+# File checker
+# ---------------------------------------------------------------------------
+
+
+class TestFileChecker:
+    def test_no_matching_files(self, tmp_path: Path) -> None:
+        source = _make_source(path=str(tmp_path / "*.tar.gz"))
+        checker = _FileChecker(source)
+        with pytest.raises(FileNotFoundError, match="No files match"):
+            checker.newest_backup_age_hours()
+
+    def test_newest_file_age(self, tmp_path: Path) -> None:
+        # Create a file with recent mtime
+        f = tmp_path / "backup.tar.gz"
+        f.write_text("data")
+        source = _make_source(path=str(tmp_path / "*.tar.gz"))
+        checker = _FileChecker(source)
+        age = checker.newest_backup_age_hours()
+        assert age < 0.01  # just created
+
+    def test_picks_newest_file(self, tmp_path: Path) -> None:
+        old_file = tmp_path / "old.tar.gz"
+        old_file.write_text("old")
+        # Set mtime to 48 hours ago
+        old_mtime = time.time() - 48 * 3600
+        import os
+
+        os.utime(old_file, (old_mtime, old_mtime))
+
+        new_file = tmp_path / "new.tar.gz"
+        new_file.write_text("new")
+
+        source = _make_source(path=str(tmp_path / "*.tar.gz"))
+        checker = _FileChecker(source)
+        age = checker.newest_backup_age_hours()
+        assert age < 0.01  # should pick the newest file
+
+
+# ---------------------------------------------------------------------------
+# Full scan cycle (mocked)
+# ---------------------------------------------------------------------------
+
+
+class TestFullScan:
+    @pytest.mark.asyncio
+    async def test_scan_calls_check_and_evaluates(self) -> None:
+        source = _make_source(max_age_hours=26)
+        scanner = _make_scanner(config=_make_config(sources=[source]))
+
+        with patch.object(
+            scanner, "_check_source", new_callable=AsyncMock,
+        ) as mock_check:
+            mock_check.return_value = 30.0  # stale
+            events = await scanner._scan()
+
+        assert len(events) == 1
+        assert events[0].event_type == "backup_stale"
+
+    @pytest.mark.asyncio
+    async def test_scan_handles_check_error(self) -> None:
+        source = _make_source()
+        scanner = _make_scanner(config=_make_config(sources=[source]))
+
+        with patch.object(
+            scanner, "_check_source", new_callable=AsyncMock,
+        ) as mock_check:
+            mock_check.side_effect = RuntimeError("connection refused")
+            events = await scanner._scan()
+
+        assert len(events) == 1
+        assert events[0].event_type == "backup_check_error"


### PR DESCRIPTION
## Summary
- New `BackupFreshnessScannerAdapter` checks backup sources for staleness and emits events on state transitions (fresh → stale, stale → fresh)
- Two source types: **PBS** (Proxmox Backup Server API) and **file** (local glob pattern + mtime)
- State-based dedup: only fires on transitions, not every scan
- API errors preserve stale state (D4 design constraint) — a failed check never clears a stale alert
- Config: `BackupSourceConfig` + `BackupFreshnessCheckConfig` with per-source `max_age_hours` (default 26h)
- Backblaze B2 deferred to separate PR

## Test plan
- [x] `ruff check .` — zero errors
- [x] `pytest --tb=short -q` — 1768 tests passing
- [x] 18 new tests: config validation, evaluate logic (fresh/stale/dedup/recovery/multi-source), error handling (dedup, D4 stale preservation), file checker (no match, age, newest), full scan cycle (mocked)
- [ ] Manual: configure with file source pointing to a real backup dir, verify events

🤖 Generated with [Claude Code](https://claude.com/claude-code)