### PR TITLE
Fix Cloudflare API path resolution dropping /client/v4/ prefix

### DIFF
--- a/oasisagent/clients/cloudflare.py
+++ b/oasisagent/clients/cloudflare.py
@@ -64,7 +64,7 @@ class CloudflareClient:
             msg = "Cloudflare client not started — call start() first"
             raise RuntimeError(msg)
 
-        async with self._session.get(path, params=params or None) as resp:
+        async with self._session.get(path.lstrip("/"), params=params or None) as resp:
             data = await resp.json()
             if resp.status >= 400:
                 errors = data.get("errors", [])
@@ -93,7 +93,7 @@ class CloudflareClient:
             msg = "Cloudflare client not started — call start() first"
             raise RuntimeError(msg)
 
-        async with self._session.post(path, json=json or {}) as resp:
+        async with self._session.post(path.lstrip("/"), json=json or {}) as resp:
             data = await resp.json()
             if resp.status >= 400:
                 errors = data.get("errors", [])
@@ -120,7 +120,7 @@ class CloudflareClient:
             msg = "Cloudflare client not started — call start() first"
             raise RuntimeError(msg)
 
-        async with self._session.delete(path) as resp:
+        async with self._session.delete(path.lstrip("/")) as resp:
             data = await resp.json()
             if resp.status >= 400:
                 errors = data.get("errors", [])


### PR DESCRIPTION
## Summary

- aiohttp treats paths with a leading `/` as absolute (relative to host), stripping the base_url path component. All Cloudflare API callers pass paths like `/accounts/{id}/cfd_tunnel`, causing requests to hit `https://api.cloudflare.com/accounts/...` instead of `https://api.cloudflare.com/client/v4/accounts/...`.
- Applied `lstrip("/")` in `get()`, `post()`, and `delete()` so the client correctly resolves relative to the base_url.
- Related to #153 which added the trailing slash to `_BASE_URL` — without this fix, the trailing slash alone doesn't help because the absolute paths override it.

## Test plan

- [x] 108 Cloudflare tests passing
- [x] All 1990 tests passing
- [ ] Deploy and verify Cloudflare tunnel polling returns data instead of 404

🤖 Generated with [Claude Code](https://claude.com/claude-code)