### PR TITLE
Fix UniFi client: retry auth on 403 in addition to 401

### DIFF
--- a/oasisagent/clients/unifi.py
+++ b/oasisagent/clients/unifi.py
@@ -1,12 +1,12 @@
 """UniFi Network controller HTTP client.
 
-Handles session cookie authentication, automatic re-auth on 401,
+Handles session cookie authentication, automatic re-auth on 401/403,
 and UDM/UCG path prefixing. Used by both the UniFi ingestion adapter
 and the UniFi handler.
 
 UniFi local controllers use POST /api/auth/login returning a session
 cookie — not a stateless token. Sessions expire unpredictably, so
-the client retries exactly once on 401 (re-authenticate then replay).
+the client retries exactly once on 401 or 403 (re-authenticate then replay).
 """
 
 from __future__ import annotations
@@ -124,7 +124,7 @@ class UnifiClient:
         *,
         json: dict[str, Any] | None = None,
     ) -> aiohttp.ClientResponse:
-        """Make an authenticated request. Retries exactly once on 401.
+        """Make an authenticated request. Retries exactly once on 401 or 403.
 
         Args:
             method: HTTP method (GET, POST, PUT, DELETE).
@@ -141,7 +141,7 @@ class UnifiClient:
         url = self._build_url(path)
 
         resp = await self._session.request(method, url, json=json)
-        if resp.status == 401:
+        if resp.status in (401, 403):
             resp.release()
             await self._authenticate()
             resp = await self._session.request(method, url, json=json)

--- a/tests/test_clients/test_unifi_client.py
+++ b/tests/test_clients/test_unifi_client.py
@@ -133,7 +133,7 @@ class TestAuthentication:
 
 
 # ---------------------------------------------------------------------------
-# Request with retry-on-401
+# Request with retry-on-401/403
 # ---------------------------------------------------------------------------
 
 
@@ -152,12 +152,13 @@ class TestRequestRetry:
         mock_session.request.assert_called_once()
 
     @pytest.mark.asyncio
-    async def test_401_triggers_reauth_and_retry(self) -> None:
+    @pytest.mark.parametrize("status", [401, 403])
+    async def test_auth_failure_triggers_reauth_and_retry(self, status: int) -> None:
         client = _make_client()
         mock_session = AsyncMock(spec=aiohttp.ClientSession)
 
         first_resp = MagicMock()
-        first_resp.status = 401
+        first_resp.status = status
         first_resp.release = MagicMock()
 
         second_resp = MagicMock()
@@ -175,6 +176,30 @@ class TestRequestRetry:
         assert mock_session.request.call_count == 2
         client._authenticate.assert_called_once()
         first_resp.release.assert_called_once()
+
+    @pytest.mark.asyncio
+    async def test_403_after_reauth_is_returned_as_is(self) -> None:
+        """If re-auth succeeds but the retry also returns 403, return it without looping."""
+        client = _make_client()
+        mock_session = AsyncMock(spec=aiohttp.ClientSession)
+
+        first_resp = MagicMock()
+        first_resp.status = 403
+        first_resp.release = MagicMock()
+
+        second_resp = MagicMock()
+        second_resp.status = 403
+
+        mock_session.request = AsyncMock(side_effect=[first_resp, second_resp])
+
+        client._session = mock_session
+        client._authenticate = AsyncMock()  # type: ignore[method-assign]
+
+        resp = await client.request("GET", "stat/device")
+
+        assert resp.status == 403
+        assert mock_session.request.call_count == 2
+        client._authenticate.assert_called_once()
 
     @pytest.mark.asyncio
     async def test_request_without_connect_raises(self) -> None:


### PR DESCRIPTION
## Summary
- UniFi client `request()` now retries authentication on HTTP 403 in addition to 401
- Some UniFi firmware versions return 403 (not 401) for expired session cookies
- One-line logic change: `== 401` → `in (401, 403)`
- Parametrized existing 401 retry test to cover both status codes

## Test plan
- [x] Parametrized test covers both 401 and 403 retry paths
- [x] New test verifies 403-after-successful-reauth is returned without second retry
- [x] Full suite: 2030 tests passing, `ruff check` clean

Closes #156

🤖 Generated with [Claude Code](https://claude.com/claude-code)