### PR TITLE
Add target_entity_id to RecommendedAction

### DIFF
--- a/oasisagent/engine/decision.py
+++ b/oasisagent/engine/decision.py
@@ -311,8 +311,9 @@ class DecisionEngine:
         blocked_count = 0
 
         for action in diagnosis.recommended_actions:
+            check_entity = action.target_entity_id or event.entity_id
             guardrail_result = self._guardrails.check(
-                entity_id=event.entity_id,
+                entity_id=check_entity,
                 risk_tier=action.risk_tier,
             )
 

--- a/oasisagent/handlers/homeassistant.py
+++ b/oasisagent/handlers/homeassistant.py
@@ -138,7 +138,8 @@ class HomeAssistantHandler(Handler):
             return VerifyResult(verified=True, message="No verification needed")
 
         self._ensure_started()
-        return await self._verify_entity_recovery(event.entity_id)
+        entity = action.target_entity_id or event.entity_id
+        return await self._verify_entity_recovery(entity)
 
     async def get_context(self, event: Event) -> dict[str, Any]:
         """Gather HA-specific context for diagnosis."""
@@ -168,10 +169,11 @@ class HomeAssistantHandler(Handler):
     ) -> ActionResult:
         """Notify — no system changes. Returns the diagnosis message."""
         message = action.params.get("message", action.description)
-        logger.info("HA notify: %s (entity=%s)", message, event.entity_id)
+        entity = action.target_entity_id or event.entity_id
+        logger.info("HA notify: %s (entity=%s)", message, entity)
         return ActionResult(
             status=ActionStatus.SUCCESS,
-            details={"message": message, "entity_id": event.entity_id},
+            details={"message": message, "entity_id": entity},
         )
 
     async def _op_restart_integration(
@@ -245,7 +247,10 @@ class HomeAssistantHandler(Handler):
         self, event: Event, action: RecommendedAction
     ) -> ActionResult:
         """Read entity state — context-gathering, not a mutating action."""
-        entity_id = action.params.get("entity_id", event.entity_id)
+        entity_id = (
+            action.target_entity_id
+            or action.params.get("entity_id", event.entity_id)
+        )
         state = await self._get_state(entity_id)
         return ActionResult(
             status=ActionStatus.SUCCESS,

--- a/oasisagent/llm/prompts/diagnose_failure.py
+++ b/oasisagent/llm/prompts/diagnose_failure.py
@@ -41,12 +41,17 @@ Respond with a JSON object matching this exact schema:
       "operation": "restart_integration",
       "params": {"integration": "zwave_js"},
       "risk_tier": "auto_fix",
-      "reasoning": "Why this action is appropriate"
+      "reasoning": "Why this action is appropriate",
+      "target_entity_id": "sensor.zwave_js_status"
     }
   ],
   "risk_assessment": "Overall risk analysis of the situation",
   "additional_context": "Any other relevant observations"
 }
+
+Include "target_entity_id" when the action targets a different entity than the \
+event source (e.g., event on sensor.temperature but action targets \
+switch.heater). Omit it or set to null when the action targets the event entity.
 
 Valid risk_tier values (choose carefully):
 - "auto_fix" — Safe to execute automatically (e.g., restart a non-critical integration)

--- a/oasisagent/models.py
+++ b/oasisagent/models.py
@@ -147,6 +147,7 @@ class RecommendedAction(BaseModel):
     params: dict[str, Any] = Field(default_factory=dict)
     risk_tier: RiskTier
     reasoning: str = ""
+    target_entity_id: str | None = None
 
 
 class DiagnosisResult(BaseModel):

--- a/oasisagent/orchestrator.py
+++ b/oasisagent/orchestrator.py
@@ -937,6 +937,8 @@ class Orchestrator:
         assert self._pending_queue is not None
 
         for action in result.recommended_actions:
+            cb_entity = action.target_entity_id or event.entity_id
+
             # RECOMMEND-tier actions go to the pending queue
             if action.risk_tier == RiskTier.RECOMMEND:
                 pending = await self._pending_queue.add(
@@ -944,7 +946,7 @@ class Orchestrator:
                     action=action,
                     diagnosis=result.diagnosis,
                     timeout_minutes=self._config.guardrails.approval_timeout_minutes,
-                    entity_id=event.entity_id,
+                    entity_id=cb_entity,
                     severity=event.severity.value,
                     source=event.source,
                     system=event.system,
@@ -966,7 +968,7 @@ class Orchestrator:
                 action_result = await handler.execute(event, action)
                 success = action_result.status == ActionStatus.SUCCESS
                 self._circuit_breaker.record_attempt(
-                    event.entity_id, success=success
+                    cb_entity, success=success
                 )
                 if success:
                     self._actions_taken += 1
@@ -993,7 +995,7 @@ class Orchestrator:
                     event.id,
                 )
                 self._circuit_breaker.record_attempt(
-                    event.entity_id, success=False
+                    cb_entity, success=False
                 )
 
     # -------------------------------------------------------------------

--- a/tests/test_decision_t2.py
+++ b/tests/test_decision_t2.py
@@ -295,6 +295,63 @@ class TestT2Guardrails:
 
         assert result.disposition == DecisionDisposition.BLOCKED
 
+    async def test_target_entity_id_checked_instead_of_event(self) -> None:
+        """Guardrails check action.target_entity_id when set, not event.entity_id."""
+        diagnosis = DiagnosisResult(
+            root_cause="Lock firmware issue",
+            confidence=0.9,
+            recommended_actions=[
+                RecommendedAction(
+                    description="Restart lock integration",
+                    handler="homeassistant",
+                    operation="restart_integration",
+                    risk_tier=RiskTier.AUTO_FIX,
+                    reasoning="Need to restart",
+                    target_entity_id="lock.front_door",
+                ),
+            ],
+            risk_assessment="Affects security domain",
+        )
+        reasoning = _make_reasoning_service(diagnosis)
+        engine = _make_engine(
+            triage_service=_make_triage_service(),
+            reasoning_service=reasoning,
+        )
+        # Event entity is NOT in a blocked domain, but target is
+        event = _make_event(entity_id="sensor.temperature")
+
+        result = await engine.process_event(event)
+
+        assert result.disposition == DecisionDisposition.BLOCKED
+
+    async def test_no_target_entity_falls_back_to_event(self) -> None:
+        """Without target_entity_id, guardrails use event.entity_id."""
+        diagnosis = DiagnosisResult(
+            root_cause="Sensor issue",
+            confidence=0.9,
+            recommended_actions=[
+                RecommendedAction(
+                    description="Restart sensor integration",
+                    handler="homeassistant",
+                    operation="restart_integration",
+                    risk_tier=RiskTier.AUTO_FIX,
+                    reasoning="Safe restart",
+                ),
+            ],
+            risk_assessment="Low risk",
+        )
+        reasoning = _make_reasoning_service(diagnosis)
+        engine = _make_engine(
+            triage_service=_make_triage_service(),
+            reasoning_service=reasoning,
+        )
+        event = _make_event(entity_id="sensor.temperature")
+
+        result = await engine.process_event(event)
+
+        assert result.disposition == DecisionDisposition.MATCHED
+        assert len(result.recommended_actions) == 1
+
     async def test_dry_run_blocks_t2_actions(self) -> None:
         """Dry run mode blocks all T2 actions (they count as not approved)."""
         reasoning = _make_reasoning_service()

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -373,6 +373,58 @@ class TestDiagnosisResult:
 
 
 # ---------------------------------------------------------------------------
+# RecommendedAction.target_entity_id
+# ---------------------------------------------------------------------------
+
+
+class TestRecommendedActionTargetEntityId:
+    """Tests for the optional target_entity_id field on RecommendedAction."""
+
+    def test_target_entity_id_defaults_none(self) -> None:
+        action = RecommendedAction(
+            description="test",
+            handler="test",
+            operation="test",
+            risk_tier=RiskTier.AUTO_FIX,
+        )
+        assert action.target_entity_id is None
+
+    def test_target_entity_id_set_explicitly(self) -> None:
+        action = RecommendedAction(
+            description="Restart lock integration",
+            handler="homeassistant",
+            operation="restart_integration",
+            risk_tier=RiskTier.AUTO_FIX,
+            target_entity_id="lock.front_door",
+        )
+        assert action.target_entity_id == "lock.front_door"
+
+    def test_target_entity_id_roundtrip(self) -> None:
+        action = RecommendedAction(
+            description="Restart",
+            handler="homeassistant",
+            operation="restart_integration",
+            risk_tier=RiskTier.RECOMMEND,
+            target_entity_id="switch.heater",
+        )
+        data = action.model_dump()
+        restored = RecommendedAction.model_validate(data)
+        assert restored.target_entity_id == "switch.heater"
+
+    def test_target_entity_id_none_roundtrip(self) -> None:
+        action = RecommendedAction(
+            description="test",
+            handler="test",
+            operation="test",
+            risk_tier=RiskTier.AUTO_FIX,
+        )
+        data = action.model_dump()
+        assert data["target_entity_id"] is None
+        restored = RecommendedAction.model_validate(data)
+        assert restored.target_entity_id is None
+
+
+# ---------------------------------------------------------------------------
 # ActionResult and VerifyResult
 # ---------------------------------------------------------------------------
 

--- a/tests/test_reasoning.py
+++ b/tests/test_reasoning.py
@@ -190,6 +190,16 @@ class TestParseDiagnosis:
         )
         assert result.additional_context == "USB device log shows errors"
 
+    def test_target_entity_id_parsed(self) -> None:
+        data = json.loads(_valid_diagnosis_json())
+        data["recommended_actions"][0]["target_entity_id"] = "lock.front_door"
+        result = _parse_diagnosis(json.dumps(data))
+        assert result.recommended_actions[0].target_entity_id == "lock.front_door"
+
+    def test_target_entity_id_absent_defaults_none(self) -> None:
+        result = _parse_diagnosis(_valid_diagnosis_json())
+        assert result.recommended_actions[0].target_entity_id is None
+
 
 # ---------------------------------------------------------------------------
 # ReasoningService.diagnose


### PR DESCRIPTION
## Summary
- Adds optional `target_entity_id: str | None = None` field to `RecommendedAction` model
- Decision engine guardrails now check `action.target_entity_id` (falling back to `event.entity_id`) when evaluating T2 actions against blocked domains/entities
- HA handler `verify()`, `_op_notify()`, and `_op_get_entity_state()` prefer `action.target_entity_id` over `event.entity_id`
- Orchestrator circuit breaker and pending queue use `action.target_entity_id` when available
- T2 prompt schema updated to include the new field with usage instructions
- 8 new tests covering model field behavior, guardrail target checking, and LLM output parsing

## Test plan
- [x] `ruff check .` passes
- [x] Full test suite passes (1869 tests)
- [x] New test: guardrails block action when `target_entity_id` matches blocked domain even though `event.entity_id` does not
- [x] New test: guardrails fall back to `event.entity_id` when `target_entity_id` is None
- [x] New test: `target_entity_id` parsed from T2 LLM JSON output
- [x] New test: `target_entity_id` defaults to None when absent
- [x] New tests: model field construction, serialization roundtrip

Closes #19

🤖 Generated with [Claude Code](https://claude.com/claude-code)