### PR TITLE
Add LLM health check warm-up probes at startup

### DIFF
--- a/oasisagent/llm/client.py
+++ b/oasisagent/llm/client.py
@@ -204,6 +204,60 @@ class LLMClient:
         """Return cumulative token usage per role."""
         return {role.value: stats for role, stats in self._usage.items()}
 
+    async def warm_up(self) -> dict[LLMRole, bool]:
+        """Send a minimal probe prompt to each configured role.
+
+        Validates the full LLM path (endpoint, auth, model) by sending a
+        single-token completion request. Results are logged and update the
+        ``_last_call_ok`` tracker so ``get_role_health()`` reflects real
+        status immediately after startup.
+
+        Never raises — failed probes are logged as warnings and the
+        corresponding role is marked unhealthy. Probe calls are not
+        counted toward usage statistics.
+        """
+        results: dict[LLMRole, bool] = {}
+        probe_messages = [{"role": "user", "content": "Respond with OK"}]
+        parts: list[str] = []
+
+        for role in LLMRole:
+            endpoint = self._endpoint_for(role)
+            start = time.monotonic()
+            try:
+                kwargs: dict[str, Any] = {
+                    "model": endpoint.model,
+                    "messages": probe_messages,
+                    "api_base": endpoint.base_url,
+                    "timeout": min(endpoint.timeout, 15),
+                    "max_tokens": 1,
+                    "temperature": 0,
+                }
+                if endpoint.api_key:
+                    kwargs["api_key"] = endpoint.api_key
+
+                await litellm.acompletion(**kwargs)
+                latency_ms = (time.monotonic() - start) * 1000
+                self._last_call_ok[role] = True
+                results[role] = True
+                parts.append(f"{role.value}=ok ({latency_ms:.0f}ms)")
+            except Exception as exc:
+                latency_ms = (time.monotonic() - start) * 1000
+                self._last_call_ok[role] = False
+                results[role] = False
+                # Use the exception type + message for concise logging
+                err_desc = f"{type(exc).__name__}: {exc}" if str(exc) else type(exc).__name__
+                parts.append(f"{role.value}=FAILED ({err_desc})")
+                logger.warning(
+                    "LLM warm-up probe failed for %s (%s, %.0fms): %s",
+                    role.value,
+                    endpoint.model,
+                    latency_ms,
+                    exc,
+                )
+
+        logger.info("LLM warm-up: %s", ", ".join(parts))
+        return results
+
     def get_role_health(self, role: LLMRole) -> str:
         """Return health status for a role based on last call outcome.
 

--- a/oasisagent/orchestrator.py
+++ b/oasisagent/orchestrator.py
@@ -606,6 +606,13 @@ class Orchestrator:
         except Exception:
             logger.exception("Failed to start notification dispatcher")
 
+        # LLM warm-up — probe each endpoint to establish initial health
+        if self._llm_client is not None:
+            try:
+                await self._llm_client.warm_up()
+            except Exception:
+                logger.exception("LLM warm-up failed unexpectedly")
+
         # Approval listener — background task
         if self._approval_listener is not None:
             self._approval_listener_task = asyncio.create_task(

--- a/tests/test_llm_client.py
+++ b/tests/test_llm_client.py
@@ -662,3 +662,156 @@ class TestRoleHealth:
         mock_acomp.return_value = _mock_response()
         await client.complete(LLMRole.TRIAGE, _MESSAGES)
         assert client.get_role_health(LLMRole.TRIAGE) == "connected"
+
+
+# ---------------------------------------------------------------------------
+# Warm-up (health probe at startup)
+# ---------------------------------------------------------------------------
+
+
+class TestWarmUp:
+    """warm_up() sends minimal probes to each role and logs results."""
+
+    @patch("oasisagent.llm.client.litellm.acompletion", new_callable=AsyncMock)
+    async def test_both_roles_healthy(self, mock_acomp: AsyncMock) -> None:
+        mock_acomp.return_value = _mock_response(content="OK")
+        client = _client()
+
+        results = await client.warm_up()
+
+        assert results == {LLMRole.TRIAGE: True, LLMRole.REASONING: True}
+        assert client.get_role_health(LLMRole.TRIAGE) == "connected"
+        assert client.get_role_health(LLMRole.REASONING) == "connected"
+        # Two calls: one per role
+        assert mock_acomp.call_count == 2
+
+    @patch("oasisagent.llm.client.litellm.acompletion", new_callable=AsyncMock)
+    async def test_one_role_fails(self, mock_acomp: AsyncMock) -> None:
+        """Triage succeeds, reasoning fails — warm_up doesn't raise."""
+        mock_acomp.side_effect = [
+            _mock_response(content="OK"),  # triage
+            litellm.APIConnectionError(
+                message="connection refused", model="test", llm_provider="test"
+            ),  # reasoning
+        ]
+        client = _client()
+
+        results = await client.warm_up()
+
+        assert results[LLMRole.TRIAGE] is True
+        assert results[LLMRole.REASONING] is False
+        assert client.get_role_health(LLMRole.TRIAGE) == "connected"
+        assert client.get_role_health(LLMRole.REASONING) == "error"
+
+    @patch("oasisagent.llm.client.litellm.acompletion", new_callable=AsyncMock)
+    async def test_both_roles_fail(self, mock_acomp: AsyncMock) -> None:
+        """Both fail — warm_up still doesn't raise."""
+        mock_acomp.side_effect = _timeout()
+        client = _client()
+
+        results = await client.warm_up()
+
+        assert results == {LLMRole.TRIAGE: False, LLMRole.REASONING: False}
+        assert client.get_role_health(LLMRole.TRIAGE) == "error"
+        assert client.get_role_health(LLMRole.REASONING) == "error"
+
+    @patch("oasisagent.llm.client.litellm.acompletion", new_callable=AsyncMock)
+    async def test_probe_uses_max_tokens_1(self, mock_acomp: AsyncMock) -> None:
+        """Probe uses max_tokens=1 to minimize cost."""
+        mock_acomp.return_value = _mock_response(content="OK")
+        client = _client()
+
+        await client.warm_up()
+
+        for call in mock_acomp.call_args_list:
+            assert call.kwargs["max_tokens"] == 1
+
+    @patch("oasisagent.llm.client.litellm.acompletion", new_callable=AsyncMock)
+    async def test_probe_uses_correct_endpoints(self, mock_acomp: AsyncMock) -> None:
+        """Each probe uses the real endpoint config for its role."""
+        mock_acomp.return_value = _mock_response(content="OK")
+        client = _client()
+
+        await client.warm_up()
+
+        calls = mock_acomp.call_args_list
+        # First call = triage
+        assert calls[0].kwargs["model"] == "qwen2.5:7b"
+        assert calls[0].kwargs["api_base"] == "http://localhost:11434/v1"
+        # Second call = reasoning
+        assert calls[1].kwargs["model"] == "claude-sonnet-4-5-20250929"
+        assert calls[1].kwargs["api_base"] == "https://api.anthropic.com"
+        assert calls[1].kwargs["api_key"] == "sk-test-key"
+
+    @patch("oasisagent.llm.client.litellm.acompletion", new_callable=AsyncMock)
+    async def test_probe_does_not_count_usage(self, mock_acomp: AsyncMock) -> None:
+        """Warm-up probes bypass usage tracking."""
+        mock_acomp.return_value = _mock_response(content="OK")
+        client = _client()
+
+        await client.warm_up()
+
+        stats = client.get_usage_stats()
+        assert stats["triage"].total_requests == 0
+        assert stats["reasoning"].total_requests == 0
+
+    @patch("oasisagent.llm.client.litellm.acompletion", new_callable=AsyncMock)
+    async def test_logs_summary(
+        self, mock_acomp: AsyncMock, caplog: pytest.LogCaptureFixture
+    ) -> None:
+        """Warm-up logs a single summary line."""
+        mock_acomp.return_value = _mock_response(content="OK")
+        client = _client()
+
+        import logging
+
+        with caplog.at_level(logging.INFO, logger="oasisagent.llm.client"):
+            await client.warm_up()
+
+        assert any("LLM warm-up" in record.message for record in caplog.records)
+        summary = next(r for r in caplog.records if "LLM warm-up" in r.message)
+        assert "triage=ok" in summary.message
+        assert "reasoning=ok" in summary.message
+
+    @patch("oasisagent.llm.client.litellm.acompletion", new_callable=AsyncMock)
+    async def test_logs_failure_detail(
+        self, mock_acomp: AsyncMock, caplog: pytest.LogCaptureFixture
+    ) -> None:
+        """Failed probes include error description in summary."""
+        mock_acomp.side_effect = _timeout()
+        client = _client()
+
+        import logging
+
+        with caplog.at_level(logging.INFO, logger="oasisagent.llm.client"):
+            await client.warm_up()
+
+        # Find the INFO-level summary line (not the per-role WARNING lines)
+        summary = next(
+            r for r in caplog.records
+            if "LLM warm-up:" in r.message and r.levelno == logging.INFO
+        )
+        assert "triage=FAILED" in summary.message
+        assert "reasoning=FAILED" in summary.message
+
+    @patch("oasisagent.llm.client.litellm.acompletion", new_callable=AsyncMock)
+    async def test_timeout_capped_at_15s(self, mock_acomp: AsyncMock) -> None:
+        """Probe timeout is capped at 15s even if endpoint timeout is higher."""
+        mock_acomp.return_value = _mock_response(content="OK")
+        config = _make_config(
+            reasoning=LlmEndpointConfig(
+                base_url="https://api.anthropic.com",
+                model="claude-sonnet-4-5-20250929",
+                api_key="sk-test-key",
+                timeout=120,  # very long timeout
+                max_tokens=4096,
+                temperature=0.2,
+            ),
+        )
+        client = LLMClient(config)
+
+        await client.warm_up()
+
+        # Reasoning probe timeout should be capped at 15
+        reasoning_call = mock_acomp.call_args_list[1]
+        assert reasoning_call.kwargs["timeout"] == 15


### PR DESCRIPTION
## Summary
- Add `warm_up()` method to `LLMClient` that sends a minimal probe prompt (`max_tokens=1`) to each configured LLM role (triage + reasoning) during startup
- Call `warm_up()` from `Orchestrator._start_components()` after handlers/audit/notifications are ready, before ingestion adapters begin producing events
- Probe results update `_last_call_ok` tracking so `get_role_health()` immediately returns `"connected"` or `"error"` instead of `"unknown"` on the Services dashboard
- Failed probes log `WARNING` with error detail but never block startup or count toward usage statistics
- Probe timeout is capped at 15 seconds regardless of endpoint config

Closes #171

## Test plan
- [x] `test_both_roles_healthy` — both probes succeed, health transitions to connected
- [x] `test_one_role_fails` — partial failure handled gracefully, no exception raised
- [x] `test_both_roles_fail` — both fail without raising, both marked as error
- [x] `test_probe_uses_max_tokens_1` — cost minimization verified
- [x] `test_probe_uses_correct_endpoints` — each probe uses real endpoint config (model, base_url, api_key)
- [x] `test_probe_does_not_count_usage` — usage stats remain zero after warm-up
- [x] `test_logs_summary` — single INFO summary line logged
- [x] `test_logs_failure_detail` — FAILED entries include error description
- [x] `test_timeout_capped_at_15s` — long endpoint timeouts are capped for probes
- [x] Full test suite: 2070 tests passing
- [x] `ruff check` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)