### PR TITLE
Redirect to login on HTMX 401 (#144)

### DIFF
--- a/oasisagent/ui/templates/base.html
+++ b/oasisagent/ui/templates/base.html
@@ -22,6 +22,11 @@
             document.body.addEventListener('htmx:configRequest', function(e) {
                 e.detail.headers['X-CSRF-Token'] = getCsrfToken();
             });
+            document.body.addEventListener('htmx:afterRequest', function(evt) {
+                if (evt.detail.xhr && evt.detail.xhr.status === 401) {
+                    window.location.href = '/ui/login';
+                }
+            });
         });
     </script>
 </head>

--- a/tests/test_ui/test_htmx_401.py
+++ b/tests/test_ui/test_htmx_401.py
@@ -1,0 +1,21 @@
+"""Tests for HTMX 401 redirect handler (#144)."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+TEMPLATE = Path(__file__).resolve().parents[2] / "oasisagent" / "ui" / "templates" / "base.html"
+
+
+class TestHtmx401Handler:
+    def test_template_contains_after_request_handler(self) -> None:
+        content = TEMPLATE.read_text()
+        assert "htmx:afterRequest" in content
+
+    def test_template_checks_401_status(self) -> None:
+        content = TEMPLATE.read_text()
+        assert "status === 401" in content
+
+    def test_template_redirects_to_login(self) -> None:
+        content = TEMPLATE.read_text()
+        assert "'/ui/login'" in content


### PR DESCRIPTION
## Summary
- Adds `htmx:afterRequest` listener to `base.html` that catches 401 responses
- Redirects to `/ui/login` when session expires during HTMX health polls
- Prevents stale badges from silently accumulating

Closes #144

## Test plan
- [x] Template contains `htmx:afterRequest` handler with 401 check (3 tests)
- [x] Full suite: 1973 tests passing
- [ ] Manual: expire session → health poll redirects to login

🤖 Generated with [Claude Code](https://claude.com/claude-code)