### PR TITLE
Auto-execute notify-only actions, skip approval queue

### DIFF
--- a/oasisagent/orchestrator.py
+++ b/oasisagent/orchestrator.py
@@ -1030,7 +1030,12 @@ class Orchestrator:
         for action in result.recommended_actions:
             cb_entity = action.target_entity_id or event.entity_id
 
-            # RECOMMEND-tier actions go to the pending queue
+            # RECOMMEND-tier actions go to the pending queue — except
+            # notify-only actions which are auto-executed (no state mutation).
+            if action.risk_tier == RiskTier.RECOMMEND and action.operation == "notify":
+                await self._auto_execute_notify(event, result, action)
+                continue
+
             if action.risk_tier == RiskTier.RECOMMEND:
                 pending = await self._pending_queue.add(
                     event_id=event.id,
@@ -1090,6 +1095,46 @@ class Orchestrator:
                 )
 
     # -------------------------------------------------------------------
+    # Notify auto-execution
+    # -------------------------------------------------------------------
+
+    async def _auto_execute_notify(
+        self, event: Event, result: DecisionResult, action: RecommendedAction
+    ) -> None:
+        """Auto-execute a notify action, bypassing the approval queue.
+
+        Notify actions log a message but never mutate system state, so
+        requiring operator approval adds no safety value and causes
+        infinite enqueue/expire loops when the pending action times out.
+        """
+        handler = self._handlers.get(action.handler)
+        if handler is None:
+            logger.warning(
+                "No handler registered for '%s' (auto-execute notify, event %s)",
+                action.handler,
+                event.id,
+            )
+            return
+
+        logger.info(
+            "Auto-executing notify action (no approval needed): %s [event=%s]",
+            action.description[:80],
+            event.id,
+        )
+
+        try:
+            action_result = await handler.execute(event, action)
+            if action_result.status == ActionStatus.SUCCESS:
+                self._actions_taken += 1
+        except Exception:
+            logger.exception(
+                "Auto-execute notify failed for event %s", event.id
+            )
+
+        # Still send the notification so it appears in the feed
+        await self._send_notification(event, result)
+
+    # -------------------------------------------------------------------
     # Approval queue
     # -------------------------------------------------------------------
 
@@ -1115,6 +1160,12 @@ class Orchestrator:
             params=fix.action.details,
             risk_tier=fix.risk_tier,
         )
+
+        # Notify-only actions don't mutate state — skip the approval queue
+        # and execute directly to avoid infinite enqueue/expire loops.
+        if action.operation == "notify":
+            await self._auto_execute_notify(event, result, action)
+            return
 
         pending = await self._pending_queue.add(
             event_id=event.id,

--- a/tests/test_orchestrator.py
+++ b/tests/test_orchestrator.py
@@ -36,6 +36,7 @@ from oasisagent.models import (
     ActionStatus,
     Event,
     EventMetadata,
+    RecommendedAction,
     RiskTier,
     Severity,
 )
@@ -813,3 +814,208 @@ class TestEventCorrelation:
         await orchestrator._process_one(event)
 
         assert event.metadata.correlation_id is not None
+
+
+# ---------------------------------------------------------------------------
+# Notify auto-execution (issue #167)
+# ---------------------------------------------------------------------------
+
+
+class TestNotifyAutoExecution:
+    """Notify-only RECOMMEND actions bypass the approval queue."""
+
+    async def test_t0_notify_action_auto_executes(self) -> None:
+        """T0 RECOMMEND + operation=notify executes handler directly."""
+        orchestrator = _setup_orchestrator()
+        mocks = _mock_components(orchestrator)
+        event = _make_event()
+        mocks["decision"].process_event.return_value = _matched_result(
+            event.id, risk_tier=RiskTier.RECOMMEND
+        )
+
+        mock_handler = AsyncMock()
+        mock_handler.execute.return_value = ActionResult(
+            status=ActionStatus.SUCCESS
+        )
+        orchestrator._handlers["homeassistant"] = mock_handler
+
+        # Mock registry to return a fix with operation=notify
+        mock_registry = MagicMock()
+        mock_fix = MagicMock()
+        mock_fix.action.handler = "homeassistant"
+        mock_fix.action.operation = "notify"
+        mock_fix.action.details = {"message": "Entity unavailable"}
+        mock_fix.diagnosis = "Entity is unavailable"
+        mock_fix.risk_tier = RiskTier.RECOMMEND
+        mock_registry.get_fix_by_id.return_value = mock_fix
+        orchestrator._registry = mock_registry
+
+        await orchestrator._process_one(event)
+
+        # Handler should be called (auto-executed)
+        mock_handler.execute.assert_called_once()
+        # Should NOT be enqueued to pending queue
+        assert orchestrator._pending_queue is not None
+        assert len(orchestrator._pending_queue.list_pending()) == 0
+        # Notification should still be sent
+        mocks["dispatcher"].dispatch.assert_called()
+        # Actions counter incremented
+        assert orchestrator._actions_taken == 1
+
+    async def test_t0_non_notify_recommend_still_enqueues(self) -> None:
+        """T0 RECOMMEND + operation!=notify still goes to pending queue."""
+        orchestrator = _setup_orchestrator()
+        mocks = _mock_components(orchestrator)
+        event = _make_event()
+        mocks["decision"].process_event.return_value = _matched_result(
+            event.id, risk_tier=RiskTier.RECOMMEND
+        )
+
+        mock_handler = AsyncMock()
+        orchestrator._handlers["homeassistant"] = mock_handler
+
+        mock_registry = MagicMock()
+        mock_fix = MagicMock()
+        mock_fix.action.handler = "homeassistant"
+        mock_fix.action.operation = "restart_integration"
+        mock_fix.action.details = {}
+        mock_fix.diagnosis = "Restart integration"
+        mock_fix.risk_tier = RiskTier.RECOMMEND
+        mock_registry.get_fix_by_id.return_value = mock_fix
+        orchestrator._registry = mock_registry
+
+        await orchestrator._process_one(event)
+
+        # Handler should NOT be called
+        mock_handler.execute.assert_not_called()
+        # Should be enqueued
+        assert orchestrator._pending_queue is not None
+        assert len(orchestrator._pending_queue.list_pending()) == 1
+
+    async def test_t2_notify_action_auto_executes(self) -> None:
+        """T2 RECOMMEND + operation=notify executes handler directly."""
+        orchestrator = _setup_orchestrator()
+        mocks = _mock_components(orchestrator)
+        event = _make_event()
+
+        notify_action = RecommendedAction(
+            description="Entity unavailable notification",
+            handler="homeassistant",
+            operation="notify",
+            params={"message": "Entity unavailable"},
+            risk_tier=RiskTier.RECOMMEND,
+        )
+        result = DecisionResult(
+            event_id=event.id,
+            tier=DecisionTier.T2,
+            disposition=DecisionDisposition.MATCHED,
+            diagnosis="T2 diagnosis",
+            recommended_actions=[notify_action],
+        )
+        mocks["decision"].process_event.return_value = result
+
+        mock_handler = AsyncMock()
+        mock_handler.execute.return_value = ActionResult(
+            status=ActionStatus.SUCCESS
+        )
+        orchestrator._handlers["homeassistant"] = mock_handler
+
+        await orchestrator._process_one(event)
+
+        # Handler should be called (auto-executed)
+        mock_handler.execute.assert_called_once()
+        # Should NOT be enqueued
+        assert orchestrator._pending_queue is not None
+        assert len(orchestrator._pending_queue.list_pending()) == 0
+        assert orchestrator._actions_taken == 1
+
+    async def test_t2_non_notify_recommend_still_enqueues(self) -> None:
+        """T2 RECOMMEND + operation!=notify still goes to pending queue."""
+        orchestrator = _setup_orchestrator()
+        mocks = _mock_components(orchestrator)
+        event = _make_event()
+
+        restart_action = RecommendedAction(
+            description="Restart integration",
+            handler="homeassistant",
+            operation="restart_integration",
+            params={},
+            risk_tier=RiskTier.RECOMMEND,
+        )
+        result = DecisionResult(
+            event_id=event.id,
+            tier=DecisionTier.T2,
+            disposition=DecisionDisposition.MATCHED,
+            diagnosis="T2 diagnosis",
+            recommended_actions=[restart_action],
+        )
+        mocks["decision"].process_event.return_value = result
+
+        mock_handler = AsyncMock()
+        orchestrator._handlers["homeassistant"] = mock_handler
+
+        await orchestrator._process_one(event)
+
+        # Handler should NOT be called
+        mock_handler.execute.assert_not_called()
+        # Should be enqueued
+        assert orchestrator._pending_queue is not None
+        assert len(orchestrator._pending_queue.list_pending()) == 1
+
+    async def test_notify_auto_execute_no_handler_logs_warning(self) -> None:
+        """Auto-execute notify with missing handler logs warning, no crash."""
+        orchestrator = _setup_orchestrator()
+        mocks = _mock_components(orchestrator)
+        event = _make_event()
+        mocks["decision"].process_event.return_value = _matched_result(
+            event.id, risk_tier=RiskTier.RECOMMEND
+        )
+
+        # No handler registered — orchestrator._handlers is empty
+        mock_registry = MagicMock()
+        mock_fix = MagicMock()
+        mock_fix.action.handler = "homeassistant"
+        mock_fix.action.operation = "notify"
+        mock_fix.action.details = {}
+        mock_fix.diagnosis = "Entity unavailable"
+        mock_fix.risk_tier = RiskTier.RECOMMEND
+        mock_registry.get_fix_by_id.return_value = mock_fix
+        orchestrator._registry = mock_registry
+
+        # Should not raise
+        await orchestrator._process_one(event)
+
+        # No pending actions created
+        assert orchestrator._pending_queue is not None
+        assert len(orchestrator._pending_queue.list_pending()) == 0
+        # Actions counter NOT incremented (handler missing)
+        assert orchestrator._actions_taken == 0
+
+    async def test_notify_auto_execute_handler_failure_does_not_crash(self) -> None:
+        """Handler exception during auto-execute notify is caught gracefully."""
+        orchestrator = _setup_orchestrator()
+        mocks = _mock_components(orchestrator)
+        event = _make_event()
+        mocks["decision"].process_event.return_value = _matched_result(
+            event.id, risk_tier=RiskTier.RECOMMEND
+        )
+
+        mock_handler = AsyncMock()
+        mock_handler.execute.side_effect = RuntimeError("handler crashed")
+        orchestrator._handlers["homeassistant"] = mock_handler
+
+        mock_registry = MagicMock()
+        mock_fix = MagicMock()
+        mock_fix.action.handler = "homeassistant"
+        mock_fix.action.operation = "notify"
+        mock_fix.action.details = {}
+        mock_fix.diagnosis = "Entity unavailable"
+        mock_fix.risk_tier = RiskTier.RECOMMEND
+        mock_registry.get_fix_by_id.return_value = mock_fix
+        orchestrator._registry = mock_registry
+
+        # Should not raise
+        await orchestrator._process_one(event)
+
+        # Actions counter NOT incremented (handler failed)
+        assert orchestrator._actions_taken == 0


### PR DESCRIPTION
## Summary

Closes #167

- Add `_auto_execute_notify()` method to the orchestrator that bypasses the pending/approval queue for actions with `operation: notify`
- Hook into both T0 dispatch path (`_enqueue_pending`) and T2 dispatch path (`_dispatch_t2_actions`) so notify actions are auto-executed regardless of which tier matched
- Notify actions still send notifications to the feed — they just skip the approval queue since they don't mutate system state
- Fixes infinite enqueue/expire loop where `ha-entity-unavailable-generic` (operation=notify, risk_tier=recommend) would expire after 30 min and immediately re-enqueue

## Test plan

- [x] T0 RECOMMEND + notify auto-executes handler directly
- [x] T0 RECOMMEND + non-notify still enqueues to pending queue
- [x] T2 RECOMMEND + notify auto-executes handler directly
- [x] T2 RECOMMEND + non-notify still enqueues to pending queue
- [x] Missing handler for notify action logs warning without crash
- [x] Handler exception during notify auto-execute is caught gracefully
- [x] Full test suite passes (2067 tests)
- [x] `ruff check` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)