### PR TITLE
Improve Proxmox handler health check resilience

### DIFF
--- a/oasisagent/handlers/proxmox.py
+++ b/oasisagent/handlers/proxmox.py
@@ -47,6 +47,10 @@ _KNOWN_OPERATIONS: frozenset[str] = frozenset({
 # Default inventory cache TTL in seconds.
 _INVENTORY_TTL = 300
 
+# Health check cache TTL and per-request timeout.
+_HEALTH_CACHE_TTL = 30.0  # seconds
+_HEALTH_TIMEOUT = aiohttp.ClientTimeout(total=3)
+
 
 class HandlerNotStartedError(Exception):
     """Raised when handler methods are called before start()."""
@@ -66,6 +70,9 @@ class ProxmoxHandler(Handler):
         # Cluster resource inventory: vmid → {node, type, name, status, ...}
         self._inventory: dict[str, dict[str, Any]] = {}
         self._inventory_ts: float = 0.0
+        # Health check cache
+        self._health_cache: bool | None = None
+        self._health_cache_ts: float = 0.0
 
     def name(self) -> str:
         return "proxmox"
@@ -106,14 +113,55 @@ class ProxmoxHandler(Handler):
         if self._session is not None:
             await self._session.close()
             self._session = None
+            self._health_cache = None
+            self._health_cache_ts = 0.0
             logger.info("Proxmox handler stopped")
 
     async def healthy(self) -> bool:
-        """Check Proxmox connectivity via GET /api2/json/version."""
+        """Check Proxmox connectivity via GET /api2/json/version.
+
+        Uses a 30s TTL cache to avoid hammering an unreachable host.
+        Internal 3s timeout fits inside the orchestrator's 5s envelope.
+        """
         if self._session is None:
             return False
-        async with self._session.get("/api2/json/version") as resp:
-            return resp.status == 200
+
+        now = time.monotonic()
+        if self._health_cache is not None and (now - self._health_cache_ts) < _HEALTH_CACHE_TTL:
+            return self._health_cache
+
+        try:
+            async with self._session.get(
+                "/api2/json/version", timeout=_HEALTH_TIMEOUT,
+            ) as resp:
+                result = resp.status == 200
+                if not result:
+                    logger.warning(
+                        "Proxmox health check: HTTP %d (%s)",
+                        resp.status, self._config.url,
+                    )
+        except aiohttp.ClientConnectorError as exc:
+            logger.warning(
+                "Proxmox health check: connection failed (%s): %s",
+                self._config.url, exc,
+            )
+            result = False
+        except TimeoutError:
+            logger.warning(
+                "Proxmox health check: timed out after 3s (%s)",
+                self._config.url,
+            )
+            result = False
+        except aiohttp.ClientError as exc:
+            logger.warning(
+                "Proxmox health check failed (%s): %s",
+                self._config.url, exc,
+            )
+            result = False
+
+        self._health_cache = result
+        self._health_cache_ts = now
+        return result
 
     async def can_handle(self, event: Event, action: RecommendedAction) -> bool:
         return (

--- a/tests/test_handlers/test_proxmox.py
+++ b/tests/test_handlers/test_proxmox.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import asyncio
 from datetime import UTC, datetime
 from typing import Any
 from unittest.mock import AsyncMock, MagicMock, patch
@@ -11,6 +12,7 @@ import pytest
 
 from oasisagent.config import ProxmoxHandlerConfig
 from oasisagent.handlers.proxmox import (
+    _HEALTH_CACHE_TTL,
     HandlerNotStartedError,
     ProxmoxHandler,
 )
@@ -265,6 +267,142 @@ class TestLifecycle:
         handler = ProxmoxHandler(_make_config())
         with pytest.raises(HandlerNotStartedError):
             await handler.get_context(_make_event())
+
+
+# ---------------------------------------------------------------------------
+# healthy()
+# ---------------------------------------------------------------------------
+
+
+class TestHealthy:
+    async def test_healthy_returns_false_when_not_started(self) -> None:
+        handler = ProxmoxHandler(_make_config())
+        assert await handler.healthy() is False
+
+    async def test_healthy_returns_true_on_200(self) -> None:
+        handler = _started_handler()
+        _patch_session(handler, {
+            "get:/api2/json/version": _pve_response(data={"version": "8.0"}, status=200),
+        })
+
+        assert await handler.healthy() is True
+
+    async def test_healthy_returns_false_on_non_200(self) -> None:
+        handler = _started_handler()
+        resp = MagicMock()
+        resp.status = 403
+        resp.raise_for_status = MagicMock()
+        resp.json = AsyncMock(return_value={})
+        _patch_session(handler, {
+            "get:/api2/json/version": resp,
+        })
+
+        assert await handler.healthy() is False
+
+    async def test_healthy_returns_false_on_connection_error(self) -> None:
+        handler = _started_handler()
+        session = MagicMock(spec=aiohttp.ClientSession)
+        cm = MagicMock()
+        cm.__aenter__ = AsyncMock(
+            side_effect=aiohttp.ClientConnectorError(
+                connection_key=MagicMock(),
+                os_error=OSError("Connection refused"),
+            ),
+        )
+        cm.__aexit__ = AsyncMock(return_value=False)
+        session.get = MagicMock(return_value=cm)
+        session.close = AsyncMock()
+        handler._session = session
+
+        assert await handler.healthy() is False
+
+    async def test_healthy_returns_false_on_timeout(self) -> None:
+        handler = _started_handler()
+        session = MagicMock(spec=aiohttp.ClientSession)
+        cm = MagicMock()
+        cm.__aenter__ = AsyncMock(side_effect=asyncio.TimeoutError)
+        cm.__aexit__ = AsyncMock(return_value=False)
+        session.get = MagicMock(return_value=cm)
+        session.close = AsyncMock()
+        handler._session = session
+
+        assert await handler.healthy() is False
+
+    async def test_healthy_returns_false_on_generic_client_error(self) -> None:
+        handler = _started_handler()
+        session = MagicMock(spec=aiohttp.ClientSession)
+        cm = MagicMock()
+        cm.__aenter__ = AsyncMock(side_effect=aiohttp.ClientError("something broke"))
+        cm.__aexit__ = AsyncMock(return_value=False)
+        session.get = MagicMock(return_value=cm)
+        session.close = AsyncMock()
+        handler._session = session
+
+        assert await handler.healthy() is False
+
+    async def test_healthy_uses_cache_within_ttl(self) -> None:
+        handler = _started_handler()
+        _patch_session(handler, {
+            "get:/api2/json/version": _pve_response(data={"version": "8.0"}, status=200),
+        })
+
+        # First call — hits the session
+        assert await handler.healthy() is True
+        assert handler._session.get.call_count == 1
+
+        # Second call — should use cache, not hit session again
+        assert await handler.healthy() is True
+        assert handler._session.get.call_count == 1
+
+    async def test_healthy_refreshes_after_cache_expires(self) -> None:
+        import time
+
+        handler = _started_handler()
+        _patch_session(handler, {
+            "get:/api2/json/version": _pve_response(data={"version": "8.0"}, status=200),
+        })
+
+        # First call populates cache
+        assert await handler.healthy() is True
+        assert handler._session.get.call_count == 1
+
+        # Expire the cache by backdating the timestamp
+        handler._health_cache_ts = time.monotonic() - _HEALTH_CACHE_TTL - 1
+
+        # Second call should hit the session again
+        assert await handler.healthy() is True
+        assert handler._session.get.call_count == 2
+
+    async def test_healthy_caches_false_result(self) -> None:
+        handler = _started_handler()
+        session = MagicMock(spec=aiohttp.ClientSession)
+        cm = MagicMock()
+        cm.__aenter__ = AsyncMock(side_effect=asyncio.TimeoutError)
+        cm.__aexit__ = AsyncMock(return_value=False)
+        session.get = MagicMock(return_value=cm)
+        session.close = AsyncMock()
+        handler._session = session
+
+        # First call — timeout → False
+        assert await handler.healthy() is False
+        assert session.get.call_count == 1
+
+        # Second call — should use cached False, not hit session
+        assert await handler.healthy() is False
+        assert session.get.call_count == 1
+
+    async def test_stop_resets_health_cache(self) -> None:
+        handler = _started_handler()
+        _patch_session(handler, {
+            "get:/api2/json/version": _pve_response(data={"version": "8.0"}, status=200),
+        })
+
+        await handler.healthy()
+        assert handler._health_cache is True
+
+        await handler.stop()
+        assert handler._health_cache is None
+        assert handler._health_cache_ts == 0.0
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary
- 3-second internal timeout on `GET /api2/json/version` (inside orchestrator's 5s envelope)
- 30-second TTL health cache prevents hammering unreachable hosts on every dashboard refresh
- Structured error logging: connection failures, timeouts, and HTTP errors get distinct warning messages
- Cache resets on `stop()` so restart gets a fresh check

## Test plan
- [x] 10 new tests: not started, HTTP 200/non-200, connection error, timeout, generic error, cache within TTL, cache expiry, cached false, stop resets cache
- [x] Full suite: 2038 tests passing, `ruff check` clean

Closes #160

🤖 Generated with [Claude Code](https://claude.com/claude-code)