### PR TITLE
Add Slack Incoming Webhook notification channel

### DIFF
--- a/oasisagent/config.py
+++ b/oasisagent/config.py
@@ -835,6 +835,18 @@ class DiscordNotificationConfig(BaseModel):
     avatar_url: str = ""
 
 
+class SlackNotificationConfig(BaseModel):
+    """Slack Incoming Webhook notification channel configuration."""
+
+    model_config = ConfigDict(extra="forbid")
+
+    enabled: bool = False
+    webhook_url: str = ""
+    channel: str = ""
+    username: str = "OasisAgent"
+    icon_emoji: str = ":robot_face:"
+
+
 class NotificationsConfig(BaseModel):
     """All notification channel configurations."""
 
@@ -845,6 +857,7 @@ class NotificationsConfig(BaseModel):
     webhook: WebhookNotificationConfig = Field(default_factory=WebhookNotificationConfig)
     telegram: TelegramNotificationConfig = Field(default_factory=TelegramNotificationConfig)
     discord: DiscordNotificationConfig = Field(default_factory=DiscordNotificationConfig)
+    slack: SlackNotificationConfig = Field(default_factory=SlackNotificationConfig)
 
 
 # -- Top-level config -------------------------------------------------------

--- a/oasisagent/db/config_store.py
+++ b/oasisagent/db/config_store.py
@@ -213,6 +213,7 @@ class ConfigStore:
                 ("webhook", "webhook", config.notifications.webhook),
                 ("telegram", "telegram", config.notifications.telegram),
                 ("discord", "discord", config.notifications.discord),
+                ("slack", "slack", config.notifications.slack),
             ]
             for type_name, default_name, sub_cfg in notif_map:
                 if sub_cfg.enabled:
@@ -665,6 +666,8 @@ class ConfigStore:
             kwargs["telegram"] = by_type["telegram"]["config"]
         if "discord" in by_type:
             kwargs["discord"] = by_type["discord"]["config"]
+        if "slack" in by_type:
+            kwargs["slack"] = by_type["slack"]["config"]
 
         return NotificationsConfig.model_validate(kwargs) if kwargs else NotificationsConfig()
 

--- a/oasisagent/db/registry.py
+++ b/oasisagent/db/registry.py
@@ -37,6 +37,7 @@ from oasisagent.config import (
     PortainerHandlerConfig,
     ProxmoxHandlerConfig,
     ScannerConfig,
+    SlackNotificationConfig,
     TelegramNotificationConfig,
     UnifiAdapterConfig,
     UnifiHandlerConfig,
@@ -171,6 +172,10 @@ NOTIFICATION_TYPES: dict[str, TypeMeta] = {
     ),
     "discord": TypeMeta(
         model=DiscordNotificationConfig,
+        secret_fields=frozenset({"webhook_url"}),
+    ),
+    "slack": TypeMeta(
+        model=SlackNotificationConfig,
         secret_fields=frozenset({"webhook_url"}),
     ),
 }

--- a/oasisagent/notifications/__init__.py
+++ b/oasisagent/notifications/__init__.py
@@ -6,6 +6,7 @@ from oasisagent.notifications.dispatcher import NotificationDispatcher
 from oasisagent.notifications.email import EmailNotificationChannel
 from oasisagent.notifications.interactive import InteractiveNotificationChannel
 from oasisagent.notifications.mqtt import MqttNotificationChannel
+from oasisagent.notifications.slack import SlackNotificationChannel
 from oasisagent.notifications.telegram import TelegramChannel
 from oasisagent.notifications.webhook import WebhookNotificationChannel
 
@@ -16,6 +17,7 @@ __all__ = [
     "MqttNotificationChannel",
     "NotificationChannel",
     "NotificationDispatcher",
+    "SlackNotificationChannel",
     "TelegramChannel",
     "WebhookNotificationChannel",
 ]

--- a/oasisagent/notifications/slack.py
+++ b/oasisagent/notifications/slack.py
@@ -1,0 +1,237 @@
+"""Slack notification channel — posts messages via Incoming Webhooks.
+
+Sends notifications as Slack Block Kit formatted messages with severity
+color bars, event details, and timestamps. Uses aiohttp to POST to
+the configured webhook URL.
+
+Slack Incoming Webhooks don't support a ping/health endpoint, so
+healthy() tracks the last send result (similar to the LLM health
+pattern).
+
+ARCHITECTURE.md §10 defines the notification contract.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import logging
+from typing import TYPE_CHECKING, Any
+
+import aiohttp
+
+from oasisagent.notifications.base import NotificationChannel
+
+if TYPE_CHECKING:
+    from oasisagent.config import SlackNotificationConfig
+    from oasisagent.models import Notification
+
+logger = logging.getLogger(__name__)
+
+# Retry configuration (matches webhook channel)
+_MAX_ATTEMPTS = 3
+_BACKOFF_BASE = 1.0  # seconds
+_BACKOFF_MULTIPLIER = 2.0
+_REQUEST_TIMEOUT = 10  # seconds
+
+# Severity → Slack color (hex sidebar attachment color)
+_SEVERITY_COLORS: dict[str, str] = {
+    "critical": "#E01E5A",  # red
+    "error": "#E01E5A",     # red
+    "warning": "#ECB22E",   # yellow
+    "info": "#36C5F0",      # blue
+}
+
+
+class SlackNotificationChannel(NotificationChannel):
+    """Sends notifications to Slack via Incoming Webhooks.
+
+    Must be started with ``await channel.start()`` before use.
+    Retries on 5xx with exponential backoff. 4xx errors are not retried.
+    """
+
+    def __init__(self, config: SlackNotificationConfig) -> None:
+        self._config = config
+        self._session: aiohttp.ClientSession | None = None
+        self._last_send_ok: bool | None = None
+
+    def name(self) -> str:
+        return "slack"
+
+    async def healthy(self) -> bool:
+        """Return True if webhook_url is configured and last send succeeded.
+
+        Slack Incoming Webhooks have no health/ping endpoint, so we track
+        the result of the most recent send. Before the first send, returns
+        True if the webhook URL is configured (optimistic).
+        """
+        if not self._config.enabled:
+            return True
+        if not self._config.webhook_url:
+            return False
+        if self._last_send_ok is None:
+            return True  # optimistic before first send
+        return self._last_send_ok
+
+    async def start(self) -> None:
+        """Create the aiohttp session."""
+        if not self._config.enabled:
+            logger.info("Slack notifications disabled — skipping setup")
+            return
+
+        timeout = aiohttp.ClientTimeout(total=_REQUEST_TIMEOUT)
+        self._session = aiohttp.ClientSession(timeout=timeout)
+        logger.info("Slack notification channel started")
+
+    async def stop(self) -> None:
+        """Close the aiohttp session."""
+        if self._session is not None:
+            await self._session.close()
+            self._session = None
+            logger.info("Slack notification channel stopped")
+
+    async def send(self, notification: Notification) -> bool:
+        """POST a Block Kit formatted message to the Slack webhook.
+
+        Returns True on success, False on failure (best-effort).
+        """
+        if not self._config.enabled:
+            return True
+
+        if not self._config.webhook_url:
+            logger.warning(
+                "Slack webhook_url not configured — dropping notification %s",
+                notification.id,
+            )
+            self._last_send_ok = False
+            return False
+
+        if self._session is None:
+            logger.warning(
+                "Slack channel not started — dropping notification %s",
+                notification.id,
+            )
+            self._last_send_ok = False
+            return False
+
+        payload = self._build_payload(notification)
+        ok = await self._post_with_retry(payload, notification.id)
+        self._last_send_ok = ok
+        return ok
+
+    async def _post_with_retry(
+        self, payload: dict[str, Any], notification_id: str,
+    ) -> bool:
+        """POST to the Slack webhook with retry on 5xx."""
+        assert self._session is not None
+        delay = _BACKOFF_BASE
+
+        for attempt in range(1, _MAX_ATTEMPTS + 1):
+            try:
+                async with self._session.post(
+                    self._config.webhook_url, json=payload,
+                ) as resp:
+                    if resp.status < 400:
+                        logger.debug(
+                            "Slack notification delivered: id=%s, status=%d",
+                            notification_id, resp.status,
+                        )
+                        return True
+
+                    if resp.status < 500:
+                        # 4xx — don't retry (bad webhook URL, invalid payload)
+                        body = await resp.text()
+                        logger.warning(
+                            "Slack webhook rejected (4xx): id=%s, status=%d,"
+                            " body=%s",
+                            notification_id, resp.status, body[:200],
+                        )
+                        return False
+
+                    # 5xx — retry
+                    logger.warning(
+                        "Slack webhook 5xx (attempt %d/%d): status=%d",
+                        attempt, _MAX_ATTEMPTS, resp.status,
+                    )
+            except (aiohttp.ClientError, TimeoutError) as exc:
+                logger.warning(
+                    "Slack webhook error (attempt %d/%d): %s",
+                    attempt, _MAX_ATTEMPTS, exc,
+                )
+
+            if attempt < _MAX_ATTEMPTS:
+                await asyncio.sleep(delay)
+                delay *= _BACKOFF_MULTIPLIER
+
+        logger.warning(
+            "Slack webhook exhausted retries: id=%s", notification_id,
+        )
+        return False
+
+    def _build_payload(self, notification: Notification) -> dict[str, Any]:
+        """Build a Slack Block Kit payload from a Notification."""
+        severity = notification.severity.value
+        color = _SEVERITY_COLORS.get(severity, "#808080")
+        timestamp = notification.timestamp.strftime("%Y-%m-%d %H:%M:%S UTC")
+
+        # Build the blocks for the attachment
+        blocks: list[dict[str, Any]] = [
+            {
+                "type": "header",
+                "text": {
+                    "type": "plain_text",
+                    "text": notification.title,
+                    "emoji": True,
+                },
+            },
+            {
+                "type": "section",
+                "fields": [
+                    {
+                        "type": "mrkdwn",
+                        "text": f"*Severity:*\n{severity.upper()}",
+                    },
+                    {
+                        "type": "mrkdwn",
+                        "text": (
+                            f"*Event ID:*\n"
+                            f"{notification.event_id or 'N/A'}"
+                        ),
+                    },
+                ],
+            },
+            {
+                "type": "section",
+                "text": {
+                    "type": "mrkdwn",
+                    "text": notification.message,
+                },
+            },
+            {
+                "type": "context",
+                "elements": [
+                    {
+                        "type": "mrkdwn",
+                        "text": f":clock1: {timestamp}",
+                    },
+                ],
+            },
+        ]
+
+        payload: dict[str, Any] = {
+            "attachments": [
+                {
+                    "color": color,
+                    "blocks": blocks,
+                },
+            ],
+        }
+
+        # Optional overrides
+        if self._config.channel:
+            payload["channel"] = self._config.channel
+        if self._config.username:
+            payload["username"] = self._config.username
+        if self._config.icon_emoji:
+            payload["icon_emoji"] = self._config.icon_emoji
+
+        return payload

--- a/oasisagent/orchestrator.py
+++ b/oasisagent/orchestrator.py
@@ -404,6 +404,10 @@ class Orchestrator:
             from oasisagent.notifications.discord import DiscordNotificationChannel
 
             channels.append(DiscordNotificationChannel(cfg.notifications.discord))
+        if cfg.notifications.slack.enabled:
+            from oasisagent.notifications.slack import SlackNotificationChannel
+
+            channels.append(SlackNotificationChannel(cfg.notifications.slack))
         self._dispatcher = NotificationDispatcher(channels)
 
         # 12. Pending action queue (for RECOMMEND-tier actions)

--- a/oasisagent/ui/form_specs.py
+++ b/oasisagent/ui/form_specs.py
@@ -65,6 +65,7 @@ TYPE_DISPLAY_NAMES: dict[str, str] = {
     "webhook": "Webhook",
     "telegram": "Telegram",
     "discord": "Discord",
+    "slack": "Slack",
 }
 
 TYPE_DESCRIPTIONS: dict[str, str] = {
@@ -137,6 +138,7 @@ TYPE_DESCRIPTIONS: dict[str, str] = {
     "webhook": "POST notifications to webhook URLs",
     "telegram": "Send notifications via Telegram bot",
     "discord": "Send notifications via Discord webhook",
+    "slack": "Send notifications via Slack Incoming Webhook",
 }
 
 # Types that only allow a single instance
@@ -1006,6 +1008,33 @@ FORM_SPECS: dict[str, list[FieldSpec]] = {
         FieldSpec(
             "avatar_url", "Avatar URL", "text",
             help_text="URL for the webhook avatar image (optional)",
+        ),
+    ],
+    "slack": [
+        FieldSpec(
+            "webhook_url", "Webhook URL", "password",
+            help_text=(
+                "Slack Incoming Webhook URL — create one at"
+                " api.slack.com/apps → Incoming Webhooks"
+            ),
+            required=True,
+        ),
+        FieldSpec(
+            "channel", "Channel Override", "text",
+            help_text=(
+                "Override the default channel (e.g. #alerts)."
+                " Leave blank to use the webhook default"
+            ),
+        ),
+        FieldSpec(
+            "username", "Bot Username", "text",
+            help_text="Display name for the bot in Slack",
+            default="OasisAgent",
+        ),
+        FieldSpec(
+            "icon_emoji", "Icon Emoji", "text",
+            help_text="Emoji for the bot avatar (e.g. :robot_face:)",
+            default=":robot_face:",
         ),
     ],
 }

--- a/tests/test_slack_notification.py
+++ b/tests/test_slack_notification.py
@@ -1,0 +1,297 @@
+"""Tests for the Slack notification channel."""
+
+from __future__ import annotations
+
+from typing import Any
+from unittest.mock import AsyncMock, MagicMock
+
+from oasisagent.config import SlackNotificationConfig
+from oasisagent.models import Notification, Severity
+from oasisagent.notifications.slack import SlackNotificationChannel
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _make_config(**overrides: Any) -> SlackNotificationConfig:
+    defaults: dict[str, Any] = {
+        "enabled": True,
+        "webhook_url": "https://hooks.slack.com/services/T00/B00/xxx",
+        "channel": "#alerts",
+        "username": "OasisAgent",
+        "icon_emoji": ":robot_face:",
+    }
+    defaults.update(overrides)
+    return SlackNotificationConfig(**defaults)
+
+
+def _make_notification(**overrides: Any) -> Notification:
+    defaults: dict[str, Any] = {
+        "title": "Test Alert",
+        "message": "Something happened",
+        "severity": Severity.WARNING,
+        "event_id": "evt-001",
+    }
+    defaults.update(overrides)
+    return Notification(**defaults)
+
+
+def _mock_slack_channel(
+    config: SlackNotificationConfig | None = None,
+    status: int = 200,
+    body: str = "ok",
+) -> SlackNotificationChannel:
+    """Create a Slack channel with a mocked aiohttp session."""
+    channel = SlackNotificationChannel(config or _make_config())
+
+    mock_response = AsyncMock()
+    mock_response.status = status
+    mock_response.text = AsyncMock(return_value=body)
+    mock_response.__aenter__ = AsyncMock(return_value=mock_response)
+    mock_response.__aexit__ = AsyncMock(return_value=False)
+
+    mock_session = AsyncMock()
+    mock_session.post = MagicMock(return_value=mock_response)
+
+    channel._session = mock_session
+    return channel
+
+
+# ---------------------------------------------------------------------------
+# name
+# ---------------------------------------------------------------------------
+
+
+class TestSlackName:
+    def test_name_is_slack(self) -> None:
+        channel = SlackNotificationChannel(_make_config())
+        assert channel.name() == "slack"
+
+
+# ---------------------------------------------------------------------------
+# healthy
+# ---------------------------------------------------------------------------
+
+
+class TestSlackHealthy:
+    async def test_healthy_when_disabled(self) -> None:
+        channel = SlackNotificationChannel(_make_config(enabled=False))
+        assert await channel.healthy() is True
+
+    async def test_unhealthy_when_no_webhook_url(self) -> None:
+        channel = SlackNotificationChannel(_make_config(webhook_url=""))
+        assert await channel.healthy() is False
+
+    async def test_healthy_before_first_send(self) -> None:
+        channel = SlackNotificationChannel(_make_config())
+        assert await channel.healthy() is True
+
+    async def test_healthy_after_successful_send(self) -> None:
+        channel = _mock_slack_channel()
+        await channel.send(_make_notification())
+        assert await channel.healthy() is True
+
+    async def test_unhealthy_after_failed_send(self) -> None:
+        channel = _mock_slack_channel(status=500)
+        await channel.send(_make_notification())
+        assert await channel.healthy() is False
+
+
+# ---------------------------------------------------------------------------
+# lifecycle
+# ---------------------------------------------------------------------------
+
+
+class TestSlackLifecycle:
+    async def test_start_creates_session(self) -> None:
+        channel = SlackNotificationChannel(_make_config())
+        await channel.start()
+        assert channel._session is not None
+        await channel.stop()
+
+    async def test_start_disabled_skips_session(self) -> None:
+        channel = SlackNotificationChannel(_make_config(enabled=False))
+        await channel.start()
+        assert channel._session is None
+
+    async def test_stop_closes_session(self) -> None:
+        channel = SlackNotificationChannel(_make_config())
+        await channel.start()
+        assert channel._session is not None
+        await channel.stop()
+        assert channel._session is None
+
+    async def test_stop_without_start_is_noop(self) -> None:
+        channel = SlackNotificationChannel(_make_config())
+        await channel.stop()  # Should not raise
+
+
+# ---------------------------------------------------------------------------
+# send
+# ---------------------------------------------------------------------------
+
+
+class TestSlackSend:
+    async def test_send_returns_true_on_success(self) -> None:
+        channel = _mock_slack_channel()
+        result = await channel.send(_make_notification())
+        assert result is True
+
+    async def test_send_disabled_returns_true(self) -> None:
+        channel = SlackNotificationChannel(_make_config(enabled=False))
+        result = await channel.send(_make_notification())
+        assert result is True
+
+    async def test_send_no_webhook_url_returns_false(self) -> None:
+        channel = _mock_slack_channel(config=_make_config(webhook_url=""))
+        result = await channel.send(_make_notification())
+        assert result is False
+
+    async def test_send_without_start_returns_false(self) -> None:
+        channel = SlackNotificationChannel(_make_config())
+        result = await channel.send(_make_notification())
+        assert result is False
+
+    async def test_send_posts_to_webhook_url(self) -> None:
+        channel = _mock_slack_channel()
+        await channel.send(_make_notification())
+        channel._session.post.assert_called_once()
+        call_args = channel._session.post.call_args
+        assert call_args[0][0] == "https://hooks.slack.com/services/T00/B00/xxx"
+
+    async def test_send_4xx_returns_false(self) -> None:
+        channel = _mock_slack_channel(status=403)
+        result = await channel.send(_make_notification())
+        assert result is False
+
+    async def test_send_5xx_retries_and_fails(self) -> None:
+        """5xx responses trigger retries. After exhausting, returns False."""
+        channel = _mock_slack_channel(status=500)
+        result = await channel.send(_make_notification())
+        assert result is False
+        # Should have been called 3 times (initial + 2 retries)
+        assert channel._session.post.call_count == 3
+
+    async def test_send_network_error_retries(self) -> None:
+        """Network errors trigger retries."""
+        import aiohttp
+
+        channel = _mock_slack_channel()
+        mock_response = AsyncMock()
+        mock_response.__aenter__ = AsyncMock(
+            side_effect=aiohttp.ClientError("connection reset"),
+        )
+        mock_response.__aexit__ = AsyncMock(return_value=False)
+        channel._session.post = MagicMock(return_value=mock_response)
+
+        result = await channel.send(_make_notification())
+        assert result is False
+        assert channel._session.post.call_count == 3
+
+
+# ---------------------------------------------------------------------------
+# message formatting
+# ---------------------------------------------------------------------------
+
+
+class TestSlackPayload:
+    async def test_payload_has_attachments_with_blocks(self) -> None:
+        channel = _mock_slack_channel()
+        notification = _make_notification(
+            title="Test Alert", severity=Severity.ERROR,
+        )
+        payload = channel._build_payload(notification)
+
+        assert "attachments" in payload
+        attachment = payload["attachments"][0]
+        assert attachment["color"] == "#E01E5A"  # red for error
+        assert len(attachment["blocks"]) == 4
+
+    async def test_payload_header_contains_title(self) -> None:
+        channel = _mock_slack_channel()
+        notification = _make_notification(title="DB Connection Lost")
+        payload = channel._build_payload(notification)
+
+        header = payload["attachments"][0]["blocks"][0]
+        assert header["type"] == "header"
+        assert header["text"]["text"] == "DB Connection Lost"
+
+    async def test_payload_severity_in_fields(self) -> None:
+        channel = _mock_slack_channel()
+        notification = _make_notification(severity=Severity.CRITICAL)
+        payload = channel._build_payload(notification)
+
+        fields_block = payload["attachments"][0]["blocks"][1]
+        severity_field = fields_block["fields"][0]
+        assert "CRITICAL" in severity_field["text"]
+
+    async def test_payload_event_id_in_fields(self) -> None:
+        channel = _mock_slack_channel()
+        notification = _make_notification(event_id="evt-123")
+        payload = channel._build_payload(notification)
+
+        fields_block = payload["attachments"][0]["blocks"][1]
+        event_field = fields_block["fields"][1]
+        assert "evt-123" in event_field["text"]
+
+    async def test_payload_message_in_section(self) -> None:
+        channel = _mock_slack_channel()
+        notification = _make_notification(message="Server unreachable")
+        payload = channel._build_payload(notification)
+
+        message_block = payload["attachments"][0]["blocks"][2]
+        assert message_block["text"]["text"] == "Server unreachable"
+
+    async def test_payload_includes_channel_override(self) -> None:
+        channel = _mock_slack_channel()
+        payload = channel._build_payload(_make_notification())
+        assert payload["channel"] == "#alerts"
+
+    async def test_payload_includes_username(self) -> None:
+        channel = _mock_slack_channel()
+        payload = channel._build_payload(_make_notification())
+        assert payload["username"] == "OasisAgent"
+
+    async def test_payload_includes_icon_emoji(self) -> None:
+        channel = _mock_slack_channel()
+        payload = channel._build_payload(_make_notification())
+        assert payload["icon_emoji"] == ":robot_face:"
+
+    async def test_payload_no_channel_when_empty(self) -> None:
+        channel = _mock_slack_channel(config=_make_config(channel=""))
+        payload = channel._build_payload(_make_notification())
+        assert "channel" not in payload
+
+    async def test_payload_no_event_id_shows_na(self) -> None:
+        channel = _mock_slack_channel()
+        notification = _make_notification(event_id=None)
+        payload = channel._build_payload(notification)
+
+        fields_block = payload["attachments"][0]["blocks"][1]
+        event_field = fields_block["fields"][1]
+        assert "N/A" in event_field["text"]
+
+    async def test_severity_colors(self) -> None:
+        channel = _mock_slack_channel()
+
+        for severity, expected_color in [
+            (Severity.CRITICAL, "#E01E5A"),
+            (Severity.ERROR, "#E01E5A"),
+            (Severity.WARNING, "#ECB22E"),
+            (Severity.INFO, "#36C5F0"),
+        ]:
+            notification = _make_notification(severity=severity)
+            payload = channel._build_payload(notification)
+            assert payload["attachments"][0]["color"] == expected_color, (
+                f"Wrong color for {severity}"
+            )
+
+    async def test_context_block_has_timestamp(self) -> None:
+        channel = _mock_slack_channel()
+        notification = _make_notification()
+        payload = channel._build_payload(notification)
+
+        context = payload["attachments"][0]["blocks"][3]
+        assert context["type"] == "context"
+        assert ":clock1:" in context["elements"][0]["text"]


### PR DESCRIPTION
## Summary
- Implement `SlackNotificationChannel` that posts Block Kit formatted messages to a Slack Incoming Webhook URL with severity color bars, event details, and timestamps
- Health tracking uses last-send-ok pattern (Slack webhooks have no ping endpoint)
- Config: `webhook_url`, `channel` (optional override), `username` (default "OasisAgent"), `icon_emoji` (default ":robot_face:")
- Retries on 5xx with exponential backoff, no retry on 4xx
- Full integration: config model, DB registry, config store, orchestrator, UI form specs

## Test plan
- [x] 30 unit tests covering:
  - [x] Channel name and health checks (disabled, no URL, before/after send)
  - [x] Lifecycle (start/stop, disabled mode)
  - [x] Send success, disabled no-op, missing URL, not started
  - [x] Retry on 5xx (3 attempts), no retry on 4xx, network errors
  - [x] Block Kit payload formatting (header, severity, event ID, message, timestamp)
  - [x] Optional channel/username/icon_emoji in payload
  - [x] Severity color mapping (critical/error=red, warning=yellow, info=blue)
- [x] `ruff check` passes
- [x] Full test suite: 1909 passed

Closes #59

🤖 Generated with [Claude Code](https://claude.com/claude-code)