### PR TITLE
Add MQTT mid-session disconnect recovery

### DIFF
--- a/oasisagent/notifications/mqtt.py
+++ b/oasisagent/notifications/mqtt.py
@@ -49,18 +49,24 @@ class MqttNotificationChannel(NotificationChannel):
         return self._client is not None
 
     async def _connect(self) -> None:
-        """Attempt a single connection to the MQTT broker."""
+        """Attempt a single connection to the MQTT broker.
+
+        Assigns ``_client`` only after the connection is fully established
+        to avoid a TOCTOU window where ``healthy()`` returns True for
+        an unconnected client.
+        """
         parsed = urlparse(self._config.broker)
         hostname = parsed.hostname or "localhost"
         port = parsed.port or 1883
 
-        self._client = aiomqtt.Client(
+        client = aiomqtt.Client(
             hostname=hostname,
             port=port,
             username=self._config.username or None,
             password=self._config.password or None,
         )
-        await self._client.__aenter__()
+        await client.__aenter__()
+        self._client = client
 
     async def _reconnect_loop(self) -> None:
         """Background retry loop — connects with exponential backoff."""
@@ -73,7 +79,7 @@ class MqttNotificationChannel(NotificationChannel):
             try:
                 await self._connect()
                 logger.info(
-                    "MQTT notification channel connected (broker=%s, prefix=%s)",
+                    "MQTT notification channel reconnected (broker=%s, prefix=%s)",
                     self._config.broker,
                     self._config.topic_prefix,
                 )
@@ -87,6 +93,23 @@ class MqttNotificationChannel(NotificationChannel):
                     exc,
                     backoff,
                 )
+
+    def _trigger_reconnect(self) -> None:
+        """Tear down the dead client and spawn a background reconnect task.
+
+        Safe to call multiple times — skips if a reconnect is already running
+        or if the channel is shutting down.
+        """
+        self._client = None
+        if self._stopping:
+            return
+        if self._reconnect_task is not None and not self._reconnect_task.done():
+            return
+        logger.info("MQTT notification channel: scheduling background reconnect")
+        self._reconnect_task = asyncio.create_task(
+            self._reconnect_loop(),
+            name="mqtt-notification-reconnect",
+        )
 
     async def start(self) -> None:
         """Connect to the MQTT broker.
@@ -151,7 +174,7 @@ class MqttNotificationChannel(NotificationChannel):
         """
         if self._client is None:
             logger.warning(
-                "MQTT channel not started — cannot publish to %s", topic
+                "MQTT channel not connected — cannot publish to %s", topic
             )
             return False
 
@@ -166,6 +189,7 @@ class MqttNotificationChannel(NotificationChannel):
             return True
         except Exception as exc:
             logger.warning("MQTT raw publish failed for %s: %s", topic, exc)
+            self._trigger_reconnect()
             return False
 
     async def send(self, notification: Notification) -> bool:
@@ -181,7 +205,7 @@ class MqttNotificationChannel(NotificationChannel):
 
         if self._client is None:
             logger.warning(
-                "MQTT notification channel not started — dropping notification %s",
+                "MQTT notification channel not connected — dropping notification %s",
                 notification.id,
             )
             return False
@@ -208,4 +232,5 @@ class MqttNotificationChannel(NotificationChannel):
                 notification.id,
                 exc,
             )
+            self._trigger_reconnect()
             return False

--- a/tests/test_notifications.py
+++ b/tests/test_notifications.py
@@ -6,6 +6,8 @@ import asyncio
 from typing import Any
 from unittest.mock import AsyncMock, MagicMock, patch
 
+import pytest
+
 from oasisagent.config import MqttNotificationConfig
 from oasisagent.models import Notification, Severity
 from oasisagent.notifications.base import NotificationChannel
@@ -266,6 +268,49 @@ class TestMqttErrors:
 
         assert result is False
 
+    async def test_send_failure_triggers_reconnect(self) -> None:
+        """Mid-session publish failure should spawn a reconnect task."""
+        channel = _mock_mqtt_channel()
+        channel._client.publish.side_effect = Exception("broker dropped")
+
+        result = await channel.send(_make_notification())
+
+        assert result is False
+        assert channel._client is None
+        assert channel._reconnect_task is not None
+        assert not channel._reconnect_task.done()
+
+        await channel.stop()
+
+    async def test_publish_raw_failure_triggers_reconnect(self) -> None:
+        """Mid-session raw publish failure should spawn a reconnect task."""
+        channel = _mock_mqtt_channel()
+        channel._client.publish.side_effect = Exception("broker dropped")
+
+        result = await channel.publish_raw("topic", "payload")
+
+        assert result is False
+        assert channel._client is None
+        assert channel._reconnect_task is not None
+
+        await channel.stop()
+
+    async def test_duplicate_reconnect_not_spawned(self) -> None:
+        """Multiple publish failures should not spawn duplicate reconnect tasks."""
+        channel = _mock_mqtt_channel()
+        channel._client.publish.side_effect = Exception("broker dropped")
+
+        await channel.send(_make_notification())
+        first_task = channel._reconnect_task
+
+        # Second failure — client is None so send returns False early
+        # without spawning another task
+        await channel.send(_make_notification())
+
+        assert channel._reconnect_task is first_task
+
+        await channel.stop()
+
 
 # ---------------------------------------------------------------------------
 # MQTT channel: lifecycle
@@ -330,6 +375,23 @@ class TestMqttLifecycle:
         await channel.stop()
 
         assert channel._reconnect_task is None
+
+    @patch("oasisagent.notifications.mqtt.aiomqtt.Client")
+    async def test_connect_does_not_assign_client_on_failure(
+        self, mock_cls: MagicMock,
+    ) -> None:
+        """_connect() should not leave _client set if __aenter__ raises."""
+        mock_instance = AsyncMock()
+        mock_instance.__aenter__ = AsyncMock(
+            side_effect=ConnectionRefusedError("refused"),
+        )
+        mock_cls.return_value = mock_instance
+
+        channel = MqttNotificationChannel(_make_config())
+        with pytest.raises(ConnectionRefusedError):
+            await channel._connect()
+
+        assert channel._client is None
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

- `send()` and `publish_raw()` now call `_trigger_reconnect()` on publish failure — tears down the dead client and spawns a background reconnect task with exponential backoff
- `_trigger_reconnect()` is idempotent — safe to call multiple times, skips if a reconnect is already in progress or channel is shutting down
- Fixed TOCTOU in `_connect()`: `_client` is now assigned only **after** `__aenter__` succeeds, so `healthy()` never returns True for an unconnected client
- Log messages updated: "not started" → "not connected" for clarity

Fixes #128

## Test plan

- [x] `ruff check .` — zero errors
- [x] `pytest` — 1836 tests passing (4 new)
- [ ] Deploy, kill MQTT broker mid-session → health badge should flip to Disconnected, channel should reconnect when broker returns
- [ ] Multiple rapid publish failures should not spawn duplicate reconnect tasks

🤖 Generated with [Claude Code](https://claude.com/claude-code)