### PR TITLE
Wire UniFi/Cloudflare handlers and fix llm_options health (#151)

### DIFF
--- a/oasisagent/orchestrator.py
+++ b/oasisagent/orchestrator.py
@@ -307,7 +307,7 @@ class Orchestrator:
 
     # Internal service types that lack a real health check.
     _INTERNAL_SERVICE_TYPES: tuple[str, ...] = (
-        "influxdb", "guardrails", "circuit_breaker",
+        "influxdb", "guardrails", "circuit_breaker", "llm_options",
     )
 
     # Maps LLM roles to DB service types for health lookups.
@@ -517,6 +517,16 @@ class Orchestrator:
 
             proxmox = ProxmoxHandler(cfg.handlers.proxmox)
             self._handlers[proxmox.name()] = proxmox
+        if cfg.handlers.unifi.enabled:
+            from oasisagent.handlers.unifi import UnifiHandler
+
+            unifi_h = UnifiHandler(cfg.handlers.unifi)
+            self._handlers[unifi_h.name()] = unifi_h
+        if cfg.handlers.cloudflare.enabled:
+            from oasisagent.handlers.cloudflare import CloudflareHandler
+
+            cf_h = CloudflareHandler(cfg.handlers.cloudflare)
+            self._handlers[cf_h.name()] = cf_h
 
         # 10. Audit writer
         self._audit = AuditWriter(cfg.audit)

--- a/tests/test_db/test_config_store.py
+++ b/tests/test_db/test_config_store.py
@@ -355,6 +355,34 @@ class TestEnabledFlagInjection:
         config = await store.load_config()
         assert config.ingestion.uptime_kuma.enabled is True
 
+    async def test_unifi_handler_without_enabled_in_config_json(
+        self, store: ConfigStore,
+    ) -> None:
+        """UniFi handler created without 'enabled' in config_json loads as enabled."""
+        await store.create_service(
+            "unifi_handler", "unifi-handler",
+            {
+                "url": "https://192.168.1.1",
+                "username": "admin",
+                "password": "secret",
+            },
+        )
+        config = await store.load_config()
+        assert config.handlers.unifi.enabled is True
+        assert config.handlers.unifi.url == "https://192.168.1.1"
+
+    async def test_cloudflare_handler_without_enabled_in_config_json(
+        self, store: ConfigStore,
+    ) -> None:
+        """Cloudflare handler created without 'enabled' in config_json loads as enabled."""
+        await store.create_service(
+            "cloudflare_handler", "cloudflare-handler",
+            {"api_token": "cf-tok-123"},
+        )
+        config = await store.load_config()
+        assert config.handlers.cloudflare.enabled is True
+        assert config.handlers.cloudflare.api_token == "cf-tok-123"
+
 
 class TestAgentConfig:
     async def test_default_agent_config(self, store: ConfigStore) -> None:

--- a/tests/test_orchestrator_health.py
+++ b/tests/test_orchestrator_health.py
@@ -2,10 +2,14 @@
 
 from __future__ import annotations
 
+from typing import TYPE_CHECKING, Any
 from unittest.mock import AsyncMock, MagicMock, PropertyMock
 
 from oasisagent.llm.client import LLMRole
 from oasisagent.orchestrator import Orchestrator
+
+if TYPE_CHECKING:
+    from oasisagent.config import OasisAgentConfig
 
 # ---------------------------------------------------------------------------
 # Helpers
@@ -124,6 +128,18 @@ class TestHandlerHealth:
         result = await orch.get_component_health()
         assert result["services"]["portainer_handler"] == "error"
 
+    async def test_unifi_handler_maps_to_db_type(self) -> None:
+        handler = _mock_handler("unifi", healthy=True)
+        orch = _make_orchestrator(handlers={"unifi": handler})
+        result = await orch.get_component_health()
+        assert result["services"]["unifi_handler"] == "connected"
+
+    async def test_cloudflare_handler_maps_to_db_type(self) -> None:
+        handler = _mock_handler("cloudflare", healthy=True)
+        orch = _make_orchestrator(handlers={"cloudflare": handler})
+        result = await orch.get_component_health()
+        assert result["services"]["cloudflare_handler"] == "connected"
+
     async def test_unknown_handler_name_uses_raw_name(self) -> None:
         handler = _mock_handler("custom_thing", healthy=True)
         orch = _make_orchestrator(handlers={"custom_thing": handler})
@@ -164,7 +180,7 @@ class TestInternalServices:
     async def test_internal_services_report_unknown(self) -> None:
         orch = _make_orchestrator()
         result = await orch.get_component_health()
-        for svc in ("influxdb", "guardrails", "circuit_breaker"):
+        for svc in ("influxdb", "guardrails", "circuit_breaker", "llm_options"):
             assert result["services"][svc] == "unknown"
 
 
@@ -227,6 +243,51 @@ class TestNotificationHealth:
         assert result["notifications"] == {}
 
 
+class TestBuildComponentsHandlerWiring:
+    """Verify _build_components instantiates handlers when enabled in config."""
+
+    @staticmethod
+    def _make_config(
+        **handler_overrides: dict[str, Any],
+    ) -> OasisAgentConfig:
+        from oasisagent.config import OasisAgentConfig
+
+        handlers_dict: dict[str, Any] = {}
+        for key, val in handler_overrides.items():
+            handlers_dict[key] = {**val, "enabled": True}
+
+        return OasisAgentConfig(handlers=handlers_dict)
+
+    def test_unifi_handler_wired_when_enabled(self) -> None:
+        config = self._make_config(unifi={
+            "url": "https://192.168.1.1",
+            "username": "admin",
+            "password": "secret",
+        })
+        orch = Orchestrator(config)
+        orch._build_components()
+        assert "unifi" in orch._handlers
+        assert orch._handlers["unifi"].name() == "unifi"
+
+    def test_cloudflare_handler_wired_when_enabled(self) -> None:
+        config = self._make_config(cloudflare={
+            "api_token": "cf-tok-123",
+        })
+        orch = Orchestrator(config)
+        orch._build_components()
+        assert "cloudflare" in orch._handlers
+        assert orch._handlers["cloudflare"].name() == "cloudflare"
+
+    def test_handlers_not_wired_when_disabled(self) -> None:
+        from oasisagent.config import OasisAgentConfig
+
+        config = OasisAgentConfig()  # All handlers disabled by default
+        orch = Orchestrator(config)
+        orch._build_components()
+        assert "unifi" not in orch._handlers
+        assert "cloudflare" not in orch._handlers
+
+
 class TestEmptyOrchestrator:
     async def test_empty_orchestrator(self) -> None:
         orch = _make_orchestrator()
@@ -235,4 +296,5 @@ class TestEmptyOrchestrator:
         assert result["notifications"] == {}
         # Internal services always present, LLM omitted when no client
         assert "influxdb" in result["services"]
+        assert "llm_options" in result["services"]
         assert "llm_triage" not in result["services"]


### PR DESCRIPTION
## Summary
- **Add UniFi and Cloudflare handler instantiation to `_build_components()`** — these handlers had config models, DB type mappings, and health check wiring but were never created when enabled, causing them to always show "Not Running"
- **Add `llm_options` to `_INTERNAL_SERVICE_TYPES`** — this service type has no health endpoint and was falling through to "not_running" instead of "unknown"
- Add tests for handler wiring (`_build_components` creates UniFi/Cloudflare when enabled, skips when disabled)
- Add config store tests verifying `enabled` flag injection for UniFi and Cloudflare handler rows

Closes #151

## Test plan
- [x] `pytest --tb=short` — 2110 tests passing
- [x] `ruff check` — clean
- [x] New tests verify UniFi/Cloudflare handlers appear in `_handlers` dict when config has `enabled=True`
- [x] New tests verify handlers are absent when config defaults to `enabled=False`
- [x] Existing health badge tests updated to include `llm_options` in internal services
- [ ] Deploy and verify UI shows "connected"/"unknown" instead of "Not Running" for affected components

🤖 Generated with [Claude Code](https://claude.com/claude-code)