### PR TITLE
Validate UniFi site name at startup, warn on likely display name

### DIFF
--- a/oasisagent/clients/unifi.py
+++ b/oasisagent/clients/unifi.py
@@ -57,6 +57,8 @@ class UnifiClient:
         self._session: aiohttp.ClientSession | None = None
         self._authenticated = False
 
+        self._validate_site_name(site)
+
     @property
     def site(self) -> str:
         """The configured UniFi site name."""
@@ -187,6 +189,30 @@ class UnifiClient:
     # -----------------------------------------------------------------
     # Helpers
     # -----------------------------------------------------------------
+
+    @staticmethod
+    def _validate_site_name(site: str) -> None:
+        """Warn if the site name looks like a display name instead of a site ID.
+
+        UniFi site IDs are typically lowercase alphanumeric (e.g., "default").
+        Display names often contain spaces or uppercase letters, which produce
+        URLs like ``/api/s/Oasis%20UDMP/stat/device`` and fail with
+        ``api.err.NoSiteContext``.
+        """
+        reasons: list[str] = []
+        if " " in site:
+            reasons.append("contains spaces")
+        if site != site.lower():
+            reasons.append("contains uppercase letters")
+
+        if reasons:
+            logger.warning(
+                "UniFi site '%s' %s — this looks like a display name, not a "
+                "site ID. Site IDs are typically lowercase alphanumeric "
+                "(e.g., 'default').",
+                site,
+                " and ".join(reasons),
+            )
 
     def _build_url(self, path: str) -> str:
         """Build the full URL with optional UDM prefix and site."""

--- a/tests/test_clients/test_unifi_client.py
+++ b/tests/test_clients/test_unifi_client.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import logging
 from unittest.mock import AsyncMock, MagicMock, patch
 
 import aiohttp
@@ -349,3 +350,51 @@ class TestSslConfig:
             await client.connect()
 
             mock_connector_cls.assert_called_once_with(ssl=True)
+
+
+# ---------------------------------------------------------------------------
+# Site name validation
+# ---------------------------------------------------------------------------
+
+
+class TestSiteNameValidation:
+    def test_valid_site_no_warning(self, caplog: pytest.LogCaptureFixture) -> None:
+        """Lowercase alphanumeric site IDs should not trigger a warning."""
+        with caplog.at_level(logging.WARNING, logger="oasisagent.clients.unifi"):
+            _make_client(site="default")
+        assert caplog.text == ""
+
+    def test_valid_site_alphanumeric(self, caplog: pytest.LogCaptureFixture) -> None:
+        """Site IDs like 'abc123' are valid and should not warn."""
+        with caplog.at_level(logging.WARNING, logger="oasisagent.clients.unifi"):
+            _make_client(site="abc123")
+        assert caplog.text == ""
+
+    def test_site_with_spaces_warns(self, caplog: pytest.LogCaptureFixture) -> None:
+        """A site name with spaces looks like a display name."""
+        with caplog.at_level(logging.WARNING, logger="oasisagent.clients.unifi"):
+            _make_client(site="Oasis UDMP")
+        assert "Oasis UDMP" in caplog.text
+        assert "contains spaces" in caplog.text
+        assert "display name" in caplog.text
+
+    def test_site_with_uppercase_warns(self, caplog: pytest.LogCaptureFixture) -> None:
+        """A site name with uppercase letters looks like a display name."""
+        with caplog.at_level(logging.WARNING, logger="oasisagent.clients.unifi"):
+            _make_client(site="MyHome")
+        assert "MyHome" in caplog.text
+        assert "contains uppercase letters" in caplog.text
+        assert "display name" in caplog.text
+
+    def test_site_with_spaces_and_uppercase_warns_both(
+        self, caplog: pytest.LogCaptureFixture,
+    ) -> None:
+        """Both issues should be mentioned in the warning."""
+        with caplog.at_level(logging.WARNING, logger="oasisagent.clients.unifi"):
+            _make_client(site="My Home")
+        assert "contains spaces and contains uppercase letters" in caplog.text
+
+    def test_site_with_spaces_does_not_block(self) -> None:
+        """Client should still be created even with a suspicious site name."""
+        client = _make_client(site="Oasis UDMP")
+        assert client.site == "Oasis UDMP"


### PR DESCRIPTION
Closes #169

## Summary
- Add `_validate_site_name()` static method to `UnifiClient` that logs a WARNING when the configured site contains spaces or uppercase letters (indicators of a display name vs. a site ID)
- Validation runs at `__init__` time so the warning appears early in startup logs
- Does not block startup — the user may have a valid edge case

## Test plan
- [x] Valid site IDs (`"default"`, `"abc123"`) produce no warning
- [x] Site with spaces (`"Oasis UDMP"`) logs warning mentioning "contains spaces"
- [x] Site with uppercase (`"MyHome"`) logs warning mentioning "contains uppercase letters"
- [x] Site with both issues mentions both in the warning message
- [x] Client is still created and functional with a suspicious site name
- [x] Full test suite passes (2067 tests)
- [x] `ruff check` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)