### PR TITLE
Handle HTMX 401 gracefully on session expiry (#144)

### DIFF
--- a/oasisagent/ui/templates/base.html
+++ b/oasisagent/ui/templates/base.html
@@ -22,8 +22,26 @@
             document.body.addEventListener('htmx:configRequest', function(e) {
                 e.detail.headers['X-CSRF-Token'] = getCsrfToken();
             });
-            document.body.addEventListener('htmx:afterRequest', function(evt) {
+
+            // Handle 401 on HTMX requests — redirect to login.
+            // The server also sets HX-Redirect on 401 responses, which
+            // HTMX handles natively.  This listener is a client-side
+            // fallback for edge cases (e.g. network-level 401 from a
+            // reverse proxy that doesn't set HX-Redirect).
+            document.body.addEventListener('htmx:responseError', function(evt) {
                 if (evt.detail.xhr && evt.detail.xhr.status === 401) {
+                    window.location.href = '/ui/login';
+                }
+            });
+
+            // Handle SSE connection errors.  When a session expires the
+            // SSE endpoint returns 401 and EventSource fires an error.
+            // HTMX exposes this as htmx:sseError.  EventSource doesn't
+            // expose the HTTP status, so we check whether the CSRF
+            // cookie is gone (it expires with the JWT) to distinguish
+            // auth failures from transient network blips.
+            document.body.addEventListener('htmx:sseError', function(evt) {
+                if (!getCsrfToken()) {
                     window.location.href = '/ui/login';
                 }
             });

--- a/oasisagent/web/middleware.py
+++ b/oasisagent/web/middleware.py
@@ -81,13 +81,14 @@ async def setup_guard_middleware(
 
     response = await call_next(request)
 
-    # Redirect unauthenticated UI requests to login instead of showing JSON 401
-    if (
-        response.status_code == 401
-        and path.startswith("/ui/")
-        and "hx-request" not in request.headers
-    ):
-        return RedirectResponse(url="/ui/login", status_code=303)
+    # Handle 401 on UI paths:
+    # - Normal requests → redirect to login page
+    # - HTMX requests → add HX-Redirect header so HTMX performs a client-side redirect
+    if response.status_code == 401 and path.startswith("/ui/"):
+        if "hx-request" in request.headers:
+            response.headers["HX-Redirect"] = "/ui/login"
+        else:
+            return RedirectResponse(url="/ui/login", status_code=303)
 
     return response
 

--- a/tests/test_ui/test_htmx_401.py
+++ b/tests/test_ui/test_htmx_401.py
@@ -8,9 +8,9 @@ TEMPLATE = Path(__file__).resolve().parents[2] / "oasisagent" / "ui" / "template
 
 
 class TestHtmx401Handler:
-    def test_template_contains_after_request_handler(self) -> None:
+    def test_template_contains_response_error_handler(self) -> None:
         content = TEMPLATE.read_text()
-        assert "htmx:afterRequest" in content
+        assert "htmx:responseError" in content
 
     def test_template_checks_401_status(self) -> None:
         content = TEMPLATE.read_text()
@@ -19,3 +19,7 @@ class TestHtmx401Handler:
     def test_template_redirects_to_login(self) -> None:
         content = TEMPLATE.read_text()
         assert "'/ui/login'" in content
+
+    def test_template_contains_sse_error_handler(self) -> None:
+        content = TEMPLATE.read_text()
+        assert "htmx:sseError" in content

--- a/tests/test_web/test_htmx_401.py
+++ b/tests/test_web/test_htmx_401.py
@@ -1,0 +1,138 @@
+"""Tests for HTMX 401 handling — session-expired redirects.
+
+Verifies that the setup_guard_middleware correctly handles 401 responses
+for both HTMX and non-HTMX requests on UI paths:
+- HTMX requests receive an HX-Redirect header (client-side redirect)
+- Non-HTMX requests receive a 303 redirect to the login page
+"""
+
+from __future__ import annotations
+
+import time
+from pathlib import Path
+from unittest.mock import MagicMock, PropertyMock
+
+import pytest
+from cryptography.fernet import Fernet
+from httpx import ASGITransport, AsyncClient
+
+from oasisagent.db.config_store import ConfigStore
+from oasisagent.db.crypto import CryptoProvider
+from oasisagent.db.schema import run_migrations
+from oasisagent.ui.auth import derive_jwt_key
+from oasisagent.web.app import create_app
+
+
+def _mock_orchestrator() -> MagicMock:
+    orch = MagicMock()
+    orch._events_processed = 0
+    orch._actions_taken = 0
+    orch._errors = 0
+    orch._queue = MagicMock()
+    type(orch._queue).size = PropertyMock(return_value=0)
+    return orch
+
+
+@pytest.fixture
+async def app_and_store(tmp_path: Path) -> tuple:
+    """Create app with real config store for auth testing."""
+    key = Fernet.generate_key().decode()
+    crypto = CryptoProvider(key)
+    db = await run_migrations(tmp_path / "test.db")
+    store = ConfigStore(db, crypto)
+
+    # Create admin user so setup guard allows requests through
+    await store.create_user("admin", "hashed", role="admin")
+
+    app = create_app()
+    app.state.config_store = store
+    app.state.db = db
+    app.state.start_time = time.monotonic()
+    app.state.orchestrator = _mock_orchestrator()
+    app.state.jwt_signing_key = derive_jwt_key(key)
+
+    return app, store, key
+
+
+@pytest.fixture
+async def client(app_and_store: tuple) -> AsyncClient:
+    """Test client without auth cookies — simulates expired session."""
+    app, _store, _key = app_and_store
+    transport = ASGITransport(app=app, raise_app_exceptions=False)
+    async with AsyncClient(transport=transport, base_url="http://test") as c:
+        yield c  # type: ignore[misc]
+
+
+class TestHtmx401Redirect:
+    """Middleware returns HX-Redirect on 401 for HTMX requests."""
+
+    async def test_htmx_health_poll_gets_hx_redirect(
+        self, client: AsyncClient,
+    ) -> None:
+        """Health poll with expired session gets HX-Redirect header."""
+        resp = await client.get(
+            "/ui/connectors/health",
+            headers={"HX-Request": "true"},
+        )
+        assert resp.status_code == 401
+        assert resp.headers.get("hx-redirect") == "/ui/login"
+
+    async def test_htmx_unread_count_gets_hx_redirect(
+        self, client: AsyncClient,
+    ) -> None:
+        """Notification badge poll with expired session gets HX-Redirect."""
+        resp = await client.get(
+            "/ui/notifications/unread-count",
+            headers={"HX-Request": "true"},
+        )
+        assert resp.status_code == 401
+        assert resp.headers.get("hx-redirect") == "/ui/login"
+
+    async def test_htmx_post_gets_hx_redirect(
+        self, client: AsyncClient,
+    ) -> None:
+        """HTMX POST with expired session gets HX-Redirect."""
+        resp = await client.post(
+            "/ui/connectors/1/toggle",
+            headers={"HX-Request": "true"},
+        )
+        assert resp.status_code == 401
+        assert resp.headers.get("hx-redirect") == "/ui/login"
+
+
+class TestNonHtmx401Redirect:
+    """Non-HTMX UI requests get a 303 redirect to login."""
+
+    async def test_browser_navigation_redirects_to_login(
+        self, client: AsyncClient,
+    ) -> None:
+        """Normal browser request with expired session redirects to login."""
+        resp = await client.get(
+            "/ui/dashboard",
+            follow_redirects=False,
+        )
+        assert resp.status_code == 303
+        assert resp.headers["location"] == "/ui/login"
+
+    async def test_connectors_page_redirects_to_login(
+        self, client: AsyncClient,
+    ) -> None:
+        """Connectors page with no session redirects to login."""
+        resp = await client.get(
+            "/ui/connectors",
+            follow_redirects=False,
+        )
+        assert resp.status_code == 303
+        assert resp.headers["location"] == "/ui/login"
+
+
+class TestApiUnaffected:
+    """API endpoints should NOT get redirect treatment."""
+
+    async def test_api_returns_raw_401(self, client: AsyncClient) -> None:
+        """API endpoints return raw 401 without HX-Redirect."""
+        resp = await client.get("/api/v1/status")
+        # API status doesn't require auth, but other endpoints that
+        # return 401 should not get the UI redirect treatment.
+        # The middleware only intercepts /ui/ paths.
+        assert "hx-redirect" not in resp.headers


### PR DESCRIPTION
## Summary
- **Server-side**: Middleware now sets `HX-Redirect: /ui/login` header on 401 responses for HTMX requests, so HTMX performs a clean client-side redirect instead of swapping error HTML into the page
- **Client-side**: Replaced `htmx:afterRequest` with `htmx:responseError` for more reliable 401 detection, and added `htmx:sseError` handler that checks for missing CSRF cookie to redirect on expired SSE streams (dashboard, notifications)
- Both server-side and client-side work together: `HX-Redirect` is the primary mechanism (HTMX handles it natively), `htmx:responseError` is a fallback for edge cases like reverse-proxy 401s

Closes #144

## Test plan
- [x] 6 new integration tests in `tests/test_web/test_htmx_401.py` verify middleware sets `HX-Redirect` on HTMX 401s and redirects non-HTMX 401s
- [x] Updated template assertion tests in `tests/test_ui/test_htmx_401.py` for new event names + SSE handler
- [x] Full suite: 2110 tests passing
- [x] `ruff check` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)