### PR TITLE
Increase default LLM triage timeout from 5s to 30s

### DIFF
--- a/config.example.yaml
+++ b/config.example.yaml
@@ -281,7 +281,7 @@ llm:
     base_url: http://localhost:11434/v1    # Ollama default
     model: qwen2.5:7b
     api_key: ${TRIAGE_LLM_API_KEY:-not-needed}
-    timeout: 5                   # Seconds — local models should respond fast
+    timeout: 30                  # Seconds — allows for Ollama cold-start model loading
     max_tokens: 1024
     temperature: 0.1             # Low temp for consistent classification
 

--- a/oasisagent/config.py
+++ b/oasisagent/config.py
@@ -584,7 +584,7 @@ class LlmConfig(BaseModel):
             base_url="http://localhost:11434/v1",
             model="qwen2.5:7b",
             api_key="not-needed",
-            timeout=5,
+            timeout=30,
             max_tokens=1024,
             temperature=0.1,
         )

--- a/tests/test_llm_client.py
+++ b/tests/test_llm_client.py
@@ -22,7 +22,7 @@ def _make_config(**overrides: Any) -> LlmConfig:
             base_url="http://localhost:11434/v1",
             model="qwen2.5:7b",
             api_key="",
-            timeout=5,
+            timeout=30,
             max_tokens=1024,
             temperature=0.1,
         ),


### PR DESCRIPTION
## Summary

- Increase the default triage (T1) LLM timeout from 5s to 30s to accommodate Ollama cold-start model loading (10-20s)
- Update `config.example.yaml` comment to reflect the rationale
- Update test fixture in `test_llm_client.py` to match the new default

Fixes #178

## Test plan

- [x] `pytest --tb=short` — 2103 tests passing
- [x] `ruff check` — all checks passed
- [ ] Verify Ollama cold-start triage calls no longer fail with timeout errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)