### PR TITLE
Cloudflare: per-endpoint error isolation and health granularity

### DIFF
--- a/oasisagent/ingestion/cloudflare.py
+++ b/oasisagent/ingestion/cloudflare.py
@@ -49,7 +49,15 @@ class CloudflareAdapter(IngestAdapter):
         )
         self._stopping = False
         self._task: asyncio.Task[None] | None = None
-        self._connected = False
+
+        # Per-endpoint health tracking (replaces single _connected bool)
+        self._endpoint_health: dict[str, bool] = {}
+        if self._config.poll_tunnels and self._config.account_id:
+            self._endpoint_health["tunnels"] = False
+        if self._config.poll_waf and self._config.zone_id:
+            self._endpoint_health["waf"] = False
+        if self._config.poll_ssl and self._config.zone_id:
+            self._endpoint_health["ssl"] = False
 
         # Dedup trackers
         self._tunnel_states: dict[str, str] = {}  # tunnel_id → status
@@ -64,10 +72,8 @@ class CloudflareAdapter(IngestAdapter):
         """Connect to Cloudflare API and start the polling loop."""
         try:
             await self._client.start()
-            self._connected = True
         except Exception as exc:
             logger.error("Cloudflare adapter: connection failed: %s", exc)
-            self._connected = False
             return
 
         self._task = asyncio.create_task(
@@ -80,10 +86,20 @@ class CloudflareAdapter(IngestAdapter):
         if self._task is not None:
             self._task.cancel()
         await self._client.close()
-        self._connected = False
+        for key in self._endpoint_health:
+            self._endpoint_health[key] = False
 
     async def healthy(self) -> bool:
-        return self._connected
+        if not self._endpoint_health:
+            return False
+        return any(self._endpoint_health.values())
+
+    def health_detail(self) -> dict[str, str]:
+        """Per-endpoint health for dashboard display."""
+        return {
+            endpoint: ("connected" if ok else "disconnected")
+            for endpoint, ok in self._endpoint_health.items()
+        }
 
     # -----------------------------------------------------------------
     # Poll loop
@@ -92,22 +108,35 @@ class CloudflareAdapter(IngestAdapter):
     async def _poll_loop(self) -> None:
         """Main polling loop — polls all enabled endpoints each interval."""
         while not self._stopping:
-            try:
-                if self._config.poll_tunnels and self._config.account_id:
+            if self._config.poll_tunnels and self._config.account_id:
+                try:
                     await self._poll_tunnels()
+                    self._endpoint_health["tunnels"] = True
+                except asyncio.CancelledError:
+                    return
+                except Exception as exc:
+                    logger.warning("Cloudflare tunnels poll error: %s", exc)
+                    self._endpoint_health["tunnels"] = False
 
-                if self._config.poll_waf and self._config.zone_id:
+            if self._config.poll_waf and self._config.zone_id:
+                try:
                     await self._poll_waf()
+                    self._endpoint_health["waf"] = True
+                except asyncio.CancelledError:
+                    return
+                except Exception as exc:
+                    logger.warning("Cloudflare waf poll error: %s", exc)
+                    self._endpoint_health["waf"] = False
 
-                if self._config.poll_ssl and self._config.zone_id:
+            if self._config.poll_ssl and self._config.zone_id:
+                try:
                     await self._poll_ssl()
-
-                self._connected = True
-            except asyncio.CancelledError:
-                return
-            except Exception as exc:
-                logger.warning("Cloudflare poll error: %s", exc)
-                self._connected = False
+                    self._endpoint_health["ssl"] = True
+                except asyncio.CancelledError:
+                    return
+                except Exception as exc:
+                    logger.warning("Cloudflare ssl poll error: %s", exc)
+                    self._endpoint_health["ssl"] = False
 
             for _ in range(self._config.poll_interval):
                 if self._stopping:

--- a/oasisagent/orchestrator.py
+++ b/oasisagent/orchestrator.py
@@ -320,11 +320,21 @@ class Orchestrator:
             else:
                 services["scanner"] = "connected"
 
+        # --- Connector detail (per-endpoint breakdown) ---
+        connector_details: dict[str, dict[str, str]] = {}
+        for adapter in self._adapters:
+            if hasattr(adapter, "health_detail"):
+                detail = adapter.health_detail()
+                if detail:
+                    connector_details[adapter.name] = detail
+
         result: dict[str, dict[str, str]] = {
             "connectors": connectors,
             "services": services,
             "notifications": notifications,
         }
+        if connector_details:
+            result["connector_detail"] = connector_details  # type: ignore[assignment]
         if scanner_detail:
             result["scanner_detail"] = {"detail": scanner_detail}
         return result

--- a/tests/test_ingestion/test_cloudflare.py
+++ b/tests/test_ingestion/test_cloudflare.py
@@ -83,7 +83,7 @@ class TestAdapterLifecycle:
         adapter._client = AsyncMock()
         await adapter.stop()
         assert adapter._stopping is True
-        assert adapter._connected is False
+        assert all(v is False for v in adapter._endpoint_health.values())
 
     @pytest.mark.asyncio
     async def test_start_connection_failure(self) -> None:
@@ -92,7 +92,7 @@ class TestAdapterLifecycle:
             side_effect=ConnectionError("refused"),
         )
         await adapter.start()
-        assert adapter._connected is False
+        assert not await adapter.healthy()
 
 
 # ---------------------------------------------------------------------------
@@ -533,6 +533,177 @@ class TestEnqueueErrorHandling:
         )
 
         adapter._enqueue(event)  # should not raise
+
+
+# ---------------------------------------------------------------------------
+# Per-endpoint health tracking
+# ---------------------------------------------------------------------------
+
+
+class TestEndpointHealth:
+    def test_endpoint_health_initial_state(self) -> None:
+        """All endpoints start False before first poll."""
+        adapter, _ = _make_adapter()
+        assert adapter._endpoint_health == {
+            "tunnels": False, "waf": False, "ssl": False,
+        }
+
+    @pytest.mark.asyncio
+    async def test_healthy_any_endpoint_up(self) -> None:
+        adapter, _ = _make_adapter()
+        adapter._endpoint_health["tunnels"] = True
+        adapter._endpoint_health["waf"] = False
+        assert await adapter.healthy() is True
+
+    @pytest.mark.asyncio
+    async def test_healthy_all_endpoints_down(self) -> None:
+        adapter, _ = _make_adapter()
+        # All start False
+        assert await adapter.healthy() is False
+
+    @pytest.mark.asyncio
+    async def test_healthy_no_endpoints_enabled(self) -> None:
+        adapter, _ = _make_adapter(
+            poll_tunnels=False, poll_waf=False, poll_ssl=False,
+        )
+        assert adapter._endpoint_health == {}
+        assert await adapter.healthy() is False
+
+    @pytest.mark.asyncio
+    async def test_poll_waf_failure_isolates_tunnels_ssl(self) -> None:
+        """WAF failure does not affect tunnels or SSL health."""
+        adapter, _ = _make_adapter()
+
+        async def _fail_waf() -> None:
+            msg = "waf 400"
+            raise RuntimeError(msg)
+
+        adapter._poll_tunnels = AsyncMock()  # type: ignore[method-assign]
+        adapter._poll_waf = _fail_waf  # type: ignore[method-assign]
+        adapter._poll_ssl = AsyncMock()  # type: ignore[method-assign]
+
+        # Run one iteration then stop
+        adapter._stopping = False
+
+        async def _stop_after_one(*_args: object, **_kwargs: object) -> None:
+            adapter._stopping = True
+
+        with patch("asyncio.sleep", new=_stop_after_one):
+            await adapter._poll_loop()
+
+        assert adapter._endpoint_health["tunnels"] is True
+        assert adapter._endpoint_health["waf"] is False
+        assert adapter._endpoint_health["ssl"] is True
+
+    @pytest.mark.asyncio
+    async def test_poll_tunnel_failure_isolates_waf_ssl(self) -> None:
+        """Tunnel failure does not affect WAF or SSL health."""
+        adapter, _ = _make_adapter()
+
+        async def _fail_tunnels() -> None:
+            msg = "tunnel timeout"
+            raise RuntimeError(msg)
+
+        adapter._poll_tunnels = _fail_tunnels  # type: ignore[method-assign]
+        adapter._poll_waf = AsyncMock()  # type: ignore[method-assign]
+        adapter._poll_ssl = AsyncMock()  # type: ignore[method-assign]
+
+        adapter._stopping = False
+
+        async def _stop_after_one(*_args: object, **_kwargs: object) -> None:
+            adapter._stopping = True
+
+        with patch("asyncio.sleep", new=_stop_after_one):
+            await adapter._poll_loop()
+
+        assert adapter._endpoint_health["tunnels"] is False
+        assert adapter._endpoint_health["waf"] is True
+        assert adapter._endpoint_health["ssl"] is True
+
+    @pytest.mark.asyncio
+    async def test_all_polls_fail_healthy_false(self) -> None:
+        """All endpoints fail → healthy() returns False."""
+        adapter, _ = _make_adapter()
+
+        async def _fail() -> None:
+            msg = "boom"
+            raise RuntimeError(msg)
+
+        adapter._poll_tunnels = _fail  # type: ignore[method-assign]
+        adapter._poll_waf = _fail  # type: ignore[method-assign]
+        adapter._poll_ssl = _fail  # type: ignore[method-assign]
+
+        adapter._stopping = False
+
+        async def _stop_after_one(*_args: object, **_kwargs: object) -> None:
+            adapter._stopping = True
+
+        with patch("asyncio.sleep", new=_stop_after_one):
+            await adapter._poll_loop()
+
+        assert await adapter.healthy() is False
+
+    def test_health_detail_returns_per_endpoint_status(self) -> None:
+        """Mixed health returns correct connected/disconnected dict."""
+        adapter, _ = _make_adapter()
+        adapter._endpoint_health["tunnels"] = True
+        adapter._endpoint_health["waf"] = False
+        adapter._endpoint_health["ssl"] = True
+
+        detail = adapter.health_detail()
+        assert detail == {
+            "tunnels": "connected",
+            "waf": "disconnected",
+            "ssl": "connected",
+        }
+
+    @pytest.mark.asyncio
+    async def test_endpoint_health_recovery(self) -> None:
+        """Endpoint fails one cycle, succeeds next → flips to True."""
+        adapter, _ = _make_adapter(
+            poll_tunnels=True, poll_waf=False, poll_ssl=False,
+            account_id="acc-123", zone_id="",
+            poll_interval=1,
+        )
+
+        call_count = 0
+
+        async def _fail_then_succeed() -> None:
+            nonlocal call_count
+            call_count += 1
+            if call_count == 1:
+                msg = "first fail"
+                raise RuntimeError(msg)
+
+        adapter._poll_tunnels = _fail_then_succeed  # type: ignore[method-assign]
+
+        sleep_calls = 0
+
+        async def _stop_after_two_iterations(
+            *_args: object, **_kwargs: object,
+        ) -> None:
+            nonlocal sleep_calls
+            sleep_calls += 1
+            if sleep_calls >= 2:
+                adapter._stopping = True
+
+        with patch("asyncio.sleep", new=_stop_after_two_iterations):
+            await adapter._poll_loop()
+
+        assert adapter._endpoint_health["tunnels"] is True
+
+    @pytest.mark.asyncio
+    async def test_stop_clears_endpoint_health(self) -> None:
+        """After stop(), all endpoints are False."""
+        adapter, _ = _make_adapter()
+        adapter._endpoint_health["tunnels"] = True
+        adapter._endpoint_health["waf"] = True
+        adapter._endpoint_health["ssl"] = True
+
+        adapter._client = AsyncMock()
+        await adapter.stop()
+
+        assert all(v is False for v in adapter._endpoint_health.values())
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary
- Replace single `_connected` boolean with `_endpoint_health: dict[str, bool]` tracking tunnels/WAF/SSL independently
- Each poll endpoint gets its own try/except — a WAF 400 no longer kills tunnel/SSL polling
- `healthy()` returns `True` if any enabled endpoint is working
- New `health_detail()` method for dashboard sub-component visibility
- Orchestrator surfaces `connector_detail` in health API response (follows existing `scanner_detail` pattern)

## Test plan
- [x] 10 new tests: initial state, any/all/no endpoints, per-endpoint failure isolation, recovery, health_detail output, stop cleanup
- [x] Updated existing tests referencing `_connected`
- [x] Full suite: 2038 tests passing, `ruff check` clean

Closes #158
Closes #159

🤖 Generated with [Claude Code](https://claude.com/claude-code)