### PR TITLE
Add missing type mappings for v0.3.3 components

### DIFF
--- a/oasisagent/db/config_store.py
+++ b/oasisagent/db/config_store.py
@@ -573,6 +573,13 @@ class ConfigStore:
         else:
             logger.debug("No ha_log_poller row in connectors (types: %s)", list(by_type.keys()))
 
+        if "unifi" in by_type:
+            kwargs["unifi"] = by_type["unifi"]["config"]
+        if "cloudflare" in by_type:
+            kwargs["cloudflare"] = by_type["cloudflare"]["config"]
+        if "uptime_kuma" in by_type:
+            kwargs["uptime_kuma"] = by_type["uptime_kuma"]["config"]
+
         # HTTP poller supports multiple targets (one row per target)
         poller_rows = [r for r in rows if r["type"] == "http_poller" and r["enabled"]]
         if poller_rows:
@@ -609,8 +616,14 @@ class ConfigStore:
             kwargs["homeassistant"] = by_type["ha_handler"]["config"]
         if "docker_handler" in by_type:
             kwargs["docker"] = by_type["docker_handler"]["config"]
+        if "portainer_handler" in by_type:
+            kwargs["portainer"] = by_type["portainer_handler"]["config"]
         if "proxmox_handler" in by_type:
             kwargs["proxmox"] = by_type["proxmox_handler"]["config"]
+        if "unifi_handler" in by_type:
+            kwargs["unifi"] = by_type["unifi_handler"]["config"]
+        if "cloudflare_handler" in by_type:
+            kwargs["cloudflare"] = by_type["cloudflare_handler"]["config"]
 
         return HandlersConfig.model_validate(kwargs) if kwargs else HandlersConfig()
 
@@ -647,6 +660,8 @@ class ConfigStore:
             kwargs["email"] = by_type["email"]["config"]
         if "webhook" in by_type:
             kwargs["webhook"] = by_type["webhook"]["config"]
+        if "telegram" in by_type:
+            kwargs["telegram"] = by_type["telegram"]["config"]
 
         return NotificationsConfig.model_validate(kwargs) if kwargs else NotificationsConfig()
 

--- a/oasisagent/orchestrator.py
+++ b/oasisagent/orchestrator.py
@@ -417,6 +417,18 @@ class Orchestrator:
             self._adapters.append(
                 HttpPollerAdapter(cfg.ingestion.http_poller_targets, self._queue)
             )
+        if cfg.ingestion.unifi.enabled:
+            from oasisagent.ingestion.unifi import UnifiAdapter
+
+            self._adapters.append(
+                UnifiAdapter(cfg.ingestion.unifi, self._queue)
+            )
+        if cfg.ingestion.cloudflare.enabled:
+            from oasisagent.ingestion.cloudflare import CloudflareAdapter
+
+            self._adapters.append(
+                CloudflareAdapter(cfg.ingestion.cloudflare, self._queue)
+            )
         if cfg.ingestion.uptime_kuma.enabled:
             from oasisagent.ingestion.uptime_kuma import UptimeKumaAdapter
 

--- a/tests/test_db/test_config_store.py
+++ b/tests/test_db/test_config_store.py
@@ -238,6 +238,72 @@ class TestLoadConfigWithData:
         assert config.audit.influxdb.token == "influx-tok"
 
 
+class TestLoadConfigNewTypes:
+    """Test that v0.3.3+ types are loaded from SQLite into config."""
+
+    async def test_unifi_connector(self, store: ConfigStore) -> None:
+        await store.create_connector(
+            "unifi", "oasis-udm",
+            {"enabled": True, "url": "https://192.168.1.1", "username": "admin", "password": "pw"},
+        )
+        config = await store.load_config()
+        assert config.ingestion.unifi.url == "https://192.168.1.1"
+        assert config.ingestion.unifi.enabled is True
+
+    async def test_cloudflare_connector(self, store: ConfigStore) -> None:
+        await store.create_connector(
+            "cloudflare", "cf",
+            {"enabled": True, "api_token": "tok123"},
+        )
+        config = await store.load_config()
+        assert config.ingestion.cloudflare.api_token == "tok123"
+        assert config.ingestion.cloudflare.enabled is True
+
+    async def test_uptime_kuma_connector(self, store: ConfigStore) -> None:
+        await store.create_connector(
+            "uptime_kuma", "kuma",
+            {"enabled": True, "url": "http://kuma:3001", "api_key": "key123"},
+        )
+        config = await store.load_config()
+        assert config.ingestion.uptime_kuma.url == "http://kuma:3001"
+        assert config.ingestion.uptime_kuma.enabled is True
+
+    async def test_portainer_handler(self, store: ConfigStore) -> None:
+        await store.create_service(
+            "portainer_handler", "portainer",
+            {"url": "https://portainer:9443", "api_key": "ptk"},
+        )
+        config = await store.load_config()
+        assert config.handlers.portainer.url == "https://portainer:9443"
+        assert config.handlers.portainer.api_key == "ptk"
+
+    async def test_unifi_handler(self, store: ConfigStore) -> None:
+        await store.create_service(
+            "unifi_handler", "unifi",
+            {"url": "https://192.168.1.1", "username": "admin", "password": "pw"},
+        )
+        config = await store.load_config()
+        assert config.handlers.unifi.url == "https://192.168.1.1"
+        assert config.handlers.unifi.password == "pw"
+
+    async def test_cloudflare_handler(self, store: ConfigStore) -> None:
+        await store.create_service(
+            "cloudflare_handler", "cf-handler",
+            {"api_token": "cf-tok"},
+        )
+        config = await store.load_config()
+        assert config.handlers.cloudflare.api_token == "cf-tok"
+
+    async def test_telegram_notification(self, store: ConfigStore) -> None:
+        await store.create_notification(
+            "telegram", "tg",
+            {"enabled": True, "bot_token": "bot123", "chat_id": "456"},
+        )
+        config = await store.load_config()
+        assert config.notifications.telegram.bot_token == "bot123"
+        assert config.notifications.telegram.chat_id == "456"
+
+
 class TestAgentConfig:
     async def test_default_agent_config(self, store: ConfigStore) -> None:
         config = await store.load_config()


### PR DESCRIPTION
## Summary

- Add `unifi`, `cloudflare`, `uptime_kuma` to `ConfigStore._load_ingestion()`
- Add `portainer_handler`, `unifi_handler`, `cloudflare_handler` to `_load_handlers()`
- Add `telegram` to `_load_notifications()`
- Add UniFi and Cloudflare ingestion adapter instantiation in `Orchestrator._build_components()`
- These types were registered in `registry.py` and had UI form specs but were invisible to the orchestrator — health badges showed "Not Running"

Fixes #133

## Test plan

- [x] `ruff check .` — zero errors
- [x] `pytest` — 1850 tests passing (7 new)
- [ ] Redeploy → UniFi, Cloudflare, Uptime Kuma connectors should show Connected (or real status)
- [ ] Portainer, UniFi, Cloudflare handlers should show Connected (or real status)

🤖 Generated with [Claude Code](https://claude.com/claude-code)