### PR TITLE
Suppress repeated events for permanently unavailable entities

### DIFF
--- a/config.example.yaml
+++ b/config.example.yaml
@@ -22,6 +22,7 @@ agent:
   known_fixes_dir: known_fixes/ # Directory containing T0 YAML fix registries
   correlation_window: 30        # Group related events within this window (seconds); 0 to disable
   metrics_port: 0               # Prometheus /metrics port; 0 to disable
+  max_consecutive_identical: 3   # Suppress after N consecutive identical events per entity+type
 
 # -----------------------------------------------------------------------------
 # Ingestion — Event sources

--- a/oasisagent/config.py
+++ b/oasisagent/config.py
@@ -138,6 +138,7 @@ class AgentConfig(BaseModel):
     known_fixes_dir: str = "known_fixes/"
     correlation_window: Annotated[int, Field(ge=0)] = 30
     metrics_port: Annotated[int, Field(ge=0, le=65535)] = 0
+    max_consecutive_identical: Annotated[int, Field(ge=1)] = 3
 
 
 # -- Ingestion: MQTT --------------------------------------------------------

--- a/oasisagent/db/config_store.py
+++ b/oasisagent/db/config_store.py
@@ -116,13 +116,14 @@ class ConfigStore:
                 "UPDATE agent_config SET name=?, log_level=?, "
                 "event_queue_size=?, dedup_window_seconds=?, "
                 "shutdown_timeout=?, event_ttl=?, known_fixes_dir=?, "
-                "correlation_window=?, metrics_port=? WHERE id=1",
+                "correlation_window=?, metrics_port=?, "
+                "max_consecutive_identical=? WHERE id=1",
                 (
                     agent.name, agent.log_level,
                     agent.event_queue_size, agent.dedup_window_seconds,
                     agent.shutdown_timeout, agent.event_ttl,
                     agent.known_fixes_dir, agent.correlation_window,
-                    agent.metrics_port,
+                    agent.metrics_port, agent.max_consecutive_identical,
                 ),
             )
 
@@ -281,6 +282,7 @@ class ConfigStore:
             known_fixes_dir=row["known_fixes_dir"],
             correlation_window=row["correlation_window"],
             metrics_port=row["metrics_port"],
+            max_consecutive_identical=row["max_consecutive_identical"],
         )
 
     async def update_agent_config(self, updates: dict[str, Any]) -> AgentConfig:

--- a/oasisagent/db/migrations/006_suppression_config.py
+++ b/oasisagent/db/migrations/006_suppression_config.py
@@ -1,0 +1,20 @@
+"""Add max_consecutive_identical column to agent_config.
+
+Supports the repeated-event suppression feature (#168).
+Default of 3 matches the AgentConfig Pydantic model default.
+"""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    import aiosqlite
+
+
+async def migrate(db: aiosqlite.Connection) -> None:
+    """Add max_consecutive_identical column to agent_config."""
+    await db.execute(
+        "ALTER TABLE agent_config "
+        "ADD COLUMN max_consecutive_identical INTEGER NOT NULL DEFAULT 3"
+    )

--- a/oasisagent/orchestrator.py
+++ b/oasisagent/orchestrator.py
@@ -73,6 +73,79 @@ if TYPE_CHECKING:
 
 logger = logging.getLogger(__name__)
 
+# Suffixes that indicate a recovery/resolution event.  When an event_type
+# ends with one of these, suppression for the corresponding entity is reset.
+_RECOVERY_SUFFIXES: tuple[str, ...] = ("_recovered", "_reconnected", "_renewed")
+
+
+class EventSuppressionTracker:
+    """Track consecutive identical events per (entity_id, event_type).
+
+    After *threshold* consecutive identical events the tracker suppresses
+    further occurrences until the entity produces a different event_type
+    (typically a recovery event).
+
+    This is a lightweight, in-memory tracker — no persistence needed.
+    """
+
+    def __init__(self, threshold: int = 3) -> None:
+        self._threshold = threshold
+        # key → consecutive count
+        self._counts: dict[tuple[str, str], int] = {}
+
+    # -----------------------------------------------------------------
+
+    def check(self, event: Event) -> bool:
+        """Return True if the event should be suppressed (dropped).
+
+        Side-effects:
+        * Increments the counter for (entity_id, event_type).
+        * Resets *all* counters for the entity_id when a recovery event
+          or a different event_type is seen.
+        """
+        entity_id = event.entity_id
+        event_type = event.event_type
+        key = (entity_id, event_type)
+
+        # Recovery events reset suppression for the whole entity.
+        if any(event_type.endswith(s) for s in _RECOVERY_SUFFIXES):
+            self._reset_entity(entity_id)
+            return False
+
+        # Different event_type for the same entity resets previous key.
+        self._reset_entity(entity_id, keep=key)
+
+        count = self._counts.get(key, 0) + 1
+        self._counts[key] = count
+
+        if count == self._threshold:
+            logger.warning(
+                "Suppressing repeated %s events for %s (seen %d consecutive)",
+                event_type,
+                entity_id,
+                count,
+            )
+
+        return count > self._threshold
+
+    def reset(self) -> None:
+        """Clear all tracking state."""
+        self._counts.clear()
+
+    # -----------------------------------------------------------------
+    # Internal helpers
+    # -----------------------------------------------------------------
+
+    def _reset_entity(
+        self, entity_id: str, *, keep: tuple[str, str] | None = None
+    ) -> None:
+        """Remove all counters for *entity_id* except *keep*."""
+        to_remove = [
+            k for k in self._counts if k[0] == entity_id and k != keep
+        ]
+        for k in to_remove:
+            del self._counts[k]
+
 
 class Orchestrator:
     """Builds, starts, and runs all OasisAgent components.
@@ -113,6 +186,11 @@ class Orchestrator:
         self._stats_store: StatsStore | None = None
         self._notification_store: NotificationStore | None = None
         self._web_channel: WebNotificationChannel | None = None
+
+        # Repeated-event suppression (§ issue #168)
+        self._suppression = EventSuppressionTracker(
+            threshold=config.agent.max_consecutive_identical,
+        )
 
         # Stats — seeded from SQLite on startup when db is available
         self._events_processed: int = 0
@@ -810,7 +888,17 @@ class Orchestrator:
                 logger.info("Event %s expired (TTL), dropping", event.id)
                 return
 
-            # 1b. Metrics: count ingested event
+            # 1b. Repeated-event suppression — drop before any processing
+            if self._suppression.check(event):
+                logger.debug(
+                    "Event %s suppressed (repeated %s for %s)",
+                    event.id,
+                    event.event_type,
+                    event.entity_id,
+                )
+                return
+
+            # 1c. Metrics: count ingested event
             _inc_events(event.source, event.severity.value)
 
             # 2. Correlation check

--- a/tests/test_event_suppression.py
+++ b/tests/test_event_suppression.py
@@ -1,0 +1,167 @@
+"""Tests for EventSuppressionTracker — repeated-event suppression (#168)."""
+
+from __future__ import annotations
+
+from datetime import UTC, datetime
+
+from oasisagent.models import Event, Severity
+from oasisagent.orchestrator import EventSuppressionTracker
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _event(
+    entity_id: str = "camera.g5_flex",
+    event_type: str = "ha-entity-unavailable-generic",
+) -> Event:
+    return Event(
+        source="ha_websocket",
+        system="homeassistant",
+        event_type=event_type,
+        entity_id=entity_id,
+        severity=Severity.WARNING,
+        timestamp=datetime.now(UTC),
+    )
+
+
+# ---------------------------------------------------------------------------
+# Suppression activates after N consecutive identical events
+# ---------------------------------------------------------------------------
+
+
+class TestSuppressionActivation:
+    """After threshold consecutive identical events, further events are suppressed."""
+
+    def test_below_threshold_not_suppressed(self) -> None:
+        tracker = EventSuppressionTracker(threshold=3)
+        assert tracker.check(_event()) is False  # 1
+        assert tracker.check(_event()) is False  # 2
+        assert tracker.check(_event()) is False  # 3 (== threshold, log fires)
+
+    def test_above_threshold_suppressed(self) -> None:
+        tracker = EventSuppressionTracker(threshold=3)
+        for _ in range(3):
+            tracker.check(_event())
+        # 4th and beyond are suppressed
+        assert tracker.check(_event()) is True
+        assert tracker.check(_event()) is True
+
+    def test_threshold_of_one(self) -> None:
+        tracker = EventSuppressionTracker(threshold=1)
+        assert tracker.check(_event()) is False  # 1 == threshold
+        assert tracker.check(_event()) is True   # 2 > threshold
+
+    def test_different_entities_independent(self) -> None:
+        tracker = EventSuppressionTracker(threshold=2)
+        # Exhaust entity A
+        tracker.check(_event(entity_id="sensor.a"))
+        tracker.check(_event(entity_id="sensor.a"))
+        assert tracker.check(_event(entity_id="sensor.a")) is True
+
+        # Entity B is still fresh
+        assert tracker.check(_event(entity_id="sensor.b")) is False
+
+    def test_different_event_types_independent(self) -> None:
+        tracker = EventSuppressionTracker(threshold=2)
+        tracker.check(_event(event_type="unavailable"))
+        tracker.check(_event(event_type="unavailable"))
+        assert tracker.check(_event(event_type="unavailable")) is True
+
+        # Same entity, different event_type — not suppressed
+        assert tracker.check(_event(event_type="error")) is False
+
+
+# ---------------------------------------------------------------------------
+# Suppression resets on state change
+# ---------------------------------------------------------------------------
+
+
+class TestSuppressionReset:
+    """Suppression resets when the entity produces a recovery or different event."""
+
+    def test_recovery_event_resets_suppression(self) -> None:
+        tracker = EventSuppressionTracker(threshold=2)
+        entity = "camera.g5_flex"
+
+        # Exhaust the counter
+        tracker.check(_event(entity_id=entity, event_type="state_unavailable"))
+        tracker.check(_event(entity_id=entity, event_type="state_unavailable"))
+        assert tracker.check(_event(entity_id=entity, event_type="state_unavailable")) is True
+
+        # Recovery event resets
+        result = tracker.check(
+            _event(entity_id=entity, event_type="device_reconnected")
+        )
+        assert result is False
+
+        # Original event_type is no longer suppressed
+        assert tracker.check(_event(entity_id=entity, event_type="state_unavailable")) is False
+
+    def test_recovered_suffix_resets(self) -> None:
+        tracker = EventSuppressionTracker(threshold=2)
+        entity = "sensor.x"
+
+        tracker.check(_event(entity_id=entity, event_type="health_check_failed"))
+        tracker.check(_event(entity_id=entity, event_type="health_check_failed"))
+        assert tracker.check(_event(entity_id=entity, event_type="health_check_failed")) is True
+
+        tracker.check(_event(entity_id=entity, event_type="health_check_recovered"))
+
+        assert tracker.check(_event(entity_id=entity, event_type="health_check_failed")) is False
+
+    def test_renewed_suffix_resets(self) -> None:
+        tracker = EventSuppressionTracker(threshold=2)
+        entity = "sensor.cert"
+
+        tracker.check(_event(entity_id=entity, event_type="certificate_expiring"))
+        tracker.check(_event(entity_id=entity, event_type="certificate_expiring"))
+        assert tracker.check(_event(entity_id=entity, event_type="certificate_expiring")) is True
+
+        tracker.check(_event(entity_id=entity, event_type="certificate_renewed"))
+
+        assert tracker.check(_event(entity_id=entity, event_type="certificate_expiring")) is False
+
+    def test_different_event_type_resets_previous(self) -> None:
+        """A non-recovery event_type for the same entity resets the old counter."""
+        tracker = EventSuppressionTracker(threshold=2)
+        entity = "switch.poe"
+
+        tracker.check(_event(entity_id=entity, event_type="unavailable"))
+        tracker.check(_event(entity_id=entity, event_type="unavailable"))
+        assert tracker.check(_event(entity_id=entity, event_type="unavailable")) is True
+
+        # Different (non-recovery) event type resets the "unavailable" counter
+        tracker.check(_event(entity_id=entity, event_type="power_cycle_failed"))
+
+        assert tracker.check(_event(entity_id=entity, event_type="unavailable")) is False
+
+    def test_recovery_event_itself_not_suppressed(self) -> None:
+        """Recovery events are never suppressed, even if repeated."""
+        tracker = EventSuppressionTracker(threshold=1)
+        entity = "sensor.x"
+
+        # Recovery events reset on every call, so counter never accumulates
+        assert tracker.check(_event(entity_id=entity, event_type="health_check_recovered")) is False
+        assert tracker.check(_event(entity_id=entity, event_type="health_check_recovered")) is False
+        assert tracker.check(_event(entity_id=entity, event_type="health_check_recovered")) is False
+
+
+# ---------------------------------------------------------------------------
+# reset() clears all state
+# ---------------------------------------------------------------------------
+
+
+class TestTrackerReset:
+    """The reset() method clears all tracking state."""
+
+    def test_reset_clears_suppression(self) -> None:
+        tracker = EventSuppressionTracker(threshold=2)
+        tracker.check(_event())
+        tracker.check(_event())
+        assert tracker.check(_event()) is True
+
+        tracker.reset()
+
+        assert tracker.check(_event()) is False


### PR DESCRIPTION
## Summary
- Add `EventSuppressionTracker` in the orchestrator that drops events after N consecutive identical `(entity_id, event_type)` pairs — before metrics, correlation, or decision processing
- Recovery events (`_recovered`, `_reconnected`, `_renewed` suffixes) and new event types for the same entity reset the counter automatically
- Configurable via `agent.max_consecutive_identical` (default 3), persisted in SQLite via migration 006
- In production, this eliminates ~156 redundant events/day for a single permanently unavailable camera entity

## Test plan
- [x] 11 new tests covering suppression activation, threshold behavior, recovery resets, different entities/event types, and tracker reset
- [x] Full test suite passes (2093 tests)
- [x] `ruff check` clean

Closes #168

🤖 Generated with [Claude Code](https://claude.com/claude-code)