### PR TITLE
Import YAML config into SQLite on virgin DB

### DIFF
--- a/oasisagent/db/config_store.py
+++ b/oasisagent/db/config_store.py
@@ -98,6 +98,141 @@ class ConfigStore:
         return True
 
     # ------------------------------------------------------------------
+    # YAML → SQLite import (one-way door for virgin databases)
+    # ------------------------------------------------------------------
+
+    async def import_yaml(self, config: OasisAgentConfig) -> None:
+        """Seed SQLite from a parsed YAML config.
+
+        Imports all enabled connectors, services, and notification channels
+        into the database so the orchestrator and UI share a single source
+        of truth.  Only call this on a virgin database — once rows exist
+        the YAML is permanently ignored.
+        """
+        async with self.transaction():
+            # --- Agent config ---
+            agent = config.agent
+            await self._db.execute(
+                "UPDATE agent_config SET name=?, log_level=?, "
+                "event_queue_size=?, dedup_window_seconds=?, "
+                "shutdown_timeout=?, event_ttl=?, known_fixes_dir=?, "
+                "correlation_window=?, metrics_port=? WHERE id=1",
+                (
+                    agent.name, agent.log_level,
+                    agent.event_queue_size, agent.dedup_window_seconds,
+                    agent.shutdown_timeout, agent.event_ttl,
+                    agent.known_fixes_dir, agent.correlation_window,
+                    agent.metrics_port,
+                ),
+            )
+
+            # --- Connectors ---
+            connector_map: list[tuple[str, str, Any]] = [
+                ("mqtt", "mqtt", config.ingestion.mqtt),
+                ("ha_websocket", "ha-websocket", config.ingestion.ha_websocket),
+                ("ha_log_poller", "ha-log-poller", config.ingestion.ha_log_poller),
+                ("unifi", "unifi", config.ingestion.unifi),
+                ("cloudflare", "cloudflare", config.ingestion.cloudflare),
+                ("uptime_kuma", "uptime-kuma", config.ingestion.uptime_kuma),
+            ]
+            for type_name, default_name, sub_cfg in connector_map:
+                if sub_cfg.enabled:
+                    await self._create_row(
+                        "connectors", type_name, default_name,
+                        sub_cfg.model_dump(),
+                    )
+            # http_poller: multi-row
+            for i, target in enumerate(config.ingestion.http_poller_targets):
+                name = target.system or f"http-poller-{i}"
+                await self._create_row(
+                    "connectors", "http_poller", name,
+                    target.model_dump(),
+                )
+
+            # --- Core services ---
+            # LLM endpoints have no `enabled` flag — always import
+            await self._create_row(
+                "core_services", "llm_triage", "llm-triage",
+                config.llm.triage.model_dump(),
+            )
+            await self._create_row(
+                "core_services", "llm_reasoning", "llm-reasoning",
+                config.llm.reasoning.model_dump(),
+            )
+            await self._create_row(
+                "core_services", "llm_options", "llm-options",
+                config.llm.options.model_dump(),
+            )
+
+            # Handlers + audit — only import if enabled
+            service_map: list[tuple[str, str, Any]] = [
+                ("ha_handler", "ha-handler", config.handlers.homeassistant),
+                ("docker_handler", "docker-handler", config.handlers.docker),
+                ("portainer_handler", "portainer-handler", config.handlers.portainer),
+                ("proxmox_handler", "proxmox-handler", config.handlers.proxmox),
+                ("unifi_handler", "unifi-handler", config.handlers.unifi),
+                ("cloudflare_handler", "cloudflare-handler", config.handlers.cloudflare),
+                ("influxdb", "influxdb", config.audit.influxdb),
+            ]
+            for type_name, default_name, sub_cfg in service_map:
+                if sub_cfg.enabled:
+                    await self._create_row(
+                        "core_services", type_name, default_name,
+                        sub_cfg.model_dump(),
+                    )
+
+            # Guardrails + circuit breaker
+            gr = config.guardrails
+            gr_dict = gr.model_dump(exclude={"circuit_breaker"})
+            await self._create_row(
+                "core_services", "guardrails", "guardrails", gr_dict,
+            )
+            await self._create_row(
+                "core_services", "circuit_breaker", "circuit-breaker",
+                gr.circuit_breaker.model_dump(),
+            )
+
+            # Scanner (if any check is enabled)
+            sc = config.scanner
+            if any([
+                sc.certificate_expiry.enabled,
+                sc.disk_space.enabled,
+                sc.ha_health.enabled,
+                sc.docker_health.enabled,
+                sc.backup_freshness.enabled,
+            ]):
+                await self._create_row(
+                    "core_services", "scanner", "scanner",
+                    sc.model_dump(),
+                )
+
+            # --- Notifications ---
+            notif_map: list[tuple[str, str, Any]] = [
+                ("mqtt_notification", "mqtt-notify", config.notifications.mqtt),
+                ("email", "email", config.notifications.email),
+                ("webhook", "webhook", config.notifications.webhook),
+                ("telegram", "telegram", config.notifications.telegram),
+            ]
+            for type_name, default_name, sub_cfg in notif_map:
+                if sub_cfg.enabled:
+                    await self._create_row(
+                        "notification_channels", type_name, default_name,
+                        sub_cfg.model_dump(),
+                    )
+
+        imported = await self._count_imported()
+        logger.info("YAML config imported to SQLite: %s", imported)
+
+    async def _count_imported(self) -> str:
+        """Return a summary string of imported row counts."""
+        counts = []
+        for table in ("connectors", "core_services", "notification_channels"):
+            cursor = await self._db.execute(f"SELECT COUNT(*) FROM {table}")
+            row = await cursor.fetchone()
+            counts.append(f"{table}={row[0]}" if row else f"{table}=0")
+        return ", ".join(counts)
+
+    # ------------------------------------------------------------------
     # Load full config
     # ------------------------------------------------------------------
 

--- a/oasisagent/web/app.py
+++ b/oasisagent/web/app.py
@@ -86,17 +86,18 @@ async def lifespan(app: FastAPI) -> AsyncGenerator[None]:
     db = await run_migrations(data_dir / "oasisagent.db")
     store = ConfigStore(db, crypto)
 
-    # Load config: SQLite or YAML fallback for virgin databases
+    # Load config: SQLite is the single source of truth.
+    # On first run with a virgin DB, import config.yaml into SQLite
+    # so both the orchestrator and the web UI read the same data.
     if await store.is_virgin():
         yaml_path = Path("config.yaml")
         if yaml_path.exists():
-            logger.info("Virgin database — loading config from %s", yaml_path)
-            config = load_config(yaml_path)
+            logger.info("Virgin database — importing %s into SQLite", yaml_path)
+            yaml_config = load_config(yaml_path)
+            await store.import_yaml(yaml_config)
         else:
             logger.info("Virgin database, no config.yaml — using defaults")
-            config = await store.load_config()
-    else:
-        config = await store.load_config()
+    config = await store.load_config()
 
     configure_logging(config)
 

--- a/tests/test_db/test_config_store.py
+++ b/tests/test_db/test_config_store.py
@@ -3,7 +3,7 @@
 from __future__ import annotations
 
 import json
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, Any
 
 import pytest
 
@@ -255,3 +255,149 @@ class TestAgentConfig:
     async def test_update_agent_config_rejects_unknown_fields(self, store: ConfigStore) -> None:
         with pytest.raises(ValueError, match="Unknown fields"):
             await store.update_agent_config({"bogus_field": "nope"})
+
+
+class TestImportYaml:
+    """Tests for YAML → SQLite import on virgin databases."""
+
+    def _make_config(self, **overrides: Any) -> OasisAgentConfig:
+        """Build a minimal config with some enabled components."""
+        from oasisagent.config import (
+            AuditConfig,
+            HandlersConfig,
+            InfluxDbConfig,
+            IngestionConfig,
+            MqttIngestionConfig,
+            MqttNotificationConfig,
+            NotificationsConfig,
+        )
+
+        return OasisAgentConfig(
+            ingestion=IngestionConfig(
+                mqtt=MqttIngestionConfig(
+                    enabled=True,
+                    broker="mqtt://test.local:1883",
+                    password="mqtt-secret",
+                ),
+            ),
+            audit=AuditConfig(
+                influxdb=InfluxDbConfig(
+                    enabled=True,
+                    url="http://influx.local:8086",
+                    token="influx-token",
+                ),
+            ),
+            handlers=HandlersConfig(),
+            notifications=NotificationsConfig(
+                mqtt=MqttNotificationConfig(
+                    enabled=True,
+                    broker="mqtt://test.local:1883",
+                    password="notif-secret",
+                ),
+            ),
+            **overrides,
+        )
+
+    async def test_import_creates_connector_rows(
+        self, store: ConfigStore,
+    ) -> None:
+        config = self._make_config()
+        await store.import_yaml(config)
+
+        rows = await store.list_connectors()
+        type_names = {r["type"] for r in rows}
+        # mqtt, ha_websocket, ha_log_poller all default to enabled=True
+        assert "mqtt" in type_names
+        assert "ha_websocket" in type_names
+        assert "ha_log_poller" in type_names
+
+        mqtt_row = next(r for r in rows if r["type"] == "mqtt")
+        assert mqtt_row["config"]["broker"] == "mqtt://test.local:1883"
+
+    async def test_import_creates_notification_rows(
+        self, store: ConfigStore,
+    ) -> None:
+        config = self._make_config()
+        await store.import_yaml(config)
+
+        rows = await store.list_notifications()
+        assert len(rows) == 1
+        assert rows[0]["type"] == "mqtt_notification"
+        assert rows[0]["config"]["broker"] == "mqtt://test.local:1883"
+
+    async def test_import_creates_service_rows(
+        self, store: ConfigStore,
+    ) -> None:
+        config = self._make_config()
+        await store.import_yaml(config)
+
+        rows = await store.list_services()
+        type_names = {r["type"] for r in rows}
+        # influxdb + llm_options + guardrails + circuit_breaker (always imported)
+        assert "influxdb" in type_names
+        assert "llm_options" in type_names
+        assert "guardrails" in type_names
+        assert "circuit_breaker" in type_names
+
+    async def test_import_secrets_are_encrypted(
+        self, store: ConfigStore, db: aiosqlite.Connection,
+    ) -> None:
+        config = self._make_config()
+        await store.import_yaml(config)
+
+        # Raw DB row should NOT contain plaintext password
+        cursor = await db.execute(
+            "SELECT config_json FROM notification_channels WHERE type = 'mqtt_notification'"
+        )
+        row = await cursor.fetchone()
+        raw = json.loads(row["config_json"])
+        assert "password" not in raw
+
+        # But decrypted read should have it
+        rows = await store.list_notifications()
+        assert rows[0]["config"]["password"] == "notif-secret"
+
+    async def test_import_makes_db_non_virgin(
+        self, store: ConfigStore,
+    ) -> None:
+        config = self._make_config()
+        assert await store.is_virgin() is True
+        await store.import_yaml(config)
+        assert await store.is_virgin() is False
+
+    async def test_roundtrip_yaml_to_sqlite_to_config(
+        self, store: ConfigStore,
+    ) -> None:
+        """Import YAML, then load from SQLite — should produce equivalent config."""
+        original = self._make_config()
+        await store.import_yaml(original)
+
+        loaded = await store.load_config()
+        # MQTT connector
+        assert loaded.ingestion.mqtt.enabled is True
+        assert loaded.ingestion.mqtt.broker == "mqtt://test.local:1883"
+        assert loaded.ingestion.mqtt.password == "mqtt-secret"
+        # MQTT notification
+        assert loaded.notifications.mqtt.enabled is True
+        assert loaded.notifications.mqtt.broker == "mqtt://test.local:1883"
+        assert loaded.notifications.mqtt.password == "notif-secret"
+        # InfluxDB
+        assert loaded.audit.influxdb.enabled is True
+        assert loaded.audit.influxdb.token == "influx-token"
+
+    async def test_disabled_components_not_imported(
+        self, store: ConfigStore,
+    ) -> None:
+        """Components with enabled=False should not create DB rows."""
+        config = self._make_config()
+        await store.import_yaml(config)
+
+        rows = await store.list_services()
+        type_names = {r["type"] for r in rows}
+        # UniFi handler defaults to enabled=False
+        assert "unifi_handler" not in type_names
+
+        conn_rows = await store.list_connectors()
+        conn_types = {r["type"] for r in conn_rows}
+        # Cloudflare adapter defaults to enabled=False
+        assert "cloudflare" not in conn_types


### PR DESCRIPTION
## Summary

- Add `ConfigStore.import_yaml(config)` method that seeds all SQLite tables from a parsed YAML config
- Update lifespan to call `import_yaml()` then always `load_config()` from SQLite — making SQLite the single source of truth from first boot
- Maps all config sections to their DB tables: connectors (7 types), core services (12 types), notification channels (4 types), and agent config
- Handles edge cases: LLM endpoints have no `enabled` flag (always imported), guardrails split into guardrails + circuit_breaker rows, scanner imported only if any check is enabled, http_poller supports multi-row
- Secrets are properly encrypted via `_create_row()` which calls `split_secrets()` + `crypto.encrypt()`
- Entire import runs in a single transaction — atomic commit or rollback

Fixes #131

## Test plan

- [x] `ruff check .` — zero errors
- [x] `pytest` — 1843 tests passing (7 new)
- [ ] Delete `oasisagent.db`, redeploy with `config.yaml` → all components should appear in UI
- [ ] Verify notification channels show up in UI and are functional
- [ ] Second restart should skip import (`is_virgin()` returns False)

🤖 Generated with [Claude Code](https://claude.com/claude-code)