### PR TITLE
Bump version to 0.3.5 for preventive scanning milestone

### DIFF
--- a/oasisagent/__init__.py
+++ b/oasisagent/__init__.py
@@ -1,3 +1,3 @@
 """OasisAgent — Autonomous infrastructure operations agent for home labs."""
 
-__version__ = "0.1.0"
+__version__ = "0.3.5"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "oasisagent"
-version = "0.3.4"
+version = "0.3.5"
 description = "Autonomous infrastructure operations agent for home labs"
 readme = "README.md"
 license = "MIT"


### PR DESCRIPTION
## Summary

- Bump version in `pyproject.toml` and `oasisagent/__init__.py` from 0.3.4 → 0.3.5
- Sync `__init__.py` version (was stuck at 0.1.0)
- Closes v0.3.4 preventive scanning milestone (#64)

### What shipped in v0.3.4 → v0.3.5
| PR | Feature |
|----|---------|
| #97 | Scanner framework + cert/disk scanners |
| #98 | Uptime Kuma client + adapter |
| #100 | HA + Docker health scanners |
| #102, #103 | Scanner config UI |
| #116 | Adaptive scanner intervals |
| #117 | Certificate dedup normalization |
| #118 | Backup freshness scanner |
| #121 | Known fixes + MQTT retry fix |
| #123 | Live health indicators |

## Test plan

- [x] `ruff check .` — zero errors
- [x] `pytest` — 1830 tests passing

🤖 Generated with [Claude Code](https://claude.com/claude-code)