### PR TITLE
Fix Cloudflare WAF polling: use GraphQL Analytics API

### DIFF
--- a/oasisagent/clients/cloudflare.py
+++ b/oasisagent/clients/cloudflare.py
@@ -17,6 +17,7 @@ import aiohttp
 logger = logging.getLogger(__name__)
 
 _BASE_URL = "https://api.cloudflare.com/client/v4/"
+_GRAPHQL_URL = "https://api.cloudflare.com/graphql"
 
 
 class CloudflareClient:
@@ -105,6 +106,39 @@ class CloudflareClient:
             if not data.get("success", True):
                 errors = data.get("errors", [])
                 msg = f"Cloudflare API error on POST {path}: {errors}"
+                raise aiohttp.ClientResponseError(
+                    resp.request_info, resp.history,
+                    status=resp.status, message=msg,
+                )
+            return data
+
+    async def graphql(
+        self, query: str, variables: dict[str, Any] | None = None,
+    ) -> dict[str, Any]:
+        """POST a GraphQL query to the Cloudflare Analytics API.
+
+        Uses the absolute ``_GRAPHQL_URL`` (not the REST ``_BASE_URL``).
+        Raises on HTTP errors or GraphQL-level errors.
+        """
+        if self._session is None:
+            msg = "Cloudflare client not started — call start() first"
+            raise RuntimeError(msg)
+
+        body: dict[str, Any] = {"query": query}
+        if variables is not None:
+            body["variables"] = variables
+
+        async with self._session.post(_GRAPHQL_URL, json=body) as resp:
+            data = await resp.json()
+            if resp.status >= 400:
+                msg = f"Cloudflare GraphQL failed (HTTP {resp.status})"
+                raise aiohttp.ClientResponseError(
+                    resp.request_info, resp.history,
+                    status=resp.status, message=msg,
+                )
+            if data.get("errors"):
+                msgs = [e.get("message", "") for e in data["errors"]]
+                msg = f"Cloudflare GraphQL errors: {msgs}"
                 raise aiohttp.ClientResponseError(
                     resp.request_info, resp.history,
                     status=resp.status, message=msg,

--- a/oasisagent/ingestion/cloudflare.py
+++ b/oasisagent/ingestion/cloudflare.py
@@ -239,9 +239,21 @@ class CloudflareAdapter(IngestAdapter):
         self._last_waf_poll = now
 
         since_str = since.strftime("%Y-%m-%dT%H:%M:%SZ")
-        path = f"/zones/{self._config.zone_id}/security/events"
-        data = await self._client.get(path, since=since_str)
-        events: list[dict[str, Any]] = data.get("result", [])
+        query = (
+            "{ viewer { zones(filter: {zoneTag: \""
+            + self._config.zone_id
+            + "\"}) { firewallEventsAdaptive("
+            + "filter: {datetime_gt: \""
+            + since_str
+            + "\"} limit: 100 orderBy: [datetime_DESC]"
+            + ") { action clientIP ruleId datetime } } } }"
+        )
+
+        resp = await self._client.graphql(query)
+        zones = resp.get("data", {}).get("viewer", {}).get("zones", [])
+        events: list[dict[str, Any]] = (
+            zones[0].get("firewallEventsAdaptive", []) if zones else []
+        )
 
         if not events:
             return

--- a/tests/test_clients/test_cloudflare_client.py
+++ b/tests/test_clients/test_cloudflare_client.py
@@ -9,7 +9,7 @@ from unittest.mock import AsyncMock, MagicMock, patch
 import aiohttp
 import pytest
 
-from oasisagent.clients.cloudflare import CloudflareClient
+from oasisagent.clients.cloudflare import _GRAPHQL_URL, CloudflareClient
 
 
 def _make_client(**overrides: object) -> CloudflareClient:
@@ -232,3 +232,83 @@ class TestDelete:
         client = _make_client()
         with pytest.raises(RuntimeError, match="not started"):
             await client.delete("/test")
+
+
+# ---------------------------------------------------------------------------
+# GraphQL
+# ---------------------------------------------------------------------------
+
+
+class TestGraphql:
+    @pytest.mark.asyncio
+    async def test_graphql_returns_data(self) -> None:
+        gql_resp = {
+            "data": {"viewer": {"zones": [{"firewallEventsAdaptive": []}]}},
+            "errors": None,
+        }
+        resp = _mock_resp(200, gql_resp)
+        client = _make_client()
+        mock_session = MagicMock()
+        captured: list[tuple[tuple[Any, ...], dict[str, Any]]] = []
+
+        @asynccontextmanager
+        async def _tracking_post(*args: Any, **kwargs: Any) -> Any:  # noqa: ANN401
+            captured.append((args, kwargs))
+            yield resp
+
+        mock_session.post = _tracking_post
+        client._session = mock_session
+
+        result = await client.graphql("{ viewer { zones { id } } }")
+
+        assert result == gql_resp
+        assert len(captured) == 1
+        assert captured[0][0][0] == _GRAPHQL_URL
+        assert captured[0][1]["json"] == {"query": "{ viewer { zones { id } } }"}
+
+    @pytest.mark.asyncio
+    async def test_graphql_raises_on_http_error(self) -> None:
+        resp = _mock_resp(403, {"errors": [{"message": "Forbidden"}]})
+        _, client = _mock_session_with("post", resp)
+
+        with pytest.raises(aiohttp.ClientResponseError):
+            await client.graphql("{ viewer { zones { id } } }")
+
+    @pytest.mark.asyncio
+    async def test_graphql_raises_on_graphql_errors(self) -> None:
+        resp = _mock_resp(200, {
+            "data": None,
+            "errors": [{"message": "Validation error"}],
+        })
+        _, client = _mock_session_with("post", resp)
+
+        with pytest.raises(aiohttp.ClientResponseError, match="GraphQL errors"):
+            await client.graphql("{ bad }")
+
+    @pytest.mark.asyncio
+    async def test_graphql_not_started_raises(self) -> None:
+        client = _make_client()
+        with pytest.raises(RuntimeError, match="not started"):
+            await client.graphql("{ viewer { zones { id } } }")
+
+    @pytest.mark.asyncio
+    async def test_graphql_no_variables(self) -> None:
+        """When variables is None, body should only contain 'query' key."""
+        resp = _mock_resp(200, {"data": {}, "errors": None})
+        client = _make_client()
+        mock_session = MagicMock()
+        captured: list[tuple[tuple[Any, ...], dict[str, Any]]] = []
+
+        @asynccontextmanager
+        async def _tracking_post(*args: Any, **kwargs: Any) -> Any:  # noqa: ANN401
+            captured.append((args, kwargs))
+            yield resp
+
+        mock_session.post = _tracking_post
+        client._session = mock_session
+
+        await client.graphql("{ viewer { zones { id } } }")
+
+        assert len(captured) == 1
+        assert "variables" not in captured[0][1]["json"]
+        assert captured[0][1]["json"] == {"query": "{ viewer { zones { id } } }"}

--- a/tests/test_ingestion/test_cloudflare.py
+++ b/tests/test_ingestion/test_cloudflare.py
@@ -232,6 +232,20 @@ class TestTunnelPolling:
 # ---------------------------------------------------------------------------
 
 
+def _graphql_waf_response(
+    events: list[dict[str, object]],
+) -> dict[str, object]:
+    """Wrap WAF events in the Cloudflare GraphQL response envelope."""
+    return {
+        "data": {
+            "viewer": {
+                "zones": [{"firewallEventsAdaptive": events}],
+            },
+        },
+        "errors": None,
+    }
+
+
 class TestWafPolling:
     @pytest.mark.asyncio
     async def test_waf_spike_event(self) -> None:
@@ -246,9 +260,9 @@ class TestWafPolling:
             {"action": "managed_challenge", "ruleId": "r3", "clientIP": "9.0.1.2"},
         ]
 
-        adapter._client.get = AsyncMock(return_value={
-            "result": waf_events,
-        })
+        adapter._client.graphql = AsyncMock(
+            return_value=_graphql_waf_response(waf_events),
+        )
 
         await adapter._poll_waf()
 
@@ -264,11 +278,11 @@ class TestWafPolling:
     async def test_waf_below_threshold_no_event(self) -> None:
         adapter, queue = _make_adapter(waf_spike_threshold=10)
 
-        adapter._client.get = AsyncMock(return_value={
-            "result": [
+        adapter._client.graphql = AsyncMock(
+            return_value=_graphql_waf_response([
                 {"action": "block", "ruleId": "r1", "clientIP": "1.2.3.4"},
-            ],
-        })
+            ]),
+        )
 
         await adapter._poll_waf()
         queue.put_nowait.assert_not_called()
@@ -277,13 +291,13 @@ class TestWafPolling:
     async def test_waf_allow_actions_not_counted(self) -> None:
         adapter, queue = _make_adapter(waf_spike_threshold=3)
 
-        adapter._client.get = AsyncMock(return_value={
-            "result": [
+        adapter._client.graphql = AsyncMock(
+            return_value=_graphql_waf_response([
                 {"action": "allow", "ruleId": "r1", "clientIP": "1.2.3.4"},
                 {"action": "log", "ruleId": "r2", "clientIP": "5.6.7.8"},
                 {"action": "block", "ruleId": "r3", "clientIP": "9.0.1.2"},
-            ],
-        })
+            ]),
+        )
 
         await adapter._poll_waf()
         queue.put_nowait.assert_not_called()  # only 1 blocked
@@ -292,41 +306,58 @@ class TestWafPolling:
     async def test_waf_empty_response_no_event(self) -> None:
         adapter, queue = _make_adapter()
 
-        adapter._client.get = AsyncMock(return_value={"result": []})
+        adapter._client.graphql = AsyncMock(
+            return_value=_graphql_waf_response([]),
+        )
 
         await adapter._poll_waf()
         queue.put_nowait.assert_not_called()
 
     @pytest.mark.asyncio
     async def test_waf_lookback_uses_last_poll_time(self) -> None:
-        """Second poll should use last poll time, not lookback window."""
+        """Second poll should use datetime_gt in query string."""
         from datetime import UTC, datetime
 
         adapter, _queue = _make_adapter(waf_spike_threshold=100)
         first_time = datetime(2026, 3, 12, 10, 0, 0, tzinfo=UTC)
         adapter._last_waf_poll = first_time
 
-        adapter._client.get = AsyncMock(return_value={"result": []})
+        adapter._client.graphql = AsyncMock(
+            return_value=_graphql_waf_response([]),
+        )
 
         await adapter._poll_waf()
 
-        call_kwargs = adapter._client.get.call_args[1]
-        assert call_kwargs["since"] == "2026-03-12T10:00:00Z"
+        query_arg = adapter._client.graphql.call_args[0][0]
+        assert "2026-03-12T10:00:00Z" in query_arg
 
     @pytest.mark.asyncio
     async def test_waf_dedup_key(self) -> None:
         adapter, queue = _make_adapter(waf_spike_threshold=1)
 
-        adapter._client.get = AsyncMock(return_value={
-            "result": [
+        adapter._client.graphql = AsyncMock(
+            return_value=_graphql_waf_response([
                 {"action": "block", "ruleId": "r1", "clientIP": "1.2.3.4"},
-            ],
-        })
+            ]),
+        )
 
         await adapter._poll_waf()
 
         event = queue.put_nowait.call_args[0][0]
         assert event.metadata.dedup_key == "cloudflare:waf:zone-456:spike"
+
+    @pytest.mark.asyncio
+    async def test_waf_empty_zones_no_event(self) -> None:
+        """Invalid zone tag returns empty zones list — should not crash."""
+        adapter, queue = _make_adapter()
+
+        adapter._client.graphql = AsyncMock(return_value={
+            "data": {"viewer": {"zones": []}},
+            "errors": None,
+        })
+
+        await adapter._poll_waf()
+        queue.put_nowait.assert_not_called()
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

- **Fixes #165** — `_poll_waf` called `GET /zones/{zone_id}/security/events`, which doesn't exist in the Cloudflare v4 REST API, causing HTTP 400 every poll cycle
- Added `graphql()` method to `CloudflareClient` that POSTs to the absolute `https://api.cloudflare.com/graphql` endpoint with proper HTTP and GraphQL-level error handling
- Rewrote `_poll_waf` to use `firewallEventsAdaptive` GraphQL dataset — spike detection logic unchanged since response fields (`action`, `clientIP`, `ruleId`) match
- Handles empty zones list gracefully (invalid zone tag → no crash)

## Test plan

- [x] 5 new `TestGraphql` client tests (happy path, HTTP error, GraphQL errors, not started, no variables)
- [x] 1 new `test_waf_empty_zones_no_event` adapter test
- [x] 6 existing WAF adapter tests updated to mock `graphql()` instead of `get()`
- [x] All 63 Cloudflare tests pass
- [x] Full suite: 2061 tests passing
- [x] `ruff check` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)