### PR TITLE
Infer LLM service health from last call outcome

### DIFF
--- a/oasisagent/llm/client.py
+++ b/oasisagent/llm/client.py
@@ -112,6 +112,11 @@ class LLMClient:
             LLMRole.TRIAGE: UsageStats(),
             LLMRole.REASONING: UsageStats(),
         }
+        # Track last call outcome per role: None = no calls yet
+        self._last_call_ok: dict[LLMRole, bool | None] = {
+            LLMRole.TRIAGE: None,
+            LLMRole.REASONING: None,
+        }
 
     async def complete(
         self,
@@ -146,7 +151,7 @@ class LLMClient:
 
         # Try primary endpoint with retries
         try:
-            return await self._complete_with_retries(
+            result = await self._complete_with_retries(
                 role=role,
                 endpoint=endpoint,
                 messages=messages,
@@ -154,7 +159,10 @@ class LLMClient:
                 temperature=temperature,
                 max_retries=retry_attempts,
             )
+            self._last_call_ok[role] = True
+            return result
         except _NON_RETRYABLE_ERRORS:
+            self._last_call_ok[role] = False
             raise
         except Exception as primary_err:
             # Fallback: reasoning → triage (only after retries exhausted)
@@ -165,6 +173,7 @@ class LLMClient:
                     retry_attempts,
                     primary_err,
                 )
+                self._last_call_ok[LLMRole.REASONING] = False
                 triage_endpoint = self._endpoint_for(LLMRole.TRIAGE)
                 try:
                     response = await self._complete_with_retries(
@@ -175,14 +184,17 @@ class LLMClient:
                         temperature=temperature,
                         max_retries=retry_attempts,
                     )
+                    self._last_call_ok[LLMRole.TRIAGE] = True
                     # Mark as degraded — caller/audit can use this
                     return response.model_copy(update={"degraded": True})
                 except Exception as fallback_err:
+                    self._last_call_ok[LLMRole.TRIAGE] = False
                     raise LLMError(
                         f"Both reasoning and triage endpoints failed. "
                         f"Reasoning: {primary_err}. Triage: {fallback_err}"
                     ) from fallback_err
 
+            self._last_call_ok[role] = False
             raise LLMError(
                 f"LLM completion failed for role '{role.value}' "
                 f"after {retry_attempts} retries: {primary_err}"
@@ -191,6 +203,18 @@ class LLMClient:
     def get_usage_stats(self) -> dict[str, UsageStats]:
         """Return cumulative token usage per role."""
         return {role.value: stats for role, stats in self._usage.items()}
+
+    def get_role_health(self, role: LLMRole) -> str:
+        """Return health status for a role based on last call outcome.
+
+        Returns ``"unknown"`` if no calls have been made yet,
+        ``"connected"`` if the last call succeeded, or
+        ``"error"`` if the last call failed.
+        """
+        last = self._last_call_ok.get(role)
+        if last is None:
+            return "unknown"
+        return "connected" if last else "error"
 
     # -------------------------------------------------------------------
     # Internal helpers

--- a/oasisagent/orchestrator.py
+++ b/oasisagent/orchestrator.py
@@ -39,7 +39,7 @@ from oasisagent.ingestion.ha_log_poller import HaLogPollerAdapter
 from oasisagent.ingestion.ha_websocket import HaWebSocketAdapter
 from oasisagent.ingestion.http_poller import HttpPollerAdapter
 from oasisagent.ingestion.mqtt import MqttAdapter
-from oasisagent.llm.client import LLMClient
+from oasisagent.llm.client import LLMClient, LLMRole
 from oasisagent.llm.reasoning import ReasoningService
 from oasisagent.llm.triage import TriageService
 from oasisagent.metrics import MetricsServer
@@ -211,9 +211,14 @@ class Orchestrator:
 
     # Internal service types that lack a real health check.
     _INTERNAL_SERVICE_TYPES: tuple[str, ...] = (
-        "llm_triage", "llm_reasoning", "llm_options",
         "influxdb", "guardrails", "circuit_breaker",
     )
+
+    # Maps LLM roles to DB service types for health lookups.
+    _LLM_ROLE_TO_TYPE: ClassVar[dict[str, str]] = {
+        "triage": "llm_triage",
+        "reasoning": "llm_reasoning",
+    }
 
     async def get_component_health(self) -> dict[str, dict[str, str]]:
         """Return live health status for all active components.
@@ -244,6 +249,12 @@ class Orchestrator:
                 handler.name(), handler.name(),
             )
             services[db_type] = await self._check_health(handler)
+
+        # --- Services: LLM endpoints — infer from last call ---
+        if self._llm_client is not None:
+            for role in LLMRole:
+                db_type = self._LLM_ROLE_TO_TYPE.get(role.value, role.value)
+                services[db_type] = self._llm_client.get_role_health(role)
 
         # --- Services: internal components → "unknown" ---
         for svc_type in self._INTERNAL_SERVICE_TYPES:

--- a/tests/test_llm_client.py
+++ b/tests/test_llm_client.py
@@ -562,3 +562,103 @@ class TestPromptLogging:
             await client.complete(LLMRole.TRIAGE, _MESSAGES)
 
         assert not any("LLM prompt" in record.message for record in caplog.records)
+
+
+# ---------------------------------------------------------------------------
+# Health tracking (last call outcome)
+# ---------------------------------------------------------------------------
+
+
+class TestRoleHealth:
+    """get_role_health() infers status from last call outcome."""
+
+    def test_initial_state_unknown(self) -> None:
+        client = _client()
+        assert client.get_role_health(LLMRole.TRIAGE) == "unknown"
+        assert client.get_role_health(LLMRole.REASONING) == "unknown"
+
+    @patch("oasisagent.llm.client.litellm.acompletion", new_callable=AsyncMock)
+    async def test_successful_call_sets_connected(self, mock_acomp: AsyncMock) -> None:
+        mock_acomp.return_value = _mock_response()
+        client = _client()
+
+        await client.complete(LLMRole.TRIAGE, _MESSAGES)
+
+        assert client.get_role_health(LLMRole.TRIAGE) == "connected"
+        assert client.get_role_health(LLMRole.REASONING) == "unknown"
+
+    @patch("oasisagent.llm.client.asyncio.sleep", new_callable=AsyncMock)
+    @patch("oasisagent.llm.client.litellm.acompletion", new_callable=AsyncMock)
+    async def test_failed_call_sets_error(
+        self, mock_acomp: AsyncMock, mock_sleep: AsyncMock
+    ) -> None:
+        mock_acomp.side_effect = _timeout()
+        client = _client(options=LlmOptionsConfig(retry_attempts=0, fallback_to_triage=False))
+
+        with pytest.raises(LLMError):
+            await client.complete(LLMRole.TRIAGE, _MESSAGES)
+
+        assert client.get_role_health(LLMRole.TRIAGE) == "error"
+
+    @patch("oasisagent.llm.client.litellm.acompletion", new_callable=AsyncMock)
+    async def test_auth_error_sets_error(self, mock_acomp: AsyncMock) -> None:
+        mock_acomp.side_effect = litellm.AuthenticationError(
+            message="bad key", model="test", llm_provider="test"
+        )
+        client = _client(options=LlmOptionsConfig(retry_attempts=0, fallback_to_triage=False))
+
+        with pytest.raises(litellm.AuthenticationError):
+            await client.complete(LLMRole.TRIAGE, _MESSAGES)
+
+        assert client.get_role_health(LLMRole.TRIAGE) == "error"
+
+    @patch("oasisagent.llm.client.asyncio.sleep", new_callable=AsyncMock)
+    @patch("oasisagent.llm.client.litellm.acompletion", new_callable=AsyncMock)
+    async def test_fallback_sets_both_roles(
+        self, mock_acomp: AsyncMock, mock_sleep: AsyncMock
+    ) -> None:
+        """Reasoning fails, triage fallback succeeds → reasoning=error, triage=connected."""
+        mock_acomp.side_effect = [
+            _timeout(),  # reasoning fails
+            _mock_response(content="fallback"),  # triage succeeds
+        ]
+        client = _client(options=LlmOptionsConfig(retry_attempts=0, fallback_to_triage=True))
+
+        await client.complete(LLMRole.REASONING, _MESSAGES)
+
+        assert client.get_role_health(LLMRole.REASONING) == "error"
+        assert client.get_role_health(LLMRole.TRIAGE) == "connected"
+
+    @patch("oasisagent.llm.client.asyncio.sleep", new_callable=AsyncMock)
+    @patch("oasisagent.llm.client.litellm.acompletion", new_callable=AsyncMock)
+    async def test_both_fail_sets_both_error(
+        self, mock_acomp: AsyncMock, mock_sleep: AsyncMock
+    ) -> None:
+        """Both reasoning and triage fail → both error."""
+        mock_acomp.side_effect = _timeout()
+        client = _client(options=LlmOptionsConfig(retry_attempts=0, fallback_to_triage=True))
+
+        with pytest.raises(LLMError):
+            await client.complete(LLMRole.REASONING, _MESSAGES)
+
+        assert client.get_role_health(LLMRole.REASONING) == "error"
+        assert client.get_role_health(LLMRole.TRIAGE) == "error"
+
+    @patch("oasisagent.llm.client.litellm.acompletion", new_callable=AsyncMock)
+    async def test_recovery_after_failure(self, mock_acomp: AsyncMock) -> None:
+        """A successful call after a failure flips status back to connected."""
+        client = _client(options=LlmOptionsConfig(retry_attempts=0, fallback_to_triage=False))
+
+        # First call fails
+        mock_acomp.side_effect = litellm.AuthenticationError(
+            message="bad key", model="test", llm_provider="test"
+        )
+        with pytest.raises(litellm.AuthenticationError):
+            await client.complete(LLMRole.TRIAGE, _MESSAGES)
+        assert client.get_role_health(LLMRole.TRIAGE) == "error"
+
+        # Second call succeeds
+        mock_acomp.side_effect = None
+        mock_acomp.return_value = _mock_response()
+        await client.complete(LLMRole.TRIAGE, _MESSAGES)
+        assert client.get_role_health(LLMRole.TRIAGE) == "connected"

--- a/tests/test_orchestrator_health.py
+++ b/tests/test_orchestrator_health.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 from unittest.mock import AsyncMock, MagicMock, PropertyMock
 
+from oasisagent.llm.client import LLMRole
 from oasisagent.orchestrator import Orchestrator
 
 # ---------------------------------------------------------------------------
@@ -44,15 +45,32 @@ def _mock_channel(name: str, *, healthy: bool | Exception = True) -> MagicMock:
     return channel
 
 
+def _mock_llm_client(
+    *,
+    triage_health: str = "unknown",
+    reasoning_health: str = "unknown",
+) -> MagicMock:
+    """Create a mock LLMClient with configurable per-role health."""
+    client = MagicMock()
+    health_map = {
+        LLMRole.TRIAGE: triage_health,
+        LLMRole.REASONING: reasoning_health,
+    }
+    client.get_role_health.side_effect = lambda role: health_map[role]
+    return client
+
+
 def _make_orchestrator(
     adapters: list[MagicMock] | None = None,
     handlers: dict[str, MagicMock] | None = None,
     channels: list[MagicMock] | None = None,
+    llm_client: MagicMock | None = None,
 ) -> Orchestrator:
     """Create an Orchestrator with mocked components (skip __init__)."""
     orch = object.__new__(Orchestrator)
     orch._adapters = adapters or []
     orch._handlers = handlers or {}
+    orch._llm_client = llm_client
     if channels is not None:
         dispatcher = MagicMock()
         type(dispatcher).channels = PropertyMock(return_value=channels)
@@ -113,14 +131,40 @@ class TestHandlerHealth:
         assert result["services"]["custom_thing"] == "connected"
 
 
+class TestLLMHealth:
+    async def test_no_llm_client_omits_llm_services(self) -> None:
+        orch = _make_orchestrator(llm_client=None)
+        result = await orch.get_component_health()
+        assert "llm_triage" not in result["services"]
+        assert "llm_reasoning" not in result["services"]
+
+    async def test_no_calls_yet_returns_unknown(self) -> None:
+        client = _mock_llm_client(triage_health="unknown", reasoning_health="unknown")
+        orch = _make_orchestrator(llm_client=client)
+        result = await orch.get_component_health()
+        assert result["services"]["llm_triage"] == "unknown"
+        assert result["services"]["llm_reasoning"] == "unknown"
+
+    async def test_successful_call_returns_connected(self) -> None:
+        client = _mock_llm_client(triage_health="connected", reasoning_health="connected")
+        orch = _make_orchestrator(llm_client=client)
+        result = await orch.get_component_health()
+        assert result["services"]["llm_triage"] == "connected"
+        assert result["services"]["llm_reasoning"] == "connected"
+
+    async def test_failed_call_returns_error(self) -> None:
+        client = _mock_llm_client(triage_health="error", reasoning_health="connected")
+        orch = _make_orchestrator(llm_client=client)
+        result = await orch.get_component_health()
+        assert result["services"]["llm_triage"] == "error"
+        assert result["services"]["llm_reasoning"] == "connected"
+
+
 class TestInternalServices:
     async def test_internal_services_report_unknown(self) -> None:
         orch = _make_orchestrator()
         result = await orch.get_component_health()
-        for svc in (
-            "llm_triage", "llm_reasoning", "llm_options",
-            "influxdb", "guardrails", "circuit_breaker",
-        ):
+        for svc in ("influxdb", "guardrails", "circuit_breaker"):
             assert result["services"][svc] == "unknown"
 
 
@@ -189,5 +233,6 @@ class TestEmptyOrchestrator:
         result = await orch.get_component_health()
         assert result["connectors"] == {}
         assert result["notifications"] == {}
-        # Internal services always present
-        assert "llm_triage" in result["services"]
+        # Internal services always present, LLM omitted when no client
+        assert "influxdb" in result["services"]
+        assert "llm_triage" not in result["services"]


### PR DESCRIPTION
## Summary

- Track last call success/failure per `LLMRole` in `LLMClient` via `_last_call_ok` dict
- Add `get_role_health(role)` method: no calls → "unknown", last succeeded → "connected", last failed → "error"
- Orchestrator queries `LLMClient` for `llm_triage`/`llm_reasoning` health instead of hardcoding "unknown"
- Remove `llm_options` from health tracking (it's config, not a callable endpoint)
- All 5 code paths in `complete()` set status: success, non-retryable error, retries exhausted, fallback success, fallback failure

Closes #135

## Test plan

- [x] `TestRoleHealth` — 7 tests covering initial unknown, success→connected, failure→error, auth error→error, fallback sets both roles, both fail→both error, recovery after failure
- [x] `TestLLMHealth` — 4 tests covering no client→omitted, no calls→unknown, success→connected, failure→error
- [x] Updated `TestInternalServices` and `TestEmptyOrchestrator` to reflect `llm_*` removal from internal services
- [x] 1861 tests passing, zero lint errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)