### PR TITLE
Clean up stale MQTT client on reconnect

### DIFF
--- a/oasisagent/notifications/mqtt.py
+++ b/oasisagent/notifications/mqtt.py
@@ -37,6 +37,7 @@ class MqttNotificationChannel(NotificationChannel):
         self._config = config
         self._client: aiomqtt.Client | None = None
         self._reconnect_task: asyncio.Task[None] | None = None
+        self._cleanup_tasks: set[asyncio.Task[None]] = set()
         self._stopping = False
 
     def name(self) -> str:
@@ -94,13 +95,28 @@ class MqttNotificationChannel(NotificationChannel):
                     backoff,
                 )
 
+    async def _close_stale_client(self, client: aiomqtt.Client) -> None:
+        """Best-effort cleanup of a stale MQTT client."""
+        try:
+            await client.__aexit__(None, None, None)
+        except Exception:
+            logger.debug("Stale MQTT client cleanup failed (expected)", exc_info=True)
+
     def _trigger_reconnect(self) -> None:
         """Tear down the dead client and spawn a background reconnect task.
 
         Safe to call multiple times — skips if a reconnect is already running
         or if the channel is shutting down.
         """
+        old_client = self._client
         self._client = None
+        if old_client is not None:
+            task = asyncio.create_task(
+                self._close_stale_client(old_client),
+                name="mqtt-stale-cleanup",
+            )
+            self._cleanup_tasks.add(task)
+            task.add_done_callback(self._cleanup_tasks.discard)
         if self._stopping:
             return
         if self._reconnect_task is not None and not self._reconnect_task.done():

--- a/tests/test_notifications.py
+++ b/tests/test_notifications.py
@@ -295,6 +295,49 @@ class TestMqttErrors:
 
         await channel.stop()
 
+    async def test_trigger_reconnect_calls_aexit_on_stale_client(self) -> None:
+        """_trigger_reconnect() should schedule __aexit__ on the old client."""
+        channel = _mock_mqtt_channel()
+        old_client = channel._client
+        old_client.__aexit__ = AsyncMock()
+
+        channel._trigger_reconnect()
+
+        # Let the fire-and-forget cleanup task run
+        await asyncio.sleep(0)
+
+        old_client.__aexit__.assert_awaited_once_with(None, None, None)
+        assert channel._client is None
+
+        await channel.stop()
+
+    async def test_trigger_reconnect_suppresses_aexit_error(self) -> None:
+        """If __aexit__ raises on the stale client, it should be suppressed."""
+        channel = _mock_mqtt_channel()
+        old_client = channel._client
+        old_client.__aexit__ = AsyncMock(side_effect=OSError("socket gone"))
+
+        channel._trigger_reconnect()
+
+        # Let the fire-and-forget cleanup task run — should not raise
+        await asyncio.sleep(0)
+
+        old_client.__aexit__.assert_awaited_once_with(None, None, None)
+
+        await channel.stop()
+
+    async def test_trigger_reconnect_skips_cleanup_when_no_client(self) -> None:
+        """If _client is already None, no cleanup task is created."""
+        channel = MqttNotificationChannel(_make_config())
+        assert channel._client is None
+
+        channel._trigger_reconnect()
+
+        # Only the reconnect task should exist, no stale cleanup
+        assert channel._reconnect_task is not None
+
+        await channel.stop()
+
     async def test_duplicate_reconnect_not_spawned(self) -> None:
         """Multiple publish failures should not spawn duplicate reconnect tasks."""
         channel = _mock_mqtt_channel()


### PR DESCRIPTION
## Summary
- `_trigger_reconnect()` now calls `__aexit__()` on the old `aiomqtt.Client` before nulling `self._client`, preventing potential socket FD leaks on half-open connections
- Cleanup runs as a fire-and-forget task (`_close_stale_client`) with full error suppression since the client is likely already dead
- Task references stored in `_cleanup_tasks` set with auto-discard callback to satisfy ruff RUF006

## Test plan
- [x] `test_trigger_reconnect_calls_aexit_on_stale_client` — verifies `__aexit__` is called on old client
- [x] `test_trigger_reconnect_suppresses_aexit_error` — verifies errors from stale `__aexit__` are swallowed
- [x] `test_trigger_reconnect_skips_cleanup_when_no_client` — verifies no cleanup task when client is already None
- [x] All 41 notification tests passing
- [x] ruff clean

Closes #130

🤖 Generated with [Claude Code](https://claude.com/claude-code)