### PR TITLE
Fix UniFi handler: verify session validity in healthy()

### DIFF
--- a/oasisagent/handlers/unifi.py
+++ b/oasisagent/handlers/unifi.py
@@ -40,6 +40,8 @@ class UnifiHandler(Handler):
     The UnifiClient session is created in start() and closed in stop().
     """
 
+    _HEALTH_TIMEOUT: float = 3.0
+
     def __init__(self, config: UnifiHandlerConfig) -> None:
         self._config = config
         self._client: UnifiClient | None = None
@@ -69,13 +71,18 @@ class UnifiHandler(Handler):
             logger.info("UniFi handler stopped")
 
     async def healthy(self) -> bool:
-        """Check UniFi connectivity — session must be established.
-
-        Known limitation: does not verify the session cookie is still valid.
-        A stale session may report healthy=True but fail on the next API call.
-        UniFi sessions expire unpredictably; the client handles re-auth on 401.
-        """
-        return self._client is not None
+        """Check UniFi connectivity by hitting stat/health."""
+        if self._client is None:
+            return False
+        try:
+            data = await asyncio.wait_for(
+                self._client.get("stat/health"),
+                timeout=self._HEALTH_TIMEOUT,
+            )
+            return isinstance(data.get("data"), list)
+        except Exception:
+            logger.debug("UniFi health check failed", exc_info=True)
+            return False
 
     async def can_handle(
         self, event: Event, action: RecommendedAction,

--- a/tests/test_handlers/test_healthy.py
+++ b/tests/test_handlers/test_healthy.py
@@ -246,7 +246,11 @@ class TestUnifiHealthy:
             username="admin", password="secret",
         )
         handler = UnifiHandler(config)
-        handler._client = MagicMock()  # Simulate started client
+        mock_client = AsyncMock()
+        mock_client.get = AsyncMock(return_value={
+            "data": [{"subsystem": "wlan", "status": "ok"}],
+        })
+        handler._client = mock_client
 
         assert await handler.healthy() is True
 

--- a/tests/test_handlers/test_unifi.py
+++ b/tests/test_handlers/test_unifi.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import asyncio
 from datetime import UTC, datetime
 from typing import Any
 from unittest.mock import AsyncMock, patch
@@ -121,6 +122,58 @@ class TestLifecycle:
         handler = UnifiHandler(_make_config())
         with pytest.raises(RuntimeError, match="start\\(\\) must be called"):
             await handler.execute(_make_event(), _make_action())
+
+
+# ---------------------------------------------------------------------------
+# healthy
+# ---------------------------------------------------------------------------
+
+
+class TestHealthy:
+    @pytest.mark.asyncio
+    async def test_healthy_no_client(self) -> None:
+        handler = UnifiHandler(_make_config())
+        assert await handler.healthy() is False
+
+    @pytest.mark.asyncio
+    async def test_healthy_success(self) -> None:
+        handler = _make_handler()
+        handler._client.get = AsyncMock(return_value={
+            "data": [{"subsystem": "wlan", "status": "ok"}],
+        })
+
+        assert await handler.healthy() is True
+        handler._client.get.assert_called_once_with("stat/health")
+
+    @pytest.mark.asyncio
+    async def test_healthy_http_error(self) -> None:
+        handler = _make_handler()
+        handler._client.get = AsyncMock(
+            side_effect=aiohttp.ClientError("connection refused"),
+        )
+
+        assert await handler.healthy() is False
+
+    @pytest.mark.asyncio
+    async def test_healthy_timeout(self) -> None:
+        async def _slow_get(_endpoint: str) -> dict:
+            await asyncio.sleep(10)
+            return {"data": []}
+
+        handler = _make_handler()
+        handler._client.get = _slow_get
+        handler._HEALTH_TIMEOUT = 0.1
+
+        assert await handler.healthy() is False
+
+    @pytest.mark.asyncio
+    async def test_healthy_auth_failure(self) -> None:
+        handler = _make_handler()
+        handler._client.get = AsyncMock(
+            side_effect=ConnectionError("auth failed"),
+        )
+
+        assert await handler.healthy() is False
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary
- Replace shallow `client is not None` check with real API call to `stat/health`
- 3-second `asyncio.wait_for` timeout fits inside orchestrator's 5s envelope
- Class constant `_HEALTH_TIMEOUT` allows fast test override
- Any exception (timeout, auth, HTTP error) returns `False`

## Test plan
- [x] 5 new tests: no client, success, HTTP error, timeout, auth failure
- [x] Updated existing healthy-with-client test for new API call behavior
- [x] Full suite: 2033 tests passing, `ruff check` clean

Closes #157

🤖 Generated with [Claude Code](https://claude.com/claude-code)