### PR TITLE
Add application integration adapters for media stack (#63)

### DIFF
--- a/known_fixes/plex.yaml
+++ b/known_fixes/plex.yaml
@@ -1,0 +1,75 @@
+fixes:
+  - id: plex-server-unreachable
+    match:
+      system: plex
+      event_type: plex_server_unreachable
+    diagnosis: "Plex Media Server is not responding — service may have crashed or host is down"
+    action:
+      type: escalate
+      handler: homeassistant
+      operation: notify
+      details:
+        message: |
+          Plex server unreachable. Steps:
+          1. Check if the Plex host is powered on and reachable
+          2. Verify Plex Media Server service is running
+          3. Check Plex logs for crash or OOM errors
+          4. Verify network connectivity to the Plex host
+          5. Restart Plex Media Server if the host is reachable
+    risk_tier: escalate
+
+  - id: plex-library-scan-failed
+    match:
+      system: plex
+      event_type: plex_library_scan_failed
+    diagnosis: "Plex library section shows empty — possible mount failure or scan error"
+    action:
+      type: recommend
+      handler: homeassistant
+      operation: notify
+      details:
+        message: |
+          Plex library may have a scan issue. Steps:
+          1. Check if the media storage mount is accessible
+          2. Verify NFS/SMB share connectivity
+          3. Check file permissions on the library directory
+          4. Trigger a manual library scan from the Plex UI
+          5. Review Plex logs for scan errors
+    risk_tier: recommend
+
+  - id: tautulli-plex-down
+    match:
+      system: tautulli
+      event_type: tautulli_plex_down
+    diagnosis: "Tautulli reports Plex is disconnected — Plex service may be down"
+    action:
+      type: recommend
+      handler: homeassistant
+      operation: notify
+      details:
+        message: |
+          Tautulli reports Plex is down. Steps:
+          1. Verify Plex Media Server service status
+          2. Check Plex host resource usage (CPU, memory, disk)
+          3. Review Plex logs for errors
+          4. Restart Plex if needed
+    risk_tier: recommend
+
+  - id: tdarr-worker-failed
+    match:
+      system: tdarr
+      event_type: tdarr_worker_failed
+    diagnosis: "Tdarr transcoding worker is offline — may need restart or host attention"
+    action:
+      type: recommend
+      handler: homeassistant
+      operation: notify
+      details:
+        message: |
+          Tdarr worker offline. Steps:
+          1. Check the Tdarr worker host status
+          2. Verify the worker process is running
+          3. Check available disk space on the worker
+          4. Review worker logs for errors
+          5. Restart the worker service
+    risk_tier: recommend

--- a/known_fixes/qbittorrent.yaml
+++ b/known_fixes/qbittorrent.yaml
@@ -1,0 +1,56 @@
+fixes:
+  - id: qbt-torrent-error
+    match:
+      system: qbittorrent
+      event_type: qbt_torrent_error
+    diagnosis: "Torrent is in error state — may indicate tracker issues, corrupt data, or permission problems"
+    action:
+      type: recommend
+      handler: homeassistant
+      operation: notify
+      details:
+        message: |
+          qBittorrent torrent error detected. Steps:
+          1. Check the torrent state in qBittorrent web UI
+          2. Common causes: tracker unreachable, corrupt download, disk full
+          3. Try force re-checking the torrent
+          4. If tracker error, verify tracker is online
+          5. Check disk space on download directory
+    risk_tier: recommend
+
+  - id: qbt-stalled
+    match:
+      system: qbittorrent
+      event_type: qbt_torrent_stalled
+    diagnosis: "Torrent download is stalled — no seeds available or connectivity issue"
+    action:
+      type: recommend
+      handler: homeassistant
+      operation: notify
+      details:
+        message: |
+          qBittorrent torrent stalled. Steps:
+          1. Check seed/peer count for the torrent
+          2. Verify port forwarding is configured correctly
+          3. Check VPN connectivity if using one
+          4. If no seeds, the torrent may need to be replaced
+    risk_tier: recommend
+
+  - id: qbt-connection-lost
+    match:
+      system: qbittorrent
+      event_type: qbt_connection_lost
+    diagnosis: "qBittorrent has lost internet connectivity — VPN or network issue"
+    action:
+      type: escalate
+      handler: homeassistant
+      operation: notify
+      details:
+        message: |
+          qBittorrent connection lost. Steps:
+          1. Check VPN connection status if using one
+          2. Verify host network connectivity
+          3. Check if qBittorrent is bound to a specific interface
+          4. Restart VPN/network service if needed
+          5. Verify firewall rules haven't changed
+    risk_tier: escalate

--- a/known_fixes/servarr.yaml
+++ b/known_fixes/servarr.yaml
@@ -1,0 +1,53 @@
+fixes:
+  - id: servarr-health-issue
+    match:
+      system: sonarr
+      event_type: servarr_health_issue
+    diagnosis: "Servarr app reports a health check failure — may indicate disk space, indexer, or import problems"
+    action:
+      type: recommend
+      handler: homeassistant
+      operation: notify
+      details:
+        message: |
+          Servarr health check issue detected. Steps:
+          1. Check the health page in the app's web UI
+          2. Review the specific health issue message in the event payload
+          3. Common causes: low disk space, indexer connectivity, download client offline
+          4. Check the wiki URL in the payload for specific remediation steps
+    risk_tier: recommend
+
+  - id: servarr-queue-stuck
+    match:
+      event_type: servarr_queue_stuck
+    diagnosis: "Download has been stuck in queue for over 2 hours — download client or indexer issue"
+    action:
+      type: recommend
+      handler: homeassistant
+      operation: notify
+      details:
+        message: |
+          Servarr download stuck in queue. Steps:
+          1. Check download client (qBittorrent/SABnzbd) for errors
+          2. Verify the torrent/nzb has available seeds/peers
+          3. Check if download client is connected and authenticated
+          4. Consider removing and re-searching for the release
+    risk_tier: recommend
+
+  - id: servarr-queue-failed
+    match:
+      event_type: servarr_queue_failed
+    diagnosis: "Download has failed — check download client and indexer for issues"
+    action:
+      type: recommend
+      handler: homeassistant
+      operation: notify
+      details:
+        message: |
+          Servarr download failed. Steps:
+          1. Check download client for the failure reason
+          2. Review status messages in the event payload
+          3. If import failed, check file permissions and disk space
+          4. If download failed, try searching for an alternative release
+          5. Check indexer connectivity if multiple downloads are failing
+    risk_tier: recommend

--- a/oasisagent/config.py
+++ b/oasisagent/config.py
@@ -440,6 +440,102 @@ class UptimeKumaAdapterConfig(BaseModel):
     cert_critical_days: int = 7
 
 
+# -- Servarr (Sonarr/Radarr/Prowlarr/Bazarr) --------------------------------
+
+
+class ServarrAdapterConfig(BaseModel):
+    """Servarr app polling adapter configuration.
+
+    A single config model for Sonarr, Radarr, Prowlarr, and Bazarr since
+    they all share the same API pattern (differing only in API version).
+    """
+
+    model_config = ConfigDict(extra="forbid")
+
+    enabled: bool = False
+    url: str = ""
+    api_key: str = ""
+    app_type: Literal["sonarr", "radarr", "prowlarr", "bazarr"] = "sonarr"
+    poll_interval: int = 60
+    timeout: int = 10
+
+
+# -- qBittorrent ------------------------------------------------------------
+
+
+class QBittorrentAdapterConfig(BaseModel):
+    """qBittorrent Web API polling adapter configuration."""
+
+    model_config = ConfigDict(extra="forbid")
+
+    enabled: bool = False
+    url: str = ""
+    username: str = "admin"
+    password: str = ""
+    poll_interval: int = 60
+    timeout: int = 10
+
+
+# -- Plex -------------------------------------------------------------------
+
+
+class PlexAdapterConfig(BaseModel):
+    """Plex Media Server polling adapter configuration."""
+
+    model_config = ConfigDict(extra="forbid")
+
+    enabled: bool = False
+    url: str = ""
+    token: str = ""
+    poll_interval: int = 60
+    timeout: int = 10
+
+
+# -- Tautulli ---------------------------------------------------------------
+
+
+class TautulliAdapterConfig(BaseModel):
+    """Tautulli API polling adapter configuration."""
+
+    model_config = ConfigDict(extra="forbid")
+
+    enabled: bool = False
+    url: str = ""
+    api_key: str = ""
+    poll_interval: int = 60
+    timeout: int = 10
+    bandwidth_threshold_kbps: int = 100_000
+
+
+# -- Tdarr ------------------------------------------------------------------
+
+
+class TdarrAdapterConfig(BaseModel):
+    """Tdarr API polling adapter configuration."""
+
+    model_config = ConfigDict(extra="forbid")
+
+    enabled: bool = False
+    url: str = ""
+    poll_interval: int = 60
+    timeout: int = 10
+
+
+# -- Overseerr ---------------------------------------------------------------
+
+
+class OverseerrAdapterConfig(BaseModel):
+    """Overseerr API polling adapter configuration."""
+
+    model_config = ConfigDict(extra="forbid")
+
+    enabled: bool = False
+    url: str = ""
+    api_key: str = ""
+    poll_interval: int = 60
+    timeout: int = 10
+
+
 # -- Scanner ----------------------------------------------------------------
 
 
@@ -552,6 +648,18 @@ class IngestionConfig(BaseModel):
     )
     uptime_kuma: UptimeKumaAdapterConfig = Field(
         default_factory=UptimeKumaAdapterConfig,
+    )
+    servarr: list[ServarrAdapterConfig] = Field(default_factory=list)
+    qbittorrent: QBittorrentAdapterConfig = Field(
+        default_factory=QBittorrentAdapterConfig,
+    )
+    plex: PlexAdapterConfig = Field(default_factory=PlexAdapterConfig)
+    tautulli: TautulliAdapterConfig = Field(
+        default_factory=TautulliAdapterConfig,
+    )
+    tdarr: TdarrAdapterConfig = Field(default_factory=TdarrAdapterConfig)
+    overseerr: OverseerrAdapterConfig = Field(
+        default_factory=OverseerrAdapterConfig,
     )
 
 

--- a/oasisagent/db/registry.py
+++ b/oasisagent/db/registry.py
@@ -34,10 +34,16 @@ from oasisagent.config import (
     LlmOptionsConfig,
     MqttIngestionConfig,
     MqttNotificationConfig,
+    OverseerrAdapterConfig,
+    PlexAdapterConfig,
     PortainerHandlerConfig,
     ProxmoxHandlerConfig,
+    QBittorrentAdapterConfig,
     ScannerConfig,
+    ServarrAdapterConfig,
     SlackNotificationConfig,
+    TautulliAdapterConfig,
+    TdarrAdapterConfig,
     TelegramNotificationConfig,
     UnifiAdapterConfig,
     UnifiHandlerConfig,
@@ -90,6 +96,29 @@ CONNECTOR_TYPES: dict[str, TypeMeta] = {
     ),
     "uptime_kuma": TypeMeta(
         model=UptimeKumaAdapterConfig,
+        secret_fields=frozenset({"api_key"}),
+    ),
+    "servarr": TypeMeta(
+        model=ServarrAdapterConfig,
+        secret_fields=frozenset({"api_key"}),
+    ),
+    "qbittorrent": TypeMeta(
+        model=QBittorrentAdapterConfig,
+        secret_fields=frozenset({"password"}),
+    ),
+    "plex": TypeMeta(
+        model=PlexAdapterConfig,
+        secret_fields=frozenset({"token"}),
+    ),
+    "tautulli": TypeMeta(
+        model=TautulliAdapterConfig,
+        secret_fields=frozenset({"api_key"}),
+    ),
+    "tdarr": TypeMeta(
+        model=TdarrAdapterConfig,
+    ),
+    "overseerr": TypeMeta(
+        model=OverseerrAdapterConfig,
         secret_fields=frozenset({"api_key"}),
     ),
 }

--- a/oasisagent/ingestion/overseerr.py
+++ b/oasisagent/ingestion/overseerr.py
@@ -1,0 +1,153 @@
+"""Overseerr polling ingestion adapter.
+
+Polls the Overseerr API v1 for server status and pending request counts.
+
+Events emitted on state transitions:
+- ``overseerr_server_unreachable`` (ERROR) when Overseerr can't reach Plex/media servers
+- ``overseerr_server_recovered`` (INFO) when connectivity is restored
+"""
+
+from __future__ import annotations
+
+import asyncio
+import logging
+from datetime import UTC, datetime
+from typing import TYPE_CHECKING, Any
+
+import aiohttp
+
+from oasisagent.ingestion.base import IngestAdapter
+from oasisagent.models import Event, EventMetadata, Severity
+
+if TYPE_CHECKING:
+    from oasisagent.config import OverseerrAdapterConfig
+    from oasisagent.engine.queue import EventQueue
+
+logger = logging.getLogger(__name__)
+
+
+class OverseerrAdapter(IngestAdapter):
+    """Polls Overseerr for server connectivity status.
+
+    State-based dedup ensures events only fire on transitions.
+    """
+
+    def __init__(
+        self, config: OverseerrAdapterConfig, queue: EventQueue,
+    ) -> None:
+        super().__init__(queue)
+        self._config = config
+        self._stopping = False
+        self._task: asyncio.Task[None] | None = None
+        self._connected = False
+
+        # State tracker
+        self._server_ok: bool | None = None
+
+    @property
+    def name(self) -> str:
+        return "overseerr"
+
+    def _headers(self) -> dict[str, str]:
+        return {"X-Api-Key": self._config.api_key}
+
+    async def start(self) -> None:
+        self._task = asyncio.create_task(
+            self._poll_loop(), name="overseerr-poller",
+        )
+        await self._task
+
+    async def stop(self) -> None:
+        self._stopping = True
+        if self._task is not None:
+            self._task.cancel()
+            self._task = None
+
+    async def healthy(self) -> bool:
+        return self._connected
+
+    # -----------------------------------------------------------------
+    # Poll loop
+    # -----------------------------------------------------------------
+
+    async def _poll_loop(self) -> None:
+        timeout = aiohttp.ClientTimeout(total=self._config.timeout)
+
+        while not self._stopping:
+            try:
+                async with aiohttp.ClientSession(
+                    headers=self._headers(), timeout=timeout,
+                ) as session:
+                    await self._poll_status(session)
+                    self._connected = True
+            except asyncio.CancelledError:
+                return
+            except (TimeoutError, aiohttp.ClientError) as exc:
+                if self._connected:
+                    logger.warning("Overseerr: connection error: %s", exc)
+                self._connected = False
+            except Exception:
+                self._connected = False
+                logger.exception("Overseerr: unexpected error")
+
+            for _ in range(self._config.poll_interval):
+                if self._stopping:
+                    return
+                await asyncio.sleep(1)
+
+    # -----------------------------------------------------------------
+    # Status endpoint
+    # -----------------------------------------------------------------
+
+    async def _poll_status(self, session: aiohttp.ClientSession) -> None:
+        """Poll /api/v1/status for server connectivity."""
+        url = f"{self._config.url}/api/v1/status"
+        async with session.get(url) as resp:
+            resp.raise_for_status()
+            data: dict[str, Any] = await resp.json(content_type=None)
+
+        version = data.get("version", "")
+        is_ok = resp.status == 200
+        was_ok = self._server_ok
+        self._server_ok = is_ok
+
+        if was_ok is not None and was_ok and not is_ok:
+            self._enqueue(Event(
+                source=self.name,
+                system="overseerr",
+                event_type="overseerr_server_unreachable",
+                entity_id="overseerr",
+                severity=Severity.ERROR,
+                timestamp=datetime.now(tz=UTC),
+                payload={"version": version},
+                metadata=EventMetadata(
+                    dedup_key="overseerr:server:status",
+                ),
+            ))
+        elif was_ok is not None and not was_ok and is_ok:
+            self._enqueue(Event(
+                source=self.name,
+                system="overseerr",
+                event_type="overseerr_server_recovered",
+                entity_id="overseerr",
+                severity=Severity.INFO,
+                timestamp=datetime.now(tz=UTC),
+                payload={"version": version},
+                metadata=EventMetadata(
+                    dedup_key="overseerr:server:status",
+                ),
+            ))
+
+    # -----------------------------------------------------------------
+    # Helpers
+    # -----------------------------------------------------------------
+
+    def _enqueue(self, event: Event) -> None:
+        """Enqueue an event, logging on failure."""
+        try:
+            self._queue.put_nowait(event)
+        except Exception:
+            logger.warning(
+                "Overseerr: failed to enqueue event: %s/%s",
+                event.system, event.event_type,
+            )

--- a/oasisagent/ingestion/plex.py
+++ b/oasisagent/ingestion/plex.py
@@ -1,0 +1,223 @@
+"""Plex Media Server polling ingestion adapter.
+
+Polls the Plex HTTP API for library scan status and server reachability.
+
+Events emitted on state transitions:
+- ``plex_server_unreachable`` (ERROR) when Plex stops responding
+- ``plex_server_recovered`` (INFO) when Plex starts responding again
+- ``plex_library_scan_failed`` (WARNING) when a library section reports scan issues
+"""
+
+from __future__ import annotations
+
+import asyncio
+import logging
+from datetime import UTC, datetime
+from typing import TYPE_CHECKING, Any
+
+import aiohttp
+
+from oasisagent.ingestion.base import IngestAdapter
+from oasisagent.models import Event, EventMetadata, Severity
+
+if TYPE_CHECKING:
+    from oasisagent.config import PlexAdapterConfig
+    from oasisagent.engine.queue import EventQueue
+
+logger = logging.getLogger(__name__)
+
+
+class PlexAdapter(IngestAdapter):
+    """Polls Plex Media Server for library status and server health.
+
+    State-based dedup ensures events only fire on transitions.
+    """
+
+    def __init__(
+        self, config: PlexAdapterConfig, queue: EventQueue,
+    ) -> None:
+        super().__init__(queue)
+        self._config = config
+        self._stopping = False
+        self._task: asyncio.Task[None] | None = None
+        self._connected = False
+
+        # State trackers
+        self._server_reachable: bool | None = None
+        self._library_errors: set[str] = set()  # section keys with issues
+
+    @property
+    def name(self) -> str:
+        return "plex"
+
+    def _headers(self) -> dict[str, str]:
+        return {
+            "X-Plex-Token": self._config.token,
+            "Accept": "application/json",
+        }
+
+    async def start(self) -> None:
+        self._task = asyncio.create_task(
+            self._poll_loop(), name="plex-poller",
+        )
+        await self._task
+
+    async def stop(self) -> None:
+        self._stopping = True
+        if self._task is not None:
+            self._task.cancel()
+            self._task = None
+
+    async def healthy(self) -> bool:
+        return self._connected
+
+    # -----------------------------------------------------------------
+    # Poll loop
+    # -----------------------------------------------------------------
+
+    async def _poll_loop(self) -> None:
+        timeout = aiohttp.ClientTimeout(total=self._config.timeout)
+
+        while not self._stopping:
+            try:
+                async with aiohttp.ClientSession(
+                    headers=self._headers(), timeout=timeout,
+                ) as session:
+                    reachable = await self._check_server(session)
+                    if reachable:
+                        await self._poll_libraries(session)
+                    self._connected = reachable
+            except asyncio.CancelledError:
+                return
+            except (TimeoutError, aiohttp.ClientError) as exc:
+                self._handle_unreachable(str(exc))
+                self._connected = False
+            except Exception:
+                self._connected = False
+                logger.exception("Plex: unexpected error")
+
+            for _ in range(self._config.poll_interval):
+                if self._stopping:
+                    return
+                await asyncio.sleep(1)
+
+    # -----------------------------------------------------------------
+    # Server reachability
+    # -----------------------------------------------------------------
+
+    async def _check_server(self, session: aiohttp.ClientSession) -> bool:
+        """Check if Plex server is reachable via /identity endpoint."""
+        url = f"{self._config.url}/identity"
+        try:
+            async with session.get(url) as resp:
+                if resp.status == 200:
+                    self._handle_reachable()
+                    return True
+                self._handle_unreachable(f"HTTP {resp.status}")
+                return False
+        except (TimeoutError, aiohttp.ClientError) as exc:
+            self._handle_unreachable(str(exc))
+            return False
+
+    def _handle_unreachable(self, error: str) -> None:
+        """Emit server_unreachable on transition from reachable to unreachable."""
+        was_reachable = self._server_reachable
+        self._server_reachable = False
+
+        if was_reachable is None or was_reachable:
+            self._enqueue(Event(
+                source=self.name,
+                system="plex",
+                event_type="plex_server_unreachable",
+                entity_id="plex",
+                severity=Severity.ERROR,
+                timestamp=datetime.now(tz=UTC),
+                payload={"error": error},
+                metadata=EventMetadata(
+                    dedup_key="plex:server:reachable",
+                ),
+            ))
+
+    def _handle_reachable(self) -> None:
+        """Emit server_recovered on transition from unreachable to reachable."""
+        was_reachable = self._server_reachable
+        self._server_reachable = True
+
+        if was_reachable is not None and not was_reachable:
+            self._enqueue(Event(
+                source=self.name,
+                system="plex",
+                event_type="plex_server_recovered",
+                entity_id="plex",
+                severity=Severity.INFO,
+                timestamp=datetime.now(tz=UTC),
+                payload={},
+                metadata=EventMetadata(
+                    dedup_key="plex:server:reachable",
+                ),
+            ))
+
+    # -----------------------------------------------------------------
+    # Library sections
+    # -----------------------------------------------------------------
+
+    async def _poll_libraries(self, session: aiohttp.ClientSession) -> None:
+        """Poll /library/sections for library scan issues."""
+        url = f"{self._config.url}/library/sections"
+        async with session.get(url) as resp:
+            resp.raise_for_status()
+            data: dict[str, Any] = await resp.json(content_type=None)
+
+        container = data.get("MediaContainer", {})
+        sections: list[dict[str, Any]] = container.get("Directory", [])
+
+        current_errors: set[str] = set()
+        for section in sections:
+            key = section.get("key", "")
+            title = section.get("title", key)
+
+            # Check for refresh errors - Plex uses "refreshing" status
+            # and we can detect scan failures by checking for error states
+            scanning = section.get("refreshing", False)
+            if scanning:
+                continue  # Actively scanning, not an error
+
+            # Check for sections with content but reported as empty
+            # (indicates a scan failure or mount issue)
+            content_count = section.get("count", -1)
+            if content_count == 0:
+                current_errors.add(key)
+                if key not in self._library_errors:
+                    self._enqueue(Event(
+                        source=self.name,
+                        system="plex",
+                        event_type="plex_library_scan_failed",
+                        entity_id=title,
+                        severity=Severity.WARNING,
+                        timestamp=datetime.now(tz=UTC),
+                        payload={
+                            "section_key": key,
+                            "title": title,
+                            "type": section.get("type", ""),
+                            "content_count": content_count,
+                        },
+                        metadata=EventMetadata(
+                            dedup_key=f"plex:library:{key}:scan",
+                        ),
+                    ))
+
+        self._library_errors = current_errors
+
+    # -----------------------------------------------------------------
+    # Helpers
+    # -----------------------------------------------------------------
+
+    def _enqueue(self, event: Event) -> None:
+        """Enqueue an event, logging on failure."""
+        try:
+            self._queue.put_nowait(event)
+        except Exception:
+            logger.warning(
+                "Plex: failed to enqueue event: %s/%s",
+                event.system, event.event_type,
+            )

--- a/oasisagent/ingestion/qbittorrent.py
+++ b/oasisagent/ingestion/qbittorrent.py
@@ -1,0 +1,296 @@
+"""qBittorrent polling ingestion adapter.
+
+Polls the qBittorrent Web API v2 for errored and stalled torrents,
+and monitors connection status.
+
+Events emitted on state transitions:
+- ``qbt_torrent_error`` (WARNING) when a torrent enters an error state
+- ``qbt_torrent_stalled`` (INFO) when a torrent is stalled downloading
+- ``qbt_connection_lost`` (ERROR) when qBittorrent reports no connectivity
+"""
+
+from __future__ import annotations
+
+import asyncio
+import logging
+from datetime import UTC, datetime
+from typing import TYPE_CHECKING, Any
+
+import aiohttp
+
+from oasisagent.ingestion.base import IngestAdapter
+from oasisagent.models import Event, EventMetadata, Severity
+
+if TYPE_CHECKING:
+    from oasisagent.config import QBittorrentAdapterConfig
+    from oasisagent.engine.queue import EventQueue
+
+logger = logging.getLogger(__name__)
+
+
+class QBittorrentAdapter(IngestAdapter):
+    """Polls qBittorrent for torrent errors, stalls, and connectivity issues.
+
+    Authenticates via cookie-based session. Re-authenticates on 403/401.
+    State-based dedup ensures events only fire on transitions.
+    """
+
+    def __init__(
+        self, config: QBittorrentAdapterConfig, queue: EventQueue,
+    ) -> None:
+        super().__init__(queue)
+        self._config = config
+        self._stopping = False
+        self._task: asyncio.Task[None] | None = None
+        self._connected = False
+        self._session: aiohttp.ClientSession | None = None
+
+        # State trackers for dedup
+        self._errored_hashes: set[str] = set()
+        self._stalled_hashes: set[str] = set()
+        self._connection_ok: bool | None = None  # None = unknown
+
+    @property
+    def name(self) -> str:
+        return "qbittorrent"
+
+    async def start(self) -> None:
+        """Start the polling loop."""
+        self._task = asyncio.create_task(
+            self._poll_loop(), name="qbittorrent-poller",
+        )
+        await self._task
+
+    async def stop(self) -> None:
+        self._stopping = True
+        if self._task is not None:
+            self._task.cancel()
+            self._task = None
+        if self._session and not self._session.closed:
+            await self._session.close()
+
+    async def healthy(self) -> bool:
+        return self._connected
+
+    # -----------------------------------------------------------------
+    # Authentication
+    # -----------------------------------------------------------------
+
+    async def _ensure_session(self) -> aiohttp.ClientSession:
+        """Return an authenticated session, creating/refreshing as needed."""
+        if self._session is None or self._session.closed:
+            timeout = aiohttp.ClientTimeout(total=self._config.timeout)
+            self._session = aiohttp.ClientSession(timeout=timeout)
+
+        await self._login()
+        return self._session
+
+    async def _login(self) -> None:
+        """Authenticate with qBittorrent Web API."""
+        if self._session is None:
+            return
+
+        url = f"{self._config.url}/api/v2/auth/login"
+        data = {
+            "username": self._config.username,
+            "password": self._config.password,
+        }
+        async with self._session.post(url, data=data) as resp:
+            body = await resp.text()
+            if resp.status != 200 or body.strip().upper() != "OK.":
+                msg = f"qBittorrent auth failed: {resp.status} {body}"
+                raise aiohttp.ClientError(msg)
+
+    # -----------------------------------------------------------------
+    # Poll loop
+    # -----------------------------------------------------------------
+
+    async def _poll_loop(self) -> None:
+        while not self._stopping:
+            try:
+                session = await self._ensure_session()
+                await self._poll_transfer_info(session)
+                await self._poll_errored_torrents(session)
+                await self._poll_stalled_torrents(session)
+                self._connected = True
+            except asyncio.CancelledError:
+                return
+            except (TimeoutError, aiohttp.ClientError) as exc:
+                if self._connected:
+                    logger.warning("qBittorrent: connection error: %s", exc)
+                self._connected = False
+                # Force re-auth next cycle
+                if self._session and not self._session.closed:
+                    await self._session.close()
+                self._session = None
+            except Exception:
+                self._connected = False
+                logger.exception("qBittorrent: unexpected error")
+                if self._session and not self._session.closed:
+                    await self._session.close()
+                self._session = None
+
+            for _ in range(self._config.poll_interval):
+                if self._stopping:
+                    return
+                await asyncio.sleep(1)
+
+    # -----------------------------------------------------------------
+    # Transfer info (connectivity)
+    # -----------------------------------------------------------------
+
+    async def _poll_transfer_info(self, session: aiohttp.ClientSession) -> None:
+        """Poll /api/v2/transfer/info for connection status."""
+        url = f"{self._config.url}/api/v2/transfer/info"
+        async with session.get(url) as resp:
+            resp.raise_for_status()
+            data: dict[str, Any] = await resp.json(content_type=None)
+
+        status = data.get("connection_status", "connected")
+        is_connected = status != "disconnected"
+        was_connected = self._connection_ok
+
+        self._connection_ok = is_connected
+
+        if was_connected is not None and was_connected and not is_connected:
+            self._enqueue(Event(
+                source=self.name,
+                system="qbittorrent",
+                event_type="qbt_connection_lost",
+                entity_id="qbittorrent",
+                severity=Severity.ERROR,
+                timestamp=datetime.now(tz=UTC),
+                payload={
+                    "connection_status": status,
+                    "dl_speed": data.get("dl_info_speed", 0),
+                    "up_speed": data.get("up_info_speed", 0),
+                },
+                metadata=EventMetadata(
+                    dedup_key="qbittorrent:connection",
+                ),
+            ))
+        elif was_connected is not None and not was_connected and is_connected:
+            self._enqueue(Event(
+                source=self.name,
+                system="qbittorrent",
+                event_type="qbt_connection_recovered",
+                entity_id="qbittorrent",
+                severity=Severity.INFO,
+                timestamp=datetime.now(tz=UTC),
+                payload={"connection_status": status},
+                metadata=EventMetadata(
+                    dedup_key="qbittorrent:connection",
+                ),
+            ))
+        elif was_connected is None and not is_connected:
+            self._enqueue(Event(
+                source=self.name,
+                system="qbittorrent",
+                event_type="qbt_connection_lost",
+                entity_id="qbittorrent",
+                severity=Severity.ERROR,
+                timestamp=datetime.now(tz=UTC),
+                payload={"connection_status": status},
+                metadata=EventMetadata(
+                    dedup_key="qbittorrent:connection",
+                ),
+            ))
+
+    # -----------------------------------------------------------------
+    # Errored torrents
+    # -----------------------------------------------------------------
+
+    async def _poll_errored_torrents(self, session: aiohttp.ClientSession) -> None:
+        """Poll for torrents in error state."""
+        url = f"{self._config.url}/api/v2/torrents/info"
+        params = {"filter": "errored"}
+        async with session.get(url, params=params) as resp:
+            resp.raise_for_status()
+            torrents: list[dict[str, Any]] = await resp.json(content_type=None)
+
+        current_errored: set[str] = set()
+        for torrent in torrents:
+            torrent_hash = torrent.get("hash", "")
+            if not torrent_hash:
+                continue
+
+            current_errored.add(torrent_hash)
+            if torrent_hash not in self._errored_hashes:
+                self._enqueue(Event(
+                    source=self.name,
+                    system="qbittorrent",
+                    event_type="qbt_torrent_error",
+                    entity_id=torrent.get("name", torrent_hash),
+                    severity=Severity.WARNING,
+                    timestamp=datetime.now(tz=UTC),
+                    payload={
+                        "hash": torrent_hash,
+                        "name": torrent.get("name", ""),
+                        "state": torrent.get("state", ""),
+                        "size": torrent.get("size", 0),
+                        "progress": torrent.get("progress", 0),
+                        "category": torrent.get("category", ""),
+                    },
+                    metadata=EventMetadata(
+                        dedup_key=f"qbittorrent:error:{torrent_hash}",
+                    ),
+                ))
+
+        self._errored_hashes = current_errored
+
+    # -----------------------------------------------------------------
+    # Stalled torrents
+    # -----------------------------------------------------------------
+
+    async def _poll_stalled_torrents(self, session: aiohttp.ClientSession) -> None:
+        """Poll for stalled downloading torrents."""
+        url = f"{self._config.url}/api/v2/torrents/info"
+        params = {"filter": "stalled_downloading"}
+        async with session.get(url, params=params) as resp:
+            resp.raise_for_status()
+            torrents: list[dict[str, Any]] = await resp.json(content_type=None)
+
+        current_stalled: set[str] = set()
+        for torrent in torrents:
+            torrent_hash = torrent.get("hash", "")
+            if not torrent_hash:
+                continue
+
+            current_stalled.add(torrent_hash)
+            if torrent_hash not in self._stalled_hashes:
+                self._enqueue(Event(
+                    source=self.name,
+                    system="qbittorrent",
+                    event_type="qbt_torrent_stalled",
+                    entity_id=torrent.get("name", torrent_hash),
+                    severity=Severity.INFO,
+                    timestamp=datetime.now(tz=UTC),
+                    payload={
+                        "hash": torrent_hash,
+                        "name": torrent.get("name", ""),
+                        "state": torrent.get("state", ""),
+                        "size": torrent.get("size", 0),
+                        "progress": torrent.get("progress", 0),
+                        "num_seeds": torrent.get("num_seeds", 0),
+                        "num_leechs": torrent.get("num_leechs", 0),
+                    },
+                    metadata=EventMetadata(
+                        dedup_key=f"qbittorrent:stalled:{torrent_hash}",
+                    ),
+                ))
+
+        self._stalled_hashes = current_stalled
+
+    # -----------------------------------------------------------------
+    # Helpers
+    # -----------------------------------------------------------------
+
+    def _enqueue(self, event: Event) -> None:
+        """Enqueue an event, logging on failure."""
+        try:
+            self._queue.put_nowait(event)
+        except Exception:
+            logger.warning(
+                "qBittorrent: failed to enqueue event: %s/%s",
+                event.system, event.event_type,
+            )

--- a/oasisagent/ingestion/servarr.py
+++ b/oasisagent/ingestion/servarr.py
@@ -1,0 +1,268 @@
+"""Servarr (Sonarr/Radarr/Prowlarr/Bazarr) polling ingestion adapter.
+
+Polls the Servarr v3/v1 API for health issues and download queue problems.
+A single adapter class handles all Servarr-family apps since they share
+the same API pattern, differing only in API version and port.
+
+Events emitted on state transitions:
+- ``servarr_health_issue`` (WARNING) when a new health check problem appears
+- ``servarr_queue_stuck`` (WARNING) when a download is stuck for >2 hours
+- ``servarr_queue_failed`` (ERROR) when a download has failed
+"""
+
+from __future__ import annotations
+
+import asyncio
+import logging
+from datetime import UTC, datetime
+from typing import TYPE_CHECKING, Any
+
+import aiohttp
+
+from oasisagent.ingestion.base import IngestAdapter
+from oasisagent.models import Event, EventMetadata, Severity
+
+if TYPE_CHECKING:
+    from oasisagent.config import ServarrAdapterConfig
+    from oasisagent.engine.queue import EventQueue
+
+logger = logging.getLogger(__name__)
+
+# Prowlarr and Bazarr use API v1; Sonarr and Radarr use v3
+_API_VERSION: dict[str, str] = {
+    "sonarr": "v3",
+    "radarr": "v3",
+    "prowlarr": "v1",
+    "bazarr": "v1",
+}
+
+# Stuck threshold: 2 hours in seconds
+_STUCK_THRESHOLD_SECONDS = 7200
+
+
+class ServarrAdapter(IngestAdapter):
+    """Polls Servarr apps (Sonarr, Radarr, Prowlarr, Bazarr) for health and queue issues.
+
+    Uses state-based dedup so events are only emitted on transitions.
+    """
+
+    def __init__(
+        self, config: ServarrAdapterConfig, queue: EventQueue,
+    ) -> None:
+        super().__init__(queue)
+        self._config = config
+        self._stopping = False
+        self._task: asyncio.Task[None] | None = None
+        self._connected = False
+
+        # State trackers for dedup
+        self._health_issues: set[str] = set()  # active health issue messages
+        self._failed_ids: set[str] = set()  # download IDs in failed state
+        self._stuck_ids: set[str] = set()  # download IDs flagged as stuck
+
+    @property
+    def name(self) -> str:
+        return f"servarr_{self._config.app_type}"
+
+    @property
+    def _api_version(self) -> str:
+        return _API_VERSION.get(self._config.app_type, "v3")
+
+    def _headers(self) -> dict[str, str]:
+        return {"X-Api-Key": self._config.api_key}
+
+    async def start(self) -> None:
+        """Start the polling loop."""
+        self._task = asyncio.create_task(
+            self._poll_loop(),
+            name=f"servarr-{self._config.app_type}-poller",
+        )
+        await self._task
+
+    async def stop(self) -> None:
+        self._stopping = True
+        if self._task is not None:
+            self._task.cancel()
+            self._task = None
+
+    async def healthy(self) -> bool:
+        return self._connected
+
+    # -----------------------------------------------------------------
+    # Poll loop
+    # -----------------------------------------------------------------
+
+    async def _poll_loop(self) -> None:
+        timeout = aiohttp.ClientTimeout(total=self._config.timeout)
+
+        while not self._stopping:
+            try:
+                async with aiohttp.ClientSession(
+                    headers=self._headers(), timeout=timeout,
+                ) as session:
+                    await self._poll_health(session)
+                    await self._poll_queue(session)
+                    self._connected = True
+            except asyncio.CancelledError:
+                return
+            except (TimeoutError, aiohttp.ClientError) as exc:
+                if self._connected:
+                    logger.warning(
+                        "Servarr %s: connection error: %s",
+                        self._config.app_type, exc,
+                    )
+                self._connected = False
+            except Exception:
+                self._connected = False
+                logger.exception(
+                    "Servarr %s: unexpected error",
+                    self._config.app_type,
+                )
+
+            for _ in range(self._config.poll_interval):
+                if self._stopping:
+                    return
+                await asyncio.sleep(1)
+
+    # -----------------------------------------------------------------
+    # Health endpoint
+    # -----------------------------------------------------------------
+
+    async def _poll_health(self, session: aiohttp.ClientSession) -> None:
+        """Poll /api/vX/health for health check issues."""
+        url = f"{self._config.url}/api/{self._api_version}/health"
+        async with session.get(url) as resp:
+            resp.raise_for_status()
+            data: list[dict[str, Any]] = await resp.json(content_type=None)
+
+        current_issues: set[str] = set()
+        for issue in data:
+            msg = issue.get("message", "")
+            issue_type = issue.get("type", "warning")
+            source_name = issue.get("source", "")
+            issue_key = f"{source_name}:{msg}"
+            current_issues.add(issue_key)
+
+            if issue_key not in self._health_issues:
+                severity = Severity.ERROR if issue_type == "error" else Severity.WARNING
+                self._enqueue(Event(
+                    source=self.name,
+                    system=self._config.app_type,
+                    event_type="servarr_health_issue",
+                    entity_id=source_name or self._config.app_type,
+                    severity=severity,
+                    timestamp=datetime.now(tz=UTC),
+                    payload={
+                        "app_type": self._config.app_type,
+                        "message": msg,
+                        "type": issue_type,
+                        "source": source_name,
+                        "wiki_url": issue.get("wikiUrl", ""),
+                    },
+                    metadata=EventMetadata(
+                        dedup_key=f"servarr:{self._config.app_type}:health:{issue_key}",
+                    ),
+                ))
+
+        self._health_issues = current_issues
+
+    # -----------------------------------------------------------------
+    # Queue endpoint
+    # -----------------------------------------------------------------
+
+    async def _poll_queue(self, session: aiohttp.ClientSession) -> None:
+        """Poll /api/vX/queue for stuck or failed downloads."""
+        url = f"{self._config.url}/api/{self._api_version}/queue"
+        params: dict[str, str] = {"pageSize": "50", "includeUnknownSeriesItems": "true"}
+        async with session.get(url, params=params) as resp:
+            resp.raise_for_status()
+            data: dict[str, Any] = await resp.json(content_type=None)
+
+        records: list[dict[str, Any]] = data.get("records", [])
+        now = datetime.now(tz=UTC)
+
+        current_failed: set[str] = set()
+        current_stuck: set[str] = set()
+
+        for record in records:
+            record_id = str(record.get("id", ""))
+            if not record_id:
+                continue
+
+            status = record.get("status", "").lower()
+            title = record.get("title", "unknown")
+
+            # Check for failed downloads
+            tracked_status = record.get("trackedDownloadStatus", "").lower()
+            if tracked_status == "warning" or status == "failed":
+                current_failed.add(record_id)
+                if record_id not in self._failed_ids:
+                    self._enqueue(Event(
+                        source=self.name,
+                        system=self._config.app_type,
+                        event_type="servarr_queue_failed",
+                        entity_id=title,
+                        severity=Severity.ERROR,
+                        timestamp=now,
+                        payload={
+                            "app_type": self._config.app_type,
+                            "record_id": record_id,
+                            "title": title,
+                            "status": status,
+                            "tracked_status": tracked_status,
+                            "error_message": record.get("statusMessages", []),
+                        },
+                        metadata=EventMetadata(
+                            dedup_key=f"servarr:{self._config.app_type}:queue_failed:{record_id}",
+                        ),
+                    ))
+                continue
+
+            # Check for stuck downloads (time in queue > threshold)
+            added_str = record.get("added", "")
+            if added_str and status == "downloading":
+                try:
+                    added = datetime.fromisoformat(
+                        added_str.replace("Z", "+00:00"),
+                    )
+                    age_seconds = (now - added).total_seconds()
+                    if age_seconds > _STUCK_THRESHOLD_SECONDS:
+                        current_stuck.add(record_id)
+                        if record_id not in self._stuck_ids:
+                            self._enqueue(Event(
+                                source=self.name,
+                                system=self._config.app_type,
+                                event_type="servarr_queue_stuck",
+                                entity_id=title,
+                                severity=Severity.WARNING,
+                                timestamp=now,
+                                payload={
+                                    "app_type": self._config.app_type,
+                                    "record_id": record_id,
+                                    "title": title,
+                                    "age_hours": round(age_seconds / 3600, 1),
+                                    "status": status,
+                                },
+                                metadata=EventMetadata(
+                                    dedup_key=f"servarr:{self._config.app_type}:queue_stuck:{record_id}",
+                                ),
+                            ))
+                except (ValueError, TypeError):
+                    pass
+
+        self._failed_ids = current_failed
+        self._stuck_ids = current_stuck
+
+    # -----------------------------------------------------------------
+    # Helpers
+    # -----------------------------------------------------------------
+
+    def _enqueue(self, event: Event) -> None:
+        """Enqueue an event, logging on failure."""
+        try:
+            self._queue.put_nowait(event)
+        except Exception:
+            logger.warning(
+                "Servarr %s: failed to enqueue event: %s/%s",
+                self._config.app_type, event.system, event.event_type,
+            )

--- a/oasisagent/ingestion/tautulli.py
+++ b/oasisagent/ingestion/tautulli.py
@@ -1,0 +1,251 @@
+"""Tautulli polling ingestion adapter.
+
+Polls the Tautulli API v2 for Plex server status and bandwidth monitoring.
+Tautulli provides richer monitoring data than the Plex API directly.
+
+Events emitted on state transitions:
+- ``tautulli_plex_down`` (ERROR) when Tautulli reports Plex is down
+- ``tautulli_plex_recovered`` (INFO) when Plex comes back up
+- ``tautulli_high_bandwidth`` (WARNING) when total bandwidth exceeds threshold
+- ``tautulli_bandwidth_recovered`` (INFO) when bandwidth drops below threshold
+"""
+
+from __future__ import annotations
+
+import asyncio
+import logging
+from datetime import UTC, datetime
+from typing import TYPE_CHECKING, Any
+
+import aiohttp
+
+from oasisagent.ingestion.base import IngestAdapter
+from oasisagent.models import Event, EventMetadata, Severity
+
+if TYPE_CHECKING:
+    from oasisagent.config import TautulliAdapterConfig
+    from oasisagent.engine.queue import EventQueue
+
+logger = logging.getLogger(__name__)
+
+# Default bandwidth threshold in kbps (100 Mbps)
+_DEFAULT_BANDWIDTH_THRESHOLD_KBPS = 100_000
+
+
+class TautulliAdapter(IngestAdapter):
+    """Polls Tautulli for Plex server status and bandwidth metrics.
+
+    State-based dedup ensures events only fire on transitions.
+    """
+
+    def __init__(
+        self, config: TautulliAdapterConfig, queue: EventQueue,
+    ) -> None:
+        super().__init__(queue)
+        self._config = config
+        self._stopping = False
+        self._task: asyncio.Task[None] | None = None
+        self._connected = False
+
+        # State trackers
+        self._plex_connected: bool | None = None
+        self._bandwidth_high: bool = False
+
+    @property
+    def name(self) -> str:
+        return "tautulli"
+
+    async def start(self) -> None:
+        self._task = asyncio.create_task(
+            self._poll_loop(), name="tautulli-poller",
+        )
+        await self._task
+
+    async def stop(self) -> None:
+        self._stopping = True
+        if self._task is not None:
+            self._task.cancel()
+            self._task = None
+
+    async def healthy(self) -> bool:
+        return self._connected
+
+    # -----------------------------------------------------------------
+    # Poll loop
+    # -----------------------------------------------------------------
+
+    async def _poll_loop(self) -> None:
+        timeout = aiohttp.ClientTimeout(total=self._config.timeout)
+
+        while not self._stopping:
+            try:
+                async with aiohttp.ClientSession(timeout=timeout) as session:
+                    await self._poll_server_status(session)
+                    await self._poll_activity(session)
+                    self._connected = True
+            except asyncio.CancelledError:
+                return
+            except (TimeoutError, aiohttp.ClientError) as exc:
+                if self._connected:
+                    logger.warning("Tautulli: connection error: %s", exc)
+                self._connected = False
+            except Exception:
+                self._connected = False
+                logger.exception("Tautulli: unexpected error")
+
+            for _ in range(self._config.poll_interval):
+                if self._stopping:
+                    return
+                await asyncio.sleep(1)
+
+    # -----------------------------------------------------------------
+    # Server status
+    # -----------------------------------------------------------------
+
+    async def _poll_server_status(self, session: aiohttp.ClientSession) -> None:
+        """Poll Tautulli's server_status command to check Plex connectivity."""
+        url = self._api_url("server_status")
+        async with session.get(url) as resp:
+            resp.raise_for_status()
+            data: dict[str, Any] = await resp.json(content_type=None)
+
+        response = data.get("response", {})
+        result = response.get("result", "error")
+        status_data = response.get("data", {})
+
+        if result != "success":
+            return
+
+        is_connected = status_data.get("connected", False)
+        was_connected = self._plex_connected
+        self._plex_connected = is_connected
+
+        if was_connected is not None and was_connected and not is_connected:
+            self._enqueue(Event(
+                source=self.name,
+                system="tautulli",
+                event_type="tautulli_plex_down",
+                entity_id="plex",
+                severity=Severity.ERROR,
+                timestamp=datetime.now(tz=UTC),
+                payload={
+                    "plex_version": status_data.get("pms_version", ""),
+                    "plex_platform": status_data.get("pms_platform", ""),
+                },
+                metadata=EventMetadata(
+                    dedup_key="tautulli:plex:status",
+                ),
+            ))
+        elif was_connected is not None and not was_connected and is_connected:
+            self._enqueue(Event(
+                source=self.name,
+                system="tautulli",
+                event_type="tautulli_plex_recovered",
+                entity_id="plex",
+                severity=Severity.INFO,
+                timestamp=datetime.now(tz=UTC),
+                payload={
+                    "plex_version": status_data.get("pms_version", ""),
+                },
+                metadata=EventMetadata(
+                    dedup_key="tautulli:plex:status",
+                ),
+            ))
+        elif was_connected is None and not is_connected:
+            # First poll, already down
+            self._enqueue(Event(
+                source=self.name,
+                system="tautulli",
+                event_type="tautulli_plex_down",
+                entity_id="plex",
+                severity=Severity.ERROR,
+                timestamp=datetime.now(tz=UTC),
+                payload={
+                    "plex_version": status_data.get("pms_version", ""),
+                    "plex_platform": status_data.get("pms_platform", ""),
+                },
+                metadata=EventMetadata(
+                    dedup_key="tautulli:plex:status",
+                ),
+            ))
+
+    # -----------------------------------------------------------------
+    # Activity / bandwidth
+    # -----------------------------------------------------------------
+
+    async def _poll_activity(self, session: aiohttp.ClientSession) -> None:
+        """Poll Tautulli's get_activity command for bandwidth monitoring."""
+        url = self._api_url("get_activity")
+        async with session.get(url) as resp:
+            resp.raise_for_status()
+            data: dict[str, Any] = await resp.json(content_type=None)
+
+        response = data.get("response", {})
+        result = response.get("result", "error")
+        activity = response.get("data", {})
+
+        if result != "success":
+            return
+
+        total_bandwidth = activity.get("total_bandwidth", 0)
+        stream_count = activity.get("stream_count", 0)
+        threshold = self._config.bandwidth_threshold_kbps
+
+        was_high = self._bandwidth_high
+        is_high = total_bandwidth > threshold
+
+        self._bandwidth_high = is_high
+
+        if not was_high and is_high:
+            self._enqueue(Event(
+                source=self.name,
+                system="tautulli",
+                event_type="tautulli_high_bandwidth",
+                entity_id="plex",
+                severity=Severity.WARNING,
+                timestamp=datetime.now(tz=UTC),
+                payload={
+                    "total_bandwidth_kbps": total_bandwidth,
+                    "threshold_kbps": threshold,
+                    "stream_count": stream_count,
+                    "stream_count_direct_play": activity.get("stream_count_direct_play", 0),
+                    "stream_count_transcode": activity.get("stream_count_transcode", 0),
+                },
+                metadata=EventMetadata(
+                    dedup_key="tautulli:bandwidth",
+                ),
+            ))
+        elif was_high and not is_high:
+            self._enqueue(Event(
+                source=self.name,
+                system="tautulli",
+                event_type="tautulli_bandwidth_recovered",
+                entity_id="plex",
+                severity=Severity.INFO,
+                timestamp=datetime.now(tz=UTC),
+                payload={
+                    "total_bandwidth_kbps": total_bandwidth,
+                    "stream_count": stream_count,
+                },
+                metadata=EventMetadata(
+                    dedup_key="tautulli:bandwidth",
+                ),
+            ))
+
+    # -----------------------------------------------------------------
+    # Helpers
+    # -----------------------------------------------------------------
+
+    def _api_url(self, cmd: str) -> str:
+        """Build Tautulli API URL with command and API key."""
+        return f"{self._config.url}/api/v2?apikey={self._config.api_key}&cmd={cmd}"
+
+    def _enqueue(self, event: Event) -> None:
+        """Enqueue an event, logging on failure."""
+        try:
+            self._queue.put_nowait(event)
+        except Exception:
+            logger.warning(
+                "Tautulli: failed to enqueue event: %s/%s",
+                event.system, event.event_type,
+            )

--- a/oasisagent/ingestion/tdarr.py
+++ b/oasisagent/ingestion/tdarr.py
@@ -1,0 +1,254 @@
+"""Tdarr polling ingestion adapter.
+
+Polls the Tdarr API v2 for worker health and queue status.
+
+Events emitted on state transitions:
+- ``tdarr_worker_failed`` (WARNING) when a worker goes offline
+- ``tdarr_worker_recovered`` (INFO) when a worker comes back online
+- ``tdarr_queue_stuck`` (WARNING) when queue items are not progressing
+"""
+
+from __future__ import annotations
+
+import asyncio
+import logging
+from datetime import UTC, datetime
+from typing import TYPE_CHECKING, Any
+
+import aiohttp
+
+from oasisagent.ingestion.base import IngestAdapter
+from oasisagent.models import Event, EventMetadata, Severity
+
+if TYPE_CHECKING:
+    from oasisagent.config import TdarrAdapterConfig
+    from oasisagent.engine.queue import EventQueue
+
+logger = logging.getLogger(__name__)
+
+# Queue is considered stuck if no items processed in this many polls
+_STUCK_POLL_THRESHOLD = 3
+
+
+class TdarrAdapter(IngestAdapter):
+    """Polls Tdarr for worker health and queue status.
+
+    State-based dedup ensures events only fire on transitions.
+    """
+
+    def __init__(
+        self, config: TdarrAdapterConfig, queue: EventQueue,
+    ) -> None:
+        super().__init__(queue)
+        self._config = config
+        self._stopping = False
+        self._task: asyncio.Task[None] | None = None
+        self._connected = False
+
+        # State trackers
+        self._worker_states: dict[str, bool] = {}  # worker_id -> is_online
+        self._last_queue_processed: int | None = None
+        self._stall_counter: int = 0
+        self._queue_stuck: bool = False
+
+    @property
+    def name(self) -> str:
+        return "tdarr"
+
+    async def start(self) -> None:
+        self._task = asyncio.create_task(
+            self._poll_loop(), name="tdarr-poller",
+        )
+        await self._task
+
+    async def stop(self) -> None:
+        self._stopping = True
+        if self._task is not None:
+            self._task.cancel()
+            self._task = None
+
+    async def healthy(self) -> bool:
+        return self._connected
+
+    # -----------------------------------------------------------------
+    # Poll loop
+    # -----------------------------------------------------------------
+
+    async def _poll_loop(self) -> None:
+        timeout = aiohttp.ClientTimeout(total=self._config.timeout)
+
+        while not self._stopping:
+            try:
+                async with aiohttp.ClientSession(timeout=timeout) as session:
+                    await self._poll_status(session)
+                    self._connected = True
+            except asyncio.CancelledError:
+                return
+            except (TimeoutError, aiohttp.ClientError) as exc:
+                if self._connected:
+                    logger.warning("Tdarr: connection error: %s", exc)
+                self._connected = False
+            except Exception:
+                self._connected = False
+                logger.exception("Tdarr: unexpected error")
+
+            for _ in range(self._config.poll_interval):
+                if self._stopping:
+                    return
+                await asyncio.sleep(1)
+
+    # -----------------------------------------------------------------
+    # Status endpoint
+    # -----------------------------------------------------------------
+
+    async def _poll_status(self, session: aiohttp.ClientSession) -> None:
+        """Poll /api/v2/status for worker and queue status."""
+        url = f"{self._config.url}/api/v2/status"
+        async with session.get(url) as resp:
+            resp.raise_for_status()
+            data: dict[str, Any] = await resp.json(content_type=None)
+
+        self._check_workers(data)
+        self._check_queue(data)
+
+    def _check_workers(self, data: dict[str, Any]) -> None:
+        """Check worker status for offline transitions."""
+        workers: dict[str, Any] = data.get("workers", {})
+
+        for worker_id, worker_info in workers.items():
+            info: dict[str, Any] = worker_info if isinstance(worker_info, dict) else {}
+            is_online = bool(info) and info.get("idle", True) is not None
+            was_online = self._worker_states.get(worker_id)
+
+            self._worker_states[worker_id] = is_online
+
+            if was_online is not None and was_online and not is_online:
+                self._enqueue(Event(
+                    source=self.name,
+                    system="tdarr",
+                    event_type="tdarr_worker_failed",
+                    entity_id=worker_id,
+                    severity=Severity.WARNING,
+                    timestamp=datetime.now(tz=UTC),
+                    payload={
+                        "worker_id": worker_id,
+                        "worker_type": info.get("workerType", ""),
+                    },
+                    metadata=EventMetadata(
+                        dedup_key=f"tdarr:worker:{worker_id}",
+                    ),
+                ))
+            elif was_online is not None and not was_online and is_online:
+                self._enqueue(Event(
+                    source=self.name,
+                    system="tdarr",
+                    event_type="tdarr_worker_recovered",
+                    entity_id=worker_id,
+                    severity=Severity.INFO,
+                    timestamp=datetime.now(tz=UTC),
+                    payload={"worker_id": worker_id},
+                    metadata=EventMetadata(
+                        dedup_key=f"tdarr:worker:{worker_id}",
+                    ),
+                ))
+            elif was_online is None and not is_online:
+                # First poll, already offline
+                self._enqueue(Event(
+                    source=self.name,
+                    system="tdarr",
+                    event_type="tdarr_worker_failed",
+                    entity_id=worker_id,
+                    severity=Severity.WARNING,
+                    timestamp=datetime.now(tz=UTC),
+                    payload={
+                        "worker_id": worker_id,
+                        "worker_type": info.get("workerType", ""),
+                    },
+                    metadata=EventMetadata(
+                        dedup_key=f"tdarr:worker:{worker_id}",
+                    ),
+                ))
+
+    def _check_queue(self, data: dict[str, Any]) -> None:
+        """Check queue progress for stuck detection."""
+        queue_count = data.get("queueCount", 0)
+        processed_count = data.get("processedCount", 0)
+
+        if queue_count == 0:
+            # Nothing queued, reset stall tracking
+            if self._queue_stuck:
+                self._enqueue(Event(
+                    source=self.name,
+                    system="tdarr",
+                    event_type="tdarr_queue_recovered",
+                    entity_id="tdarr",
+                    severity=Severity.INFO,
+                    timestamp=datetime.now(tz=UTC),
+                    payload={"queue_count": 0, "processed_count": processed_count},
+                    metadata=EventMetadata(
+                        dedup_key="tdarr:queue:stuck",
+                    ),
+                ))
+            self._stall_counter = 0
+            self._queue_stuck = False
+            self._last_queue_processed = processed_count
+            return
+
+        # Queue has items — check if progress is being made
+        if self._last_queue_processed is not None:
+            if processed_count <= self._last_queue_processed:
+                self._stall_counter += 1
+            else:
+                self._stall_counter = 0
+                if self._queue_stuck:
+                    self._queue_stuck = False
+                    self._enqueue(Event(
+                        source=self.name,
+                        system="tdarr",
+                        event_type="tdarr_queue_recovered",
+                        entity_id="tdarr",
+                        severity=Severity.INFO,
+                        timestamp=datetime.now(tz=UTC),
+                        payload={
+                            "queue_count": queue_count,
+                            "processed_count": processed_count,
+                        },
+                        metadata=EventMetadata(
+                            dedup_key="tdarr:queue:stuck",
+                        ),
+                    ))
+
+        self._last_queue_processed = processed_count
+
+        if self._stall_counter >= _STUCK_POLL_THRESHOLD and not self._queue_stuck:
+            self._queue_stuck = True
+            self._enqueue(Event(
+                source=self.name,
+                system="tdarr",
+                event_type="tdarr_queue_stuck",
+                entity_id="tdarr",
+                severity=Severity.WARNING,
+                timestamp=datetime.now(tz=UTC),
+                payload={
+                    "queue_count": queue_count,
+                    "processed_count": processed_count,
+                    "stalled_polls": self._stall_counter,
+                },
+                metadata=EventMetadata(
+                    dedup_key="tdarr:queue:stuck",
+                ),
+            ))
+
+    # -----------------------------------------------------------------
+    # Helpers
+    # -----------------------------------------------------------------
+
+    def _enqueue(self, event: Event) -> None:
+        """Enqueue an event, logging on failure."""
+        try:
+            self._queue.put_nowait(event)
+        except Exception:
+            logger.warning(
+                "Tdarr: failed to enqueue event: %s/%s",
+                event.system, event.event_type,
+            )

--- a/oasisagent/ui/form_specs.py
+++ b/oasisagent/ui/form_specs.py
@@ -45,6 +45,12 @@ TYPE_DISPLAY_NAMES: dict[str, str] = {
     "unifi": "UniFi Network",
     "cloudflare": "Cloudflare",
     "uptime_kuma": "Uptime Kuma",
+    "servarr": "Servarr (Sonarr/Radarr/Prowlarr/Bazarr)",
+    "qbittorrent": "qBittorrent",
+    "plex": "Plex Media Server",
+    "tautulli": "Tautulli",
+    "tdarr": "Tdarr",
+    "overseerr": "Overseerr",
     # Services
     "llm_triage": "LLM Triage (T1)",
     "llm_reasoning": "LLM Reasoning (T2)",
@@ -91,6 +97,29 @@ TYPE_DESCRIPTIONS: dict[str, str] = {
     "uptime_kuma": (
         "Pull monitor status from Uptime Kuma's"
         " Prometheus endpoint"
+    ),
+    "servarr": (
+        "Monitor Sonarr, Radarr, Prowlarr, or Bazarr"
+        " health and download queue"
+    ),
+    "qbittorrent": (
+        "Monitor qBittorrent for errored, stalled,"
+        " and disconnected torrents"
+    ),
+    "plex": (
+        "Monitor Plex Media Server reachability"
+        " and library health"
+    ),
+    "tautulli": (
+        "Monitor Plex via Tautulli — server status"
+        " and bandwidth"
+    ),
+    "tdarr": (
+        "Monitor Tdarr transcoding workers"
+        " and queue progress"
+    ),
+    "overseerr": (
+        "Monitor Overseerr server connectivity"
     ),
     # Services
     "llm_triage": (
@@ -544,6 +573,141 @@ FORM_SPECS: dict[str, list[FieldSpec]] = {
                 " within N days"
             ),
             default=7, min_val=1,
+        ),
+    ],
+
+    "servarr": [
+        FieldSpec(
+            "url", "Server URL", "text",
+            help_text="e.g. http://localhost:8989",
+            required=True,
+        ),
+        FieldSpec(
+            "api_key", "API Key", "password",
+            required=True, group="Authentication",
+        ),
+        FieldSpec(
+            "app_type", "Application", "select",
+            options=[
+                ("sonarr", "Sonarr"),
+                ("radarr", "Radarr"),
+                ("prowlarr", "Prowlarr"),
+                ("bazarr", "Bazarr"),
+            ],
+            default="sonarr",
+        ),
+        FieldSpec(
+            "poll_interval", "Poll Interval (seconds)",
+            "number", default=60,
+        ),
+        FieldSpec(
+            "timeout", "Request Timeout (seconds)",
+            "number", default=10, min_val=1,
+        ),
+    ],
+    "qbittorrent": [
+        FieldSpec(
+            "url", "Server URL", "text",
+            help_text="e.g. http://localhost:8080",
+            required=True,
+        ),
+        FieldSpec(
+            "username", "Username", "text",
+            required=True, group="Authentication",
+            default="admin",
+        ),
+        FieldSpec(
+            "password", "Password", "password",
+            required=True, group="Authentication",
+        ),
+        FieldSpec(
+            "poll_interval", "Poll Interval (seconds)",
+            "number", default=60,
+        ),
+        FieldSpec(
+            "timeout", "Request Timeout (seconds)",
+            "number", default=10, min_val=1,
+        ),
+    ],
+    "plex": [
+        FieldSpec(
+            "url", "Server URL", "text",
+            help_text="e.g. http://localhost:32400",
+            required=True,
+        ),
+        FieldSpec(
+            "token", "X-Plex-Token", "password",
+            required=True, group="Authentication",
+        ),
+        FieldSpec(
+            "poll_interval", "Poll Interval (seconds)",
+            "number", default=60,
+        ),
+        FieldSpec(
+            "timeout", "Request Timeout (seconds)",
+            "number", default=10, min_val=1,
+        ),
+    ],
+    "tautulli": [
+        FieldSpec(
+            "url", "Server URL", "text",
+            help_text="e.g. http://localhost:8181",
+            required=True,
+        ),
+        FieldSpec(
+            "api_key", "API Key", "password",
+            required=True, group="Authentication",
+        ),
+        FieldSpec(
+            "poll_interval", "Poll Interval (seconds)",
+            "number", default=60,
+        ),
+        FieldSpec(
+            "timeout", "Request Timeout (seconds)",
+            "number", default=10, min_val=1,
+        ),
+        FieldSpec(
+            "bandwidth_threshold_kbps",
+            "Bandwidth Threshold (kbps)", "number",
+            help_text=(
+                "Alert when total bandwidth exceeds"
+                " this value (default: 100000 = 100 Mbps)"
+            ),
+            default=100_000, min_val=1,
+        ),
+    ],
+    "tdarr": [
+        FieldSpec(
+            "url", "Server URL", "text",
+            help_text="e.g. http://localhost:8265",
+            required=True,
+        ),
+        FieldSpec(
+            "poll_interval", "Poll Interval (seconds)",
+            "number", default=60,
+        ),
+        FieldSpec(
+            "timeout", "Request Timeout (seconds)",
+            "number", default=10, min_val=1,
+        ),
+    ],
+    "overseerr": [
+        FieldSpec(
+            "url", "Server URL", "text",
+            help_text="e.g. http://localhost:5055",
+            required=True,
+        ),
+        FieldSpec(
+            "api_key", "API Key", "password",
+            required=True, group="Authentication",
+        ),
+        FieldSpec(
+            "poll_interval", "Poll Interval (seconds)",
+            "number", default=60,
+        ),
+        FieldSpec(
+            "timeout", "Request Timeout (seconds)",
+            "number", default=10, min_val=1,
         ),
     ],
 

--- a/tests/test_ingestion/test_overseerr.py
+++ b/tests/test_ingestion/test_overseerr.py
@@ -1,0 +1,162 @@
+"""Tests for the Overseerr polling ingestion adapter."""
+
+from __future__ import annotations
+
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+from pydantic import ValidationError
+
+from oasisagent.config import OverseerrAdapterConfig
+from oasisagent.ingestion.overseerr import OverseerrAdapter
+from oasisagent.models import Severity
+
+
+def _make_config(**overrides: object) -> OverseerrAdapterConfig:
+    defaults: dict[str, object] = {
+        "enabled": True,
+        "url": "http://localhost:5055",
+        "api_key": "test-overseerr-key",
+        "poll_interval": 60,
+        "timeout": 10,
+    }
+    defaults.update(overrides)
+    return OverseerrAdapterConfig(**defaults)  # type: ignore[arg-type]
+
+
+def _mock_queue() -> MagicMock:
+    return MagicMock()
+
+
+def _make_adapter(**overrides: object) -> tuple[OverseerrAdapter, MagicMock]:
+    config = _make_config(**overrides)
+    queue = _mock_queue()
+    adapter = OverseerrAdapter(config, queue)
+    return adapter, queue
+
+
+def _mock_response(data: object, status: int = 200) -> AsyncMock:
+    mock = AsyncMock()
+    mock.status = status
+    mock.raise_for_status = MagicMock()
+    mock.json = AsyncMock(return_value=data)
+    mock.__aenter__ = AsyncMock(return_value=mock)
+    mock.__aexit__ = AsyncMock(return_value=False)
+    return mock
+
+
+# ---------------------------------------------------------------------------
+# Config validation
+# ---------------------------------------------------------------------------
+
+
+class TestConfigValidation:
+    def test_defaults(self) -> None:
+        config = OverseerrAdapterConfig()
+        assert config.enabled is False
+        assert config.poll_interval == 60
+
+    def test_extra_fields_forbidden(self) -> None:
+        with pytest.raises(ValidationError, match="Extra inputs"):
+            _make_config(bogus="nope")
+
+
+# ---------------------------------------------------------------------------
+# Adapter identity & lifecycle
+# ---------------------------------------------------------------------------
+
+
+class TestAdapterLifecycle:
+    def test_name(self) -> None:
+        adapter, _ = _make_adapter()
+        assert adapter.name == "overseerr"
+
+    @pytest.mark.asyncio
+    async def test_healthy_initially_false(self) -> None:
+        adapter, _ = _make_adapter()
+        assert not await adapter.healthy()
+
+    @pytest.mark.asyncio
+    async def test_stop_sets_flag(self) -> None:
+        adapter, _ = _make_adapter()
+        await adapter.stop()
+        assert adapter._stopping is True
+
+
+# ---------------------------------------------------------------------------
+# Status polling
+# ---------------------------------------------------------------------------
+
+
+class TestStatusPolling:
+    @pytest.mark.asyncio
+    async def test_server_recovered(self) -> None:
+        adapter, queue = _make_adapter()
+        adapter._server_ok = False
+
+        mock_session = AsyncMock()
+        mock_session.get = MagicMock(return_value=_mock_response(
+            {"version": "1.33.0"}, status=200,
+        ))
+
+        await adapter._poll_status(mock_session)
+
+        queue.put_nowait.assert_called_once()
+        event = queue.put_nowait.call_args[0][0]
+        assert event.event_type == "overseerr_server_recovered"
+        assert event.severity == Severity.INFO
+
+    @pytest.mark.asyncio
+    async def test_already_ok_no_event(self) -> None:
+        adapter, queue = _make_adapter()
+        adapter._server_ok = True
+
+        mock_session = AsyncMock()
+        mock_session.get = MagicMock(return_value=_mock_response(
+            {"version": "1.33.0"}, status=200,
+        ))
+
+        await adapter._poll_status(mock_session)
+        queue.put_nowait.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_first_poll_ok_no_event(self) -> None:
+        adapter, queue = _make_adapter()
+
+        mock_session = AsyncMock()
+        mock_session.get = MagicMock(return_value=_mock_response(
+            {"version": "1.33.0"}, status=200,
+        ))
+
+        await adapter._poll_status(mock_session)
+        queue.put_nowait.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_dedup_key(self) -> None:
+        adapter, queue = _make_adapter()
+        adapter._server_ok = False
+
+        mock_session = AsyncMock()
+        mock_session.get = MagicMock(return_value=_mock_response(
+            {"version": "1.33.0"}, status=200,
+        ))
+
+        await adapter._poll_status(mock_session)
+
+        event = queue.put_nowait.call_args[0][0]
+        assert event.metadata.dedup_key == "overseerr:server:status"
+
+
+# ---------------------------------------------------------------------------
+# Registry
+# ---------------------------------------------------------------------------
+
+
+class TestRegistry:
+    def test_overseerr_connector_registered(self) -> None:
+        from oasisagent.db.registry import CONNECTOR_TYPES
+
+        assert "overseerr" in CONNECTOR_TYPES
+        meta = CONNECTOR_TYPES["overseerr"]
+        assert meta.model is OverseerrAdapterConfig
+        assert "api_key" in meta.secret_fields

--- a/tests/test_ingestion/test_plex.py
+++ b/tests/test_ingestion/test_plex.py
@@ -1,0 +1,333 @@
+"""Tests for the Plex polling ingestion adapter."""
+
+from __future__ import annotations
+
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+from pydantic import ValidationError
+
+from oasisagent.config import PlexAdapterConfig
+from oasisagent.ingestion.plex import PlexAdapter
+from oasisagent.models import Severity
+
+
+def _make_config(**overrides: object) -> PlexAdapterConfig:
+    defaults: dict[str, object] = {
+        "enabled": True,
+        "url": "http://localhost:32400",
+        "token": "test-plex-token",
+        "poll_interval": 60,
+        "timeout": 10,
+    }
+    defaults.update(overrides)
+    return PlexAdapterConfig(**defaults)  # type: ignore[arg-type]
+
+
+def _mock_queue() -> MagicMock:
+    return MagicMock()
+
+
+def _make_adapter(**overrides: object) -> tuple[PlexAdapter, MagicMock]:
+    config = _make_config(**overrides)
+    queue = _mock_queue()
+    adapter = PlexAdapter(config, queue)
+    return adapter, queue
+
+
+def _mock_response(data: object, status: int = 200) -> AsyncMock:
+    mock = AsyncMock()
+    mock.status = status
+    mock.raise_for_status = MagicMock()
+    mock.json = AsyncMock(return_value=data)
+    mock.__aenter__ = AsyncMock(return_value=mock)
+    mock.__aexit__ = AsyncMock(return_value=False)
+    return mock
+
+
+# ---------------------------------------------------------------------------
+# Config validation
+# ---------------------------------------------------------------------------
+
+
+class TestConfigValidation:
+    def test_defaults(self) -> None:
+        config = PlexAdapterConfig()
+        assert config.enabled is False
+        assert config.poll_interval == 60
+
+    def test_extra_fields_forbidden(self) -> None:
+        with pytest.raises(ValidationError, match="Extra inputs"):
+            _make_config(bogus="nope")
+
+
+# ---------------------------------------------------------------------------
+# Adapter identity & lifecycle
+# ---------------------------------------------------------------------------
+
+
+class TestAdapterLifecycle:
+    def test_name(self) -> None:
+        adapter, _ = _make_adapter()
+        assert adapter.name == "plex"
+
+    @pytest.mark.asyncio
+    async def test_healthy_initially_false(self) -> None:
+        adapter, _ = _make_adapter()
+        assert not await adapter.healthy()
+
+    @pytest.mark.asyncio
+    async def test_stop_sets_flag(self) -> None:
+        adapter, _ = _make_adapter()
+        await adapter.stop()
+        assert adapter._stopping is True
+
+
+# ---------------------------------------------------------------------------
+# Server reachability
+# ---------------------------------------------------------------------------
+
+
+class TestServerReachability:
+    @pytest.mark.asyncio
+    async def test_server_unreachable_emits_event(self) -> None:
+        adapter, queue = _make_adapter()
+        adapter._server_reachable = True
+
+        adapter._handle_unreachable("Connection refused")
+
+        queue.put_nowait.assert_called_once()
+        event = queue.put_nowait.call_args[0][0]
+        assert event.event_type == "plex_server_unreachable"
+        assert event.severity == Severity.ERROR
+        assert event.payload["error"] == "Connection refused"
+
+    @pytest.mark.asyncio
+    async def test_server_recovered_emits_event(self) -> None:
+        adapter, queue = _make_adapter()
+        adapter._server_reachable = False
+
+        adapter._handle_reachable()
+
+        queue.put_nowait.assert_called_once()
+        event = queue.put_nowait.call_args[0][0]
+        assert event.event_type == "plex_server_recovered"
+        assert event.severity == Severity.INFO
+
+    def test_already_reachable_no_event(self) -> None:
+        adapter, queue = _make_adapter()
+        adapter._server_reachable = True
+
+        adapter._handle_reachable()
+        queue.put_nowait.assert_not_called()
+
+    def test_already_unreachable_no_event(self) -> None:
+        adapter, queue = _make_adapter()
+        adapter._server_reachable = False
+
+        adapter._handle_unreachable("still down")
+        queue.put_nowait.assert_not_called()
+
+    def test_first_poll_unreachable_emits(self) -> None:
+        adapter, queue = _make_adapter()
+        # _server_reachable is None (first poll)
+
+        adapter._handle_unreachable("Connection refused")
+
+        queue.put_nowait.assert_called_once()
+        event = queue.put_nowait.call_args[0][0]
+        assert event.event_type == "plex_server_unreachable"
+
+    def test_first_poll_reachable_no_event(self) -> None:
+        adapter, queue = _make_adapter()
+
+        adapter._handle_reachable()
+        queue.put_nowait.assert_not_called()
+
+    def test_dedup_key(self) -> None:
+        adapter, queue = _make_adapter()
+        adapter._server_reachable = True
+
+        adapter._handle_unreachable("error")
+
+        event = queue.put_nowait.call_args[0][0]
+        assert event.metadata.dedup_key == "plex:server:reachable"
+
+    @pytest.mark.asyncio
+    async def test_check_server_success(self) -> None:
+        adapter, _queue = _make_adapter()
+        adapter._server_reachable = False
+
+        mock_resp = _mock_response({}, status=200)
+        mock_session = AsyncMock()
+        mock_session.get = MagicMock(return_value=mock_resp)
+
+        result = await adapter._check_server(mock_session)
+        assert result is True
+
+    @pytest.mark.asyncio
+    async def test_check_server_failure(self) -> None:
+        adapter, _queue = _make_adapter()
+        adapter._server_reachable = True
+
+        mock_resp = _mock_response({}, status=503)
+        mock_session = AsyncMock()
+        mock_session.get = MagicMock(return_value=mock_resp)
+
+        result = await adapter._check_server(mock_session)
+        assert result is False
+
+
+# ---------------------------------------------------------------------------
+# Library polling
+# ---------------------------------------------------------------------------
+
+
+class TestLibraryPolling:
+    @pytest.mark.asyncio
+    async def test_empty_library_emits_event(self) -> None:
+        adapter, queue = _make_adapter()
+
+        mock_session = AsyncMock()
+        mock_session.get = MagicMock(return_value=_mock_response({
+            "MediaContainer": {
+                "Directory": [
+                    {
+                        "key": "1",
+                        "title": "Movies",
+                        "type": "movie",
+                        "count": 0,
+                        "refreshing": False,
+                    },
+                ],
+            },
+        }))
+
+        await adapter._poll_libraries(mock_session)
+
+        queue.put_nowait.assert_called_once()
+        event = queue.put_nowait.call_args[0][0]
+        assert event.event_type == "plex_library_scan_failed"
+        assert event.severity == Severity.WARNING
+        assert event.entity_id == "Movies"
+
+    @pytest.mark.asyncio
+    async def test_scanning_library_no_event(self) -> None:
+        adapter, queue = _make_adapter()
+
+        mock_session = AsyncMock()
+        mock_session.get = MagicMock(return_value=_mock_response({
+            "MediaContainer": {
+                "Directory": [
+                    {
+                        "key": "1",
+                        "title": "Movies",
+                        "type": "movie",
+                        "count": 0,
+                        "refreshing": True,
+                    },
+                ],
+            },
+        }))
+
+        await adapter._poll_libraries(mock_session)
+        queue.put_nowait.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_populated_library_no_event(self) -> None:
+        adapter, queue = _make_adapter()
+
+        mock_session = AsyncMock()
+        mock_session.get = MagicMock(return_value=_mock_response({
+            "MediaContainer": {
+                "Directory": [
+                    {
+                        "key": "1",
+                        "title": "Movies",
+                        "type": "movie",
+                        "count": 500,
+                        "refreshing": False,
+                    },
+                ],
+            },
+        }))
+
+        await adapter._poll_libraries(mock_session)
+        queue.put_nowait.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_library_dedup(self) -> None:
+        adapter, queue = _make_adapter()
+        adapter._library_errors.add("1")
+
+        mock_session = AsyncMock()
+        mock_session.get = MagicMock(return_value=_mock_response({
+            "MediaContainer": {
+                "Directory": [
+                    {"key": "1", "title": "Movies", "count": 0, "refreshing": False},
+                ],
+            },
+        }))
+
+        await adapter._poll_libraries(mock_session)
+        queue.put_nowait.assert_not_called()
+
+
+# ---------------------------------------------------------------------------
+# Known fixes
+# ---------------------------------------------------------------------------
+
+
+class TestKnownFixes:
+    def test_known_fixes_file_exists(self) -> None:
+        from pathlib import Path
+
+        import yaml
+
+        fixes_path = (
+            Path(__file__).parent.parent.parent / "known_fixes" / "plex.yaml"
+        )
+        assert fixes_path.exists()
+
+        with fixes_path.open() as f:
+            data = yaml.safe_load(f)
+
+        assert "fixes" in data
+        fixes = data["fixes"]
+        assert len(fixes) >= 4
+
+        for fix in fixes:
+            assert "id" in fix
+            assert "match" in fix
+            assert "diagnosis" in fix
+            assert "action" in fix
+            assert "risk_tier" in fix
+
+    def test_known_fix_ids_unique(self) -> None:
+        from pathlib import Path
+
+        import yaml
+
+        fixes_path = (
+            Path(__file__).parent.parent.parent / "known_fixes" / "plex.yaml"
+        )
+        with fixes_path.open() as f:
+            data = yaml.safe_load(f)
+
+        ids = [fix["id"] for fix in data["fixes"]]
+        assert len(ids) == len(set(ids))
+
+
+# ---------------------------------------------------------------------------
+# Registry
+# ---------------------------------------------------------------------------
+
+
+class TestRegistry:
+    def test_plex_connector_registered(self) -> None:
+        from oasisagent.db.registry import CONNECTOR_TYPES
+
+        assert "plex" in CONNECTOR_TYPES
+        meta = CONNECTOR_TYPES["plex"]
+        assert meta.model is PlexAdapterConfig
+        assert "token" in meta.secret_fields

--- a/tests/test_ingestion/test_qbittorrent.py
+++ b/tests/test_ingestion/test_qbittorrent.py
@@ -1,0 +1,342 @@
+"""Tests for the qBittorrent polling ingestion adapter."""
+
+from __future__ import annotations
+
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+from pydantic import ValidationError
+
+from oasisagent.config import QBittorrentAdapterConfig
+from oasisagent.ingestion.qbittorrent import QBittorrentAdapter
+from oasisagent.models import Severity
+
+
+def _make_config(**overrides: object) -> QBittorrentAdapterConfig:
+    defaults: dict[str, object] = {
+        "enabled": True,
+        "url": "http://localhost:8080",
+        "username": "admin",
+        "password": "test-password",
+        "poll_interval": 60,
+        "timeout": 10,
+    }
+    defaults.update(overrides)
+    return QBittorrentAdapterConfig(**defaults)  # type: ignore[arg-type]
+
+
+def _mock_queue() -> MagicMock:
+    return MagicMock()
+
+
+def _make_adapter(**overrides: object) -> tuple[QBittorrentAdapter, MagicMock]:
+    config = _make_config(**overrides)
+    queue = _mock_queue()
+    adapter = QBittorrentAdapter(config, queue)
+    return adapter, queue
+
+
+def _mock_response(data: object, status: int = 200) -> AsyncMock:
+    mock = AsyncMock()
+    mock.status = status
+    mock.raise_for_status = MagicMock()
+    mock.json = AsyncMock(return_value=data)
+    mock.__aenter__ = AsyncMock(return_value=mock)
+    mock.__aexit__ = AsyncMock(return_value=False)
+    return mock
+
+
+# ---------------------------------------------------------------------------
+# Config validation
+# ---------------------------------------------------------------------------
+
+
+class TestConfigValidation:
+    def test_defaults(self) -> None:
+        config = QBittorrentAdapterConfig()
+        assert config.enabled is False
+        assert config.username == "admin"
+        assert config.poll_interval == 60
+
+    def test_extra_fields_forbidden(self) -> None:
+        with pytest.raises(ValidationError, match="Extra inputs"):
+            _make_config(bogus="nope")
+
+
+# ---------------------------------------------------------------------------
+# Adapter identity & lifecycle
+# ---------------------------------------------------------------------------
+
+
+class TestAdapterLifecycle:
+    def test_name(self) -> None:
+        adapter, _ = _make_adapter()
+        assert adapter.name == "qbittorrent"
+
+    @pytest.mark.asyncio
+    async def test_healthy_initially_false(self) -> None:
+        adapter, _ = _make_adapter()
+        assert not await adapter.healthy()
+
+    @pytest.mark.asyncio
+    async def test_stop_sets_flag(self) -> None:
+        adapter, _ = _make_adapter()
+        await adapter.stop()
+        assert adapter._stopping is True
+
+
+# ---------------------------------------------------------------------------
+# Transfer info (connectivity)
+# ---------------------------------------------------------------------------
+
+
+class TestTransferInfo:
+    @pytest.mark.asyncio
+    async def test_connection_lost_event(self) -> None:
+        adapter, queue = _make_adapter()
+        adapter._connection_ok = True
+
+        mock_session = AsyncMock()
+        mock_session.get = MagicMock(return_value=_mock_response({
+            "connection_status": "disconnected",
+            "dl_info_speed": 0,
+            "up_info_speed": 0,
+        }))
+
+        await adapter._poll_transfer_info(mock_session)
+
+        queue.put_nowait.assert_called_once()
+        event = queue.put_nowait.call_args[0][0]
+        assert event.event_type == "qbt_connection_lost"
+        assert event.severity == Severity.ERROR
+
+    @pytest.mark.asyncio
+    async def test_connection_recovered_event(self) -> None:
+        adapter, queue = _make_adapter()
+        adapter._connection_ok = False
+
+        mock_session = AsyncMock()
+        mock_session.get = MagicMock(return_value=_mock_response({
+            "connection_status": "connected",
+        }))
+
+        await adapter._poll_transfer_info(mock_session)
+
+        queue.put_nowait.assert_called_once()
+        event = queue.put_nowait.call_args[0][0]
+        assert event.event_type == "qbt_connection_recovered"
+        assert event.severity == Severity.INFO
+
+    @pytest.mark.asyncio
+    async def test_connected_no_event(self) -> None:
+        adapter, queue = _make_adapter()
+        adapter._connection_ok = True
+
+        mock_session = AsyncMock()
+        mock_session.get = MagicMock(return_value=_mock_response({
+            "connection_status": "connected",
+        }))
+
+        await adapter._poll_transfer_info(mock_session)
+        queue.put_nowait.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_first_poll_disconnected_emits(self) -> None:
+        adapter, queue = _make_adapter()
+        # _connection_ok is None (first poll)
+
+        mock_session = AsyncMock()
+        mock_session.get = MagicMock(return_value=_mock_response({
+            "connection_status": "disconnected",
+        }))
+
+        await adapter._poll_transfer_info(mock_session)
+
+        queue.put_nowait.assert_called_once()
+        event = queue.put_nowait.call_args[0][0]
+        assert event.event_type == "qbt_connection_lost"
+
+    @pytest.mark.asyncio
+    async def test_first_poll_connected_no_event(self) -> None:
+        adapter, queue = _make_adapter()
+
+        mock_session = AsyncMock()
+        mock_session.get = MagicMock(return_value=_mock_response({
+            "connection_status": "connected",
+        }))
+
+        await adapter._poll_transfer_info(mock_session)
+        queue.put_nowait.assert_not_called()
+
+
+# ---------------------------------------------------------------------------
+# Errored torrents
+# ---------------------------------------------------------------------------
+
+
+class TestErroredTorrents:
+    @pytest.mark.asyncio
+    async def test_errored_torrent_emits_event(self) -> None:
+        adapter, queue = _make_adapter()
+
+        mock_session = AsyncMock()
+        mock_session.get = MagicMock(return_value=_mock_response([
+            {
+                "hash": "abc123",
+                "name": "Bad Torrent",
+                "state": "error",
+                "size": 1_000_000,
+                "progress": 0.5,
+                "category": "movies",
+            },
+        ]))
+
+        await adapter._poll_errored_torrents(mock_session)
+
+        queue.put_nowait.assert_called_once()
+        event = queue.put_nowait.call_args[0][0]
+        assert event.event_type == "qbt_torrent_error"
+        assert event.severity == Severity.WARNING
+        assert event.entity_id == "Bad Torrent"
+        assert event.payload["hash"] == "abc123"
+
+    @pytest.mark.asyncio
+    async def test_errored_dedup(self) -> None:
+        adapter, queue = _make_adapter()
+        adapter._errored_hashes.add("abc123")
+
+        mock_session = AsyncMock()
+        mock_session.get = MagicMock(return_value=_mock_response([
+            {"hash": "abc123", "name": "Bad", "state": "error"},
+        ]))
+
+        await adapter._poll_errored_torrents(mock_session)
+        queue.put_nowait.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_resolved_error_clears_tracking(self) -> None:
+        adapter, _queue = _make_adapter()
+        adapter._errored_hashes.add("abc123")
+
+        mock_session = AsyncMock()
+        mock_session.get = MagicMock(return_value=_mock_response([]))
+
+        await adapter._poll_errored_torrents(mock_session)
+        assert len(adapter._errored_hashes) == 0
+
+
+# ---------------------------------------------------------------------------
+# Stalled torrents
+# ---------------------------------------------------------------------------
+
+
+class TestStalledTorrents:
+    @pytest.mark.asyncio
+    async def test_stalled_torrent_emits_event(self) -> None:
+        adapter, queue = _make_adapter()
+
+        mock_session = AsyncMock()
+        mock_session.get = MagicMock(return_value=_mock_response([
+            {
+                "hash": "def456",
+                "name": "Stalled Download",
+                "state": "stalledDL",
+                "size": 2_000_000,
+                "progress": 0.1,
+                "num_seeds": 0,
+                "num_leechs": 0,
+            },
+        ]))
+
+        await adapter._poll_stalled_torrents(mock_session)
+
+        queue.put_nowait.assert_called_once()
+        event = queue.put_nowait.call_args[0][0]
+        assert event.event_type == "qbt_torrent_stalled"
+        assert event.severity == Severity.INFO
+        assert event.entity_id == "Stalled Download"
+
+    @pytest.mark.asyncio
+    async def test_stalled_dedup(self) -> None:
+        adapter, queue = _make_adapter()
+        adapter._stalled_hashes.add("def456")
+
+        mock_session = AsyncMock()
+        mock_session.get = MagicMock(return_value=_mock_response([
+            {"hash": "def456", "name": "Stalled", "state": "stalledDL"},
+        ]))
+
+        await adapter._poll_stalled_torrents(mock_session)
+        queue.put_nowait.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_empty_hash_skipped(self) -> None:
+        adapter, queue = _make_adapter()
+
+        mock_session = AsyncMock()
+        mock_session.get = MagicMock(return_value=_mock_response([
+            {"hash": "", "name": "No Hash"},
+        ]))
+
+        await adapter._poll_stalled_torrents(mock_session)
+        queue.put_nowait.assert_not_called()
+
+
+# ---------------------------------------------------------------------------
+# Known fixes
+# ---------------------------------------------------------------------------
+
+
+class TestKnownFixes:
+    def test_known_fixes_file_exists(self) -> None:
+        from pathlib import Path
+
+        import yaml
+
+        fixes_path = (
+            Path(__file__).parent.parent.parent / "known_fixes" / "qbittorrent.yaml"
+        )
+        assert fixes_path.exists()
+
+        with fixes_path.open() as f:
+            data = yaml.safe_load(f)
+
+        assert "fixes" in data
+        fixes = data["fixes"]
+        assert len(fixes) >= 3
+
+        for fix in fixes:
+            assert "id" in fix
+            assert "match" in fix
+            assert "diagnosis" in fix
+            assert "action" in fix
+            assert "risk_tier" in fix
+
+    def test_known_fix_ids_unique(self) -> None:
+        from pathlib import Path
+
+        import yaml
+
+        fixes_path = (
+            Path(__file__).parent.parent.parent / "known_fixes" / "qbittorrent.yaml"
+        )
+        with fixes_path.open() as f:
+            data = yaml.safe_load(f)
+
+        ids = [fix["id"] for fix in data["fixes"]]
+        assert len(ids) == len(set(ids))
+
+
+# ---------------------------------------------------------------------------
+# Registry
+# ---------------------------------------------------------------------------
+
+
+class TestRegistry:
+    def test_qbittorrent_connector_registered(self) -> None:
+        from oasisagent.db.registry import CONNECTOR_TYPES
+
+        assert "qbittorrent" in CONNECTOR_TYPES
+        meta = CONNECTOR_TYPES["qbittorrent"]
+        assert meta.model is QBittorrentAdapterConfig
+        assert "password" in meta.secret_fields

--- a/tests/test_ingestion/test_servarr.py
+++ b/tests/test_ingestion/test_servarr.py
@@ -1,0 +1,459 @@
+"""Tests for the Servarr polling ingestion adapter."""
+
+from __future__ import annotations
+
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+from pydantic import ValidationError
+
+from oasisagent.config import ServarrAdapterConfig
+from oasisagent.ingestion.servarr import _API_VERSION, ServarrAdapter
+from oasisagent.models import Severity
+
+
+def _make_config(**overrides: object) -> ServarrAdapterConfig:
+    defaults: dict[str, object] = {
+        "enabled": True,
+        "url": "http://localhost:8989",
+        "api_key": "test-api-key",
+        "app_type": "sonarr",
+        "poll_interval": 60,
+        "timeout": 10,
+    }
+    defaults.update(overrides)
+    return ServarrAdapterConfig(**defaults)  # type: ignore[arg-type]
+
+
+def _mock_queue() -> MagicMock:
+    return MagicMock()
+
+
+def _make_adapter(**overrides: object) -> tuple[ServarrAdapter, MagicMock]:
+    config = _make_config(**overrides)
+    queue = _mock_queue()
+    adapter = ServarrAdapter(config, queue)
+    return adapter, queue
+
+
+# ---------------------------------------------------------------------------
+# Config validation
+# ---------------------------------------------------------------------------
+
+
+class TestConfigValidation:
+    def test_defaults(self) -> None:
+        config = ServarrAdapterConfig()
+        assert config.enabled is False
+        assert config.app_type == "sonarr"
+        assert config.poll_interval == 60
+
+    def test_valid_app_types(self) -> None:
+        for app_type in ("sonarr", "radarr", "prowlarr", "bazarr"):
+            config = _make_config(app_type=app_type)
+            assert config.app_type == app_type
+
+    def test_invalid_app_type(self) -> None:
+        with pytest.raises(ValidationError):
+            _make_config(app_type="lidarr")
+
+    def test_extra_fields_forbidden(self) -> None:
+        with pytest.raises(ValidationError, match="Extra inputs"):
+            _make_config(bogus="nope")
+
+
+# ---------------------------------------------------------------------------
+# Adapter identity & lifecycle
+# ---------------------------------------------------------------------------
+
+
+class TestAdapterLifecycle:
+    def test_name_includes_app_type(self) -> None:
+        adapter, _ = _make_adapter(app_type="sonarr")
+        assert adapter.name == "servarr_sonarr"
+
+        adapter2, _ = _make_adapter(app_type="radarr")
+        assert adapter2.name == "servarr_radarr"
+
+    @pytest.mark.asyncio
+    async def test_healthy_initially_false(self) -> None:
+        adapter, _ = _make_adapter()
+        assert not await adapter.healthy()
+
+    @pytest.mark.asyncio
+    async def test_stop_sets_flag(self) -> None:
+        adapter, _ = _make_adapter()
+        await adapter.stop()
+        assert adapter._stopping is True
+
+    def test_api_version_sonarr(self) -> None:
+        adapter, _ = _make_adapter(app_type="sonarr")
+        assert adapter._api_version == "v3"
+
+    def test_api_version_prowlarr(self) -> None:
+        adapter, _ = _make_adapter(app_type="prowlarr")
+        assert adapter._api_version == "v1"
+
+    def test_api_version_bazarr(self) -> None:
+        adapter, _ = _make_adapter(app_type="bazarr")
+        assert adapter._api_version == "v1"
+
+
+# ---------------------------------------------------------------------------
+# API version mapping
+# ---------------------------------------------------------------------------
+
+
+class TestApiVersionMapping:
+    def test_all_app_types_have_version(self) -> None:
+        for app_type in ("sonarr", "radarr", "prowlarr", "bazarr"):
+            assert app_type in _API_VERSION
+
+
+# ---------------------------------------------------------------------------
+# Health polling
+# ---------------------------------------------------------------------------
+
+
+class TestHealthPolling:
+    @pytest.mark.asyncio
+    async def test_health_issue_emits_event(self) -> None:
+        adapter, queue = _make_adapter()
+
+        mock_resp = AsyncMock()
+        mock_resp.status = 200
+        mock_resp.raise_for_status = MagicMock()
+        mock_resp.json = AsyncMock(return_value=[
+            {
+                "source": "IndexerStatusCheck",
+                "type": "warning",
+                "message": "Indexer NZBgeek is unavailable",
+                "wikiUrl": "https://wiki.servarr.com/sonarr/system#indexers",
+            },
+        ])
+        mock_resp.__aenter__ = AsyncMock(return_value=mock_resp)
+        mock_resp.__aexit__ = AsyncMock(return_value=False)
+
+        mock_session = AsyncMock()
+        mock_session.get = MagicMock(return_value=mock_resp)
+
+        await adapter._poll_health(mock_session)
+
+        queue.put_nowait.assert_called_once()
+        event = queue.put_nowait.call_args[0][0]
+        assert event.event_type == "servarr_health_issue"
+        assert event.severity == Severity.WARNING
+        assert event.payload["app_type"] == "sonarr"
+        assert "Indexer NZBgeek" in event.payload["message"]
+
+    @pytest.mark.asyncio
+    async def test_health_error_type_severity(self) -> None:
+        adapter, queue = _make_adapter()
+
+        mock_resp = AsyncMock()
+        mock_resp.status = 200
+        mock_resp.raise_for_status = MagicMock()
+        mock_resp.json = AsyncMock(return_value=[
+            {
+                "source": "DiskSpaceCheck",
+                "type": "error",
+                "message": "Disk space critically low",
+                "wikiUrl": "",
+            },
+        ])
+        mock_resp.__aenter__ = AsyncMock(return_value=mock_resp)
+        mock_resp.__aexit__ = AsyncMock(return_value=False)
+
+        mock_session = AsyncMock()
+        mock_session.get = MagicMock(return_value=mock_resp)
+
+        await adapter._poll_health(mock_session)
+
+        event = queue.put_nowait.call_args[0][0]
+        assert event.severity == Severity.ERROR
+
+    @pytest.mark.asyncio
+    async def test_health_dedup_same_issue(self) -> None:
+        """Same health issue on second poll should not emit again."""
+        adapter, queue = _make_adapter()
+        adapter._health_issues.add("IndexerStatusCheck:Indexer down")
+
+        mock_resp = AsyncMock()
+        mock_resp.status = 200
+        mock_resp.raise_for_status = MagicMock()
+        mock_resp.json = AsyncMock(return_value=[
+            {
+                "source": "IndexerStatusCheck",
+                "type": "warning",
+                "message": "Indexer down",
+            },
+        ])
+        mock_resp.__aenter__ = AsyncMock(return_value=mock_resp)
+        mock_resp.__aexit__ = AsyncMock(return_value=False)
+
+        mock_session = AsyncMock()
+        mock_session.get = MagicMock(return_value=mock_resp)
+
+        await adapter._poll_health(mock_session)
+        queue.put_nowait.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_health_clears_resolved_issues(self) -> None:
+        """Resolved issues should be removed from tracking."""
+        adapter, _queue = _make_adapter()
+        adapter._health_issues.add("OldIssue:gone now")
+
+        mock_resp = AsyncMock()
+        mock_resp.status = 200
+        mock_resp.raise_for_status = MagicMock()
+        mock_resp.json = AsyncMock(return_value=[])
+        mock_resp.__aenter__ = AsyncMock(return_value=mock_resp)
+        mock_resp.__aexit__ = AsyncMock(return_value=False)
+
+        mock_session = AsyncMock()
+        mock_session.get = MagicMock(return_value=mock_resp)
+
+        await adapter._poll_health(mock_session)
+        assert len(adapter._health_issues) == 0
+
+
+# ---------------------------------------------------------------------------
+# Queue polling
+# ---------------------------------------------------------------------------
+
+
+class TestQueuePolling:
+    @pytest.mark.asyncio
+    async def test_failed_download_emits_event(self) -> None:
+        adapter, queue = _make_adapter()
+
+        mock_resp = AsyncMock()
+        mock_resp.status = 200
+        mock_resp.raise_for_status = MagicMock()
+        mock_resp.json = AsyncMock(return_value={
+            "records": [
+                {
+                    "id": 42,
+                    "title": "Show S01E01",
+                    "status": "failed",
+                    "trackedDownloadStatus": "warning",
+                    "statusMessages": [{"title": "Download failed"}],
+                },
+            ],
+        })
+        mock_resp.__aenter__ = AsyncMock(return_value=mock_resp)
+        mock_resp.__aexit__ = AsyncMock(return_value=False)
+
+        mock_session = AsyncMock()
+        mock_session.get = MagicMock(return_value=mock_resp)
+
+        await adapter._poll_queue(mock_session)
+
+        queue.put_nowait.assert_called_once()
+        event = queue.put_nowait.call_args[0][0]
+        assert event.event_type == "servarr_queue_failed"
+        assert event.severity == Severity.ERROR
+        assert event.entity_id == "Show S01E01"
+
+    @pytest.mark.asyncio
+    async def test_stuck_download_emits_event(self) -> None:
+        from datetime import UTC, datetime, timedelta
+
+        adapter, queue = _make_adapter()
+
+        three_hours_ago = (
+            datetime.now(tz=UTC) - timedelta(hours=3)
+        ).isoformat()
+
+        mock_resp = AsyncMock()
+        mock_resp.status = 200
+        mock_resp.raise_for_status = MagicMock()
+        mock_resp.json = AsyncMock(return_value={
+            "records": [
+                {
+                    "id": 99,
+                    "title": "Movie 2026",
+                    "status": "downloading",
+                    "trackedDownloadStatus": "ok",
+                    "added": three_hours_ago,
+                },
+            ],
+        })
+        mock_resp.__aenter__ = AsyncMock(return_value=mock_resp)
+        mock_resp.__aexit__ = AsyncMock(return_value=False)
+
+        mock_session = AsyncMock()
+        mock_session.get = MagicMock(return_value=mock_resp)
+
+        await adapter._poll_queue(mock_session)
+
+        queue.put_nowait.assert_called_once()
+        event = queue.put_nowait.call_args[0][0]
+        assert event.event_type == "servarr_queue_stuck"
+        assert event.severity == Severity.WARNING
+
+    @pytest.mark.asyncio
+    async def test_recent_download_no_stuck_event(self) -> None:
+        from datetime import UTC, datetime, timedelta
+
+        adapter, queue = _make_adapter()
+
+        ten_minutes_ago = (
+            datetime.now(tz=UTC) - timedelta(minutes=10)
+        ).isoformat()
+
+        mock_resp = AsyncMock()
+        mock_resp.status = 200
+        mock_resp.raise_for_status = MagicMock()
+        mock_resp.json = AsyncMock(return_value={
+            "records": [
+                {
+                    "id": 100,
+                    "title": "New Show",
+                    "status": "downloading",
+                    "trackedDownloadStatus": "ok",
+                    "added": ten_minutes_ago,
+                },
+            ],
+        })
+        mock_resp.__aenter__ = AsyncMock(return_value=mock_resp)
+        mock_resp.__aexit__ = AsyncMock(return_value=False)
+
+        mock_session = AsyncMock()
+        mock_session.get = MagicMock(return_value=mock_resp)
+
+        await adapter._poll_queue(mock_session)
+        queue.put_nowait.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_queue_dedup_same_failed(self) -> None:
+        """Same failed download ID should not emit twice."""
+        adapter, queue = _make_adapter()
+        adapter._failed_ids.add("42")
+
+        mock_resp = AsyncMock()
+        mock_resp.status = 200
+        mock_resp.raise_for_status = MagicMock()
+        mock_resp.json = AsyncMock(return_value={
+            "records": [
+                {
+                    "id": 42,
+                    "title": "Show",
+                    "status": "failed",
+                    "trackedDownloadStatus": "warning",
+                },
+            ],
+        })
+        mock_resp.__aenter__ = AsyncMock(return_value=mock_resp)
+        mock_resp.__aexit__ = AsyncMock(return_value=False)
+
+        mock_session = AsyncMock()
+        mock_session.get = MagicMock(return_value=mock_resp)
+
+        await adapter._poll_queue(mock_session)
+        queue.put_nowait.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_empty_queue_no_event(self) -> None:
+        adapter, queue = _make_adapter()
+
+        mock_resp = AsyncMock()
+        mock_resp.status = 200
+        mock_resp.raise_for_status = MagicMock()
+        mock_resp.json = AsyncMock(return_value={"records": []})
+        mock_resp.__aenter__ = AsyncMock(return_value=mock_resp)
+        mock_resp.__aexit__ = AsyncMock(return_value=False)
+
+        mock_session = AsyncMock()
+        mock_session.get = MagicMock(return_value=mock_resp)
+
+        await adapter._poll_queue(mock_session)
+        queue.put_nowait.assert_not_called()
+
+
+# ---------------------------------------------------------------------------
+# Known fixes
+# ---------------------------------------------------------------------------
+
+
+class TestKnownFixes:
+    def test_known_fixes_file_exists(self) -> None:
+        from pathlib import Path
+
+        import yaml
+
+        fixes_path = (
+            Path(__file__).parent.parent.parent / "known_fixes" / "servarr.yaml"
+        )
+        assert fixes_path.exists()
+
+        with fixes_path.open() as f:
+            data = yaml.safe_load(f)
+
+        assert "fixes" in data
+        fixes = data["fixes"]
+        assert len(fixes) >= 3
+
+        for fix in fixes:
+            assert "id" in fix
+            assert "match" in fix
+            assert "diagnosis" in fix
+            assert "action" in fix
+            assert "risk_tier" in fix
+
+    def test_known_fix_ids_unique(self) -> None:
+        from pathlib import Path
+
+        import yaml
+
+        fixes_path = (
+            Path(__file__).parent.parent.parent / "known_fixes" / "servarr.yaml"
+        )
+        with fixes_path.open() as f:
+            data = yaml.safe_load(f)
+
+        ids = [fix["id"] for fix in data["fixes"]]
+        assert len(ids) == len(set(ids))
+
+
+# ---------------------------------------------------------------------------
+# Registry
+# ---------------------------------------------------------------------------
+
+
+class TestRegistry:
+    def test_servarr_connector_registered(self) -> None:
+        from oasisagent.db.registry import CONNECTOR_TYPES
+
+        assert "servarr" in CONNECTOR_TYPES
+        meta = CONNECTOR_TYPES["servarr"]
+        assert meta.model is ServarrAdapterConfig
+        assert "api_key" in meta.secret_fields
+
+
+# ---------------------------------------------------------------------------
+# Enqueue error handling
+# ---------------------------------------------------------------------------
+
+
+class TestEnqueueErrorHandling:
+    def test_enqueue_failure_logged(self) -> None:
+        adapter, queue = _make_adapter()
+        queue.put_nowait.side_effect = RuntimeError("queue full")
+
+        from datetime import UTC, datetime
+
+        from oasisagent.models import Event, EventMetadata
+
+        event = Event(
+            source="servarr_sonarr",
+            system="sonarr",
+            event_type="test",
+            entity_id="test",
+            severity=Severity.INFO,
+            timestamp=datetime.now(tz=UTC),
+            payload={},
+            metadata=EventMetadata(dedup_key="test"),
+        )
+
+        adapter._enqueue(event)  # should not raise

--- a/tests/test_ingestion/test_tautulli.py
+++ b/tests/test_ingestion/test_tautulli.py
@@ -1,0 +1,362 @@
+"""Tests for the Tautulli polling ingestion adapter."""
+
+from __future__ import annotations
+
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+from pydantic import ValidationError
+
+from oasisagent.config import TautulliAdapterConfig
+from oasisagent.ingestion.tautulli import TautulliAdapter
+from oasisagent.models import Severity
+
+
+def _make_config(**overrides: object) -> TautulliAdapterConfig:
+    defaults: dict[str, object] = {
+        "enabled": True,
+        "url": "http://localhost:8181",
+        "api_key": "test-tautulli-key",
+        "poll_interval": 60,
+        "timeout": 10,
+        "bandwidth_threshold_kbps": 100_000,
+    }
+    defaults.update(overrides)
+    return TautulliAdapterConfig(**defaults)  # type: ignore[arg-type]
+
+
+def _mock_queue() -> MagicMock:
+    return MagicMock()
+
+
+def _make_adapter(**overrides: object) -> tuple[TautulliAdapter, MagicMock]:
+    config = _make_config(**overrides)
+    queue = _mock_queue()
+    adapter = TautulliAdapter(config, queue)
+    return adapter, queue
+
+
+def _mock_response(data: object, status: int = 200) -> AsyncMock:
+    mock = AsyncMock()
+    mock.status = status
+    mock.raise_for_status = MagicMock()
+    mock.json = AsyncMock(return_value=data)
+    mock.__aenter__ = AsyncMock(return_value=mock)
+    mock.__aexit__ = AsyncMock(return_value=False)
+    return mock
+
+
+# ---------------------------------------------------------------------------
+# Config validation
+# ---------------------------------------------------------------------------
+
+
+class TestConfigValidation:
+    def test_defaults(self) -> None:
+        config = TautulliAdapterConfig()
+        assert config.enabled is False
+        assert config.bandwidth_threshold_kbps == 100_000
+
+    def test_extra_fields_forbidden(self) -> None:
+        with pytest.raises(ValidationError, match="Extra inputs"):
+            _make_config(bogus="nope")
+
+
+# ---------------------------------------------------------------------------
+# Adapter identity & lifecycle
+# ---------------------------------------------------------------------------
+
+
+class TestAdapterLifecycle:
+    def test_name(self) -> None:
+        adapter, _ = _make_adapter()
+        assert adapter.name == "tautulli"
+
+    @pytest.mark.asyncio
+    async def test_healthy_initially_false(self) -> None:
+        adapter, _ = _make_adapter()
+        assert not await adapter.healthy()
+
+    @pytest.mark.asyncio
+    async def test_stop_sets_flag(self) -> None:
+        adapter, _ = _make_adapter()
+        await adapter.stop()
+        assert adapter._stopping is True
+
+    def test_api_url_format(self) -> None:
+        adapter, _ = _make_adapter()
+        url = adapter._api_url("server_status")
+        assert "apikey=test-tautulli-key" in url
+        assert "cmd=server_status" in url
+
+
+# ---------------------------------------------------------------------------
+# Server status polling
+# ---------------------------------------------------------------------------
+
+
+class TestServerStatus:
+    @pytest.mark.asyncio
+    async def test_plex_down_emits_event(self) -> None:
+        adapter, queue = _make_adapter()
+        adapter._plex_connected = True
+
+        mock_session = AsyncMock()
+        mock_session.get = MagicMock(return_value=_mock_response({
+            "response": {
+                "result": "success",
+                "data": {
+                    "connected": False,
+                    "pms_version": "1.40.0",
+                    "pms_platform": "Linux",
+                },
+            },
+        }))
+
+        await adapter._poll_server_status(mock_session)
+
+        queue.put_nowait.assert_called_once()
+        event = queue.put_nowait.call_args[0][0]
+        assert event.event_type == "tautulli_plex_down"
+        assert event.severity == Severity.ERROR
+        assert event.payload["plex_version"] == "1.40.0"
+
+    @pytest.mark.asyncio
+    async def test_plex_recovered_emits_event(self) -> None:
+        adapter, queue = _make_adapter()
+        adapter._plex_connected = False
+
+        mock_session = AsyncMock()
+        mock_session.get = MagicMock(return_value=_mock_response({
+            "response": {
+                "result": "success",
+                "data": {
+                    "connected": True,
+                    "pms_version": "1.40.0",
+                },
+            },
+        }))
+
+        await adapter._poll_server_status(mock_session)
+
+        queue.put_nowait.assert_called_once()
+        event = queue.put_nowait.call_args[0][0]
+        assert event.event_type == "tautulli_plex_recovered"
+        assert event.severity == Severity.INFO
+
+    @pytest.mark.asyncio
+    async def test_plex_already_connected_no_event(self) -> None:
+        adapter, queue = _make_adapter()
+        adapter._plex_connected = True
+
+        mock_session = AsyncMock()
+        mock_session.get = MagicMock(return_value=_mock_response({
+            "response": {
+                "result": "success",
+                "data": {"connected": True},
+            },
+        }))
+
+        await adapter._poll_server_status(mock_session)
+        queue.put_nowait.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_first_poll_disconnected_emits(self) -> None:
+        adapter, queue = _make_adapter()
+        # _plex_connected is None
+
+        mock_session = AsyncMock()
+        mock_session.get = MagicMock(return_value=_mock_response({
+            "response": {
+                "result": "success",
+                "data": {
+                    "connected": False,
+                    "pms_version": "",
+                    "pms_platform": "",
+                },
+            },
+        }))
+
+        await adapter._poll_server_status(mock_session)
+
+        queue.put_nowait.assert_called_once()
+        event = queue.put_nowait.call_args[0][0]
+        assert event.event_type == "tautulli_plex_down"
+
+    @pytest.mark.asyncio
+    async def test_first_poll_connected_no_event(self) -> None:
+        adapter, queue = _make_adapter()
+
+        mock_session = AsyncMock()
+        mock_session.get = MagicMock(return_value=_mock_response({
+            "response": {
+                "result": "success",
+                "data": {"connected": True},
+            },
+        }))
+
+        await adapter._poll_server_status(mock_session)
+        queue.put_nowait.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_error_result_skipped(self) -> None:
+        adapter, queue = _make_adapter()
+
+        mock_session = AsyncMock()
+        mock_session.get = MagicMock(return_value=_mock_response({
+            "response": {
+                "result": "error",
+                "data": {},
+            },
+        }))
+
+        await adapter._poll_server_status(mock_session)
+        queue.put_nowait.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_dedup_key(self) -> None:
+        adapter, queue = _make_adapter()
+        adapter._plex_connected = True
+
+        mock_session = AsyncMock()
+        mock_session.get = MagicMock(return_value=_mock_response({
+            "response": {
+                "result": "success",
+                "data": {"connected": False, "pms_version": "", "pms_platform": ""},
+            },
+        }))
+
+        await adapter._poll_server_status(mock_session)
+
+        event = queue.put_nowait.call_args[0][0]
+        assert event.metadata.dedup_key == "tautulli:plex:status"
+
+
+# ---------------------------------------------------------------------------
+# Activity / bandwidth polling
+# ---------------------------------------------------------------------------
+
+
+class TestBandwidthPolling:
+    @pytest.mark.asyncio
+    async def test_high_bandwidth_emits_event(self) -> None:
+        adapter, queue = _make_adapter(bandwidth_threshold_kbps=50_000)
+
+        mock_session = AsyncMock()
+        mock_session.get = MagicMock(return_value=_mock_response({
+            "response": {
+                "result": "success",
+                "data": {
+                    "total_bandwidth": 60_000,
+                    "stream_count": 5,
+                    "stream_count_direct_play": 3,
+                    "stream_count_transcode": 2,
+                },
+            },
+        }))
+
+        await adapter._poll_activity(mock_session)
+
+        queue.put_nowait.assert_called_once()
+        event = queue.put_nowait.call_args[0][0]
+        assert event.event_type == "tautulli_high_bandwidth"
+        assert event.severity == Severity.WARNING
+        assert event.payload["total_bandwidth_kbps"] == 60_000
+        assert event.payload["stream_count"] == 5
+
+    @pytest.mark.asyncio
+    async def test_bandwidth_recovered_emits_event(self) -> None:
+        adapter, queue = _make_adapter(bandwidth_threshold_kbps=50_000)
+        adapter._bandwidth_high = True
+
+        mock_session = AsyncMock()
+        mock_session.get = MagicMock(return_value=_mock_response({
+            "response": {
+                "result": "success",
+                "data": {
+                    "total_bandwidth": 30_000,
+                    "stream_count": 2,
+                },
+            },
+        }))
+
+        await adapter._poll_activity(mock_session)
+
+        queue.put_nowait.assert_called_once()
+        event = queue.put_nowait.call_args[0][0]
+        assert event.event_type == "tautulli_bandwidth_recovered"
+        assert event.severity == Severity.INFO
+
+    @pytest.mark.asyncio
+    async def test_normal_bandwidth_no_event(self) -> None:
+        adapter, queue = _make_adapter(bandwidth_threshold_kbps=100_000)
+
+        mock_session = AsyncMock()
+        mock_session.get = MagicMock(return_value=_mock_response({
+            "response": {
+                "result": "success",
+                "data": {
+                    "total_bandwidth": 50_000,
+                    "stream_count": 2,
+                },
+            },
+        }))
+
+        await adapter._poll_activity(mock_session)
+        queue.put_nowait.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_bandwidth_already_high_no_event(self) -> None:
+        adapter, queue = _make_adapter(bandwidth_threshold_kbps=50_000)
+        adapter._bandwidth_high = True
+
+        mock_session = AsyncMock()
+        mock_session.get = MagicMock(return_value=_mock_response({
+            "response": {
+                "result": "success",
+                "data": {
+                    "total_bandwidth": 60_000,
+                    "stream_count": 5,
+                },
+            },
+        }))
+
+        await adapter._poll_activity(mock_session)
+        queue.put_nowait.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_bandwidth_dedup_key(self) -> None:
+        adapter, queue = _make_adapter(bandwidth_threshold_kbps=1)
+
+        mock_session = AsyncMock()
+        mock_session.get = MagicMock(return_value=_mock_response({
+            "response": {
+                "result": "success",
+                "data": {
+                    "total_bandwidth": 100,
+                    "stream_count": 1,
+                    "stream_count_direct_play": 1,
+                    "stream_count_transcode": 0,
+                },
+            },
+        }))
+
+        await adapter._poll_activity(mock_session)
+
+        event = queue.put_nowait.call_args[0][0]
+        assert event.metadata.dedup_key == "tautulli:bandwidth"
+
+
+# ---------------------------------------------------------------------------
+# Registry
+# ---------------------------------------------------------------------------
+
+
+class TestRegistry:
+    def test_tautulli_connector_registered(self) -> None:
+        from oasisagent.db.registry import CONNECTOR_TYPES
+
+        assert "tautulli" in CONNECTOR_TYPES
+        meta = CONNECTOR_TYPES["tautulli"]
+        assert meta.model is TautulliAdapterConfig
+        assert "api_key" in meta.secret_fields

--- a/tests/test_ingestion/test_tdarr.py
+++ b/tests/test_ingestion/test_tdarr.py
@@ -1,0 +1,284 @@
+"""Tests for the Tdarr polling ingestion adapter."""
+
+from __future__ import annotations
+
+from unittest.mock import MagicMock
+
+import pytest
+from pydantic import ValidationError
+
+from oasisagent.config import TdarrAdapterConfig
+from oasisagent.ingestion.tdarr import _STUCK_POLL_THRESHOLD, TdarrAdapter
+from oasisagent.models import Severity
+
+
+def _make_config(**overrides: object) -> TdarrAdapterConfig:
+    defaults: dict[str, object] = {
+        "enabled": True,
+        "url": "http://localhost:8265",
+        "poll_interval": 60,
+        "timeout": 10,
+    }
+    defaults.update(overrides)
+    return TdarrAdapterConfig(**defaults)  # type: ignore[arg-type]
+
+
+def _mock_queue() -> MagicMock:
+    return MagicMock()
+
+
+def _make_adapter(**overrides: object) -> tuple[TdarrAdapter, MagicMock]:
+    config = _make_config(**overrides)
+    queue = _mock_queue()
+    adapter = TdarrAdapter(config, queue)
+    return adapter, queue
+
+
+# ---------------------------------------------------------------------------
+# Config validation
+# ---------------------------------------------------------------------------
+
+
+class TestConfigValidation:
+    def test_defaults(self) -> None:
+        config = TdarrAdapterConfig()
+        assert config.enabled is False
+        assert config.poll_interval == 60
+
+    def test_extra_fields_forbidden(self) -> None:
+        with pytest.raises(ValidationError, match="Extra inputs"):
+            _make_config(bogus="nope")
+
+
+# ---------------------------------------------------------------------------
+# Adapter identity & lifecycle
+# ---------------------------------------------------------------------------
+
+
+class TestAdapterLifecycle:
+    def test_name(self) -> None:
+        adapter, _ = _make_adapter()
+        assert adapter.name == "tdarr"
+
+    @pytest.mark.asyncio
+    async def test_healthy_initially_false(self) -> None:
+        adapter, _ = _make_adapter()
+        assert not await adapter.healthy()
+
+    @pytest.mark.asyncio
+    async def test_stop_sets_flag(self) -> None:
+        adapter, _ = _make_adapter()
+        await adapter.stop()
+        assert adapter._stopping is True
+
+
+# ---------------------------------------------------------------------------
+# Worker status
+# ---------------------------------------------------------------------------
+
+
+class TestWorkerStatus:
+    def test_worker_goes_offline(self) -> None:
+        adapter, queue = _make_adapter()
+        adapter._worker_states["worker1"] = True
+
+        adapter._check_workers({
+            "workers": {
+                "worker1": None,
+            },
+        })
+
+        queue.put_nowait.assert_called_once()
+        event = queue.put_nowait.call_args[0][0]
+        assert event.event_type == "tdarr_worker_failed"
+        assert event.severity == Severity.WARNING
+        assert event.entity_id == "worker1"
+
+    def test_worker_recovered(self) -> None:
+        adapter, queue = _make_adapter()
+        adapter._worker_states["worker1"] = False
+
+        adapter._check_workers({
+            "workers": {
+                "worker1": {"idle": True, "workerType": "transcode"},
+            },
+        })
+
+        queue.put_nowait.assert_called_once()
+        event = queue.put_nowait.call_args[0][0]
+        assert event.event_type == "tdarr_worker_recovered"
+        assert event.severity == Severity.INFO
+
+    def test_worker_still_online_no_event(self) -> None:
+        adapter, queue = _make_adapter()
+        adapter._worker_states["worker1"] = True
+
+        adapter._check_workers({
+            "workers": {
+                "worker1": {"idle": True, "workerType": "transcode"},
+            },
+        })
+
+        queue.put_nowait.assert_not_called()
+
+    def test_first_poll_offline_emits(self) -> None:
+        adapter, queue = _make_adapter()
+
+        adapter._check_workers({
+            "workers": {
+                "worker1": None,
+            },
+        })
+
+        queue.put_nowait.assert_called_once()
+        event = queue.put_nowait.call_args[0][0]
+        assert event.event_type == "tdarr_worker_failed"
+
+    def test_first_poll_online_no_event(self) -> None:
+        adapter, queue = _make_adapter()
+
+        adapter._check_workers({
+            "workers": {
+                "worker1": {"idle": True, "workerType": "transcode"},
+            },
+        })
+
+        queue.put_nowait.assert_not_called()
+
+    def test_worker_dedup_key(self) -> None:
+        adapter, queue = _make_adapter()
+        adapter._worker_states["worker1"] = True
+
+        adapter._check_workers({"workers": {"worker1": None}})
+
+        event = queue.put_nowait.call_args[0][0]
+        assert event.metadata.dedup_key == "tdarr:worker:worker1"
+
+
+# ---------------------------------------------------------------------------
+# Queue stuck detection
+# ---------------------------------------------------------------------------
+
+
+class TestQueueStuck:
+    def test_queue_stuck_after_threshold_polls(self) -> None:
+        adapter, queue = _make_adapter()
+        adapter._last_queue_processed = 10
+
+        # Simulate _STUCK_POLL_THRESHOLD polls with no progress
+        for _i in range(_STUCK_POLL_THRESHOLD):
+            queue.reset_mock()
+            adapter._check_queue({
+                "queueCount": 5,
+                "processedCount": 10,
+            })
+
+        # Should have emitted on the threshold-th poll
+        queue.put_nowait.assert_called_once()
+        event = queue.put_nowait.call_args[0][0]
+        assert event.event_type == "tdarr_queue_stuck"
+        assert event.severity == Severity.WARNING
+
+    def test_queue_progress_resets_counter(self) -> None:
+        adapter, _queue = _make_adapter()
+        adapter._last_queue_processed = 10
+        adapter._stall_counter = 2  # almost stuck
+
+        adapter._check_queue({
+            "queueCount": 5,
+            "processedCount": 12,  # progress made
+        })
+
+        assert adapter._stall_counter == 0
+
+    def test_queue_empty_no_stuck(self) -> None:
+        adapter, queue = _make_adapter()
+        adapter._last_queue_processed = 10
+        adapter._stall_counter = 5
+
+        adapter._check_queue({
+            "queueCount": 0,
+            "processedCount": 10,
+        })
+
+        assert adapter._stall_counter == 0
+        queue.put_nowait.assert_not_called()
+
+    def test_queue_stuck_only_emits_once(self) -> None:
+        adapter, queue = _make_adapter()
+        adapter._last_queue_processed = 10
+        adapter._queue_stuck = True
+        adapter._stall_counter = _STUCK_POLL_THRESHOLD + 1
+
+        adapter._check_queue({
+            "queueCount": 5,
+            "processedCount": 10,
+        })
+
+        queue.put_nowait.assert_not_called()
+
+    def test_queue_recovered_after_stuck(self) -> None:
+        adapter, queue = _make_adapter()
+        adapter._last_queue_processed = 10
+        adapter._queue_stuck = True
+
+        adapter._check_queue({
+            "queueCount": 5,
+            "processedCount": 15,  # progress made
+        })
+
+        queue.put_nowait.assert_called_once()
+        event = queue.put_nowait.call_args[0][0]
+        assert event.event_type == "tdarr_queue_recovered"
+        assert event.severity == Severity.INFO
+
+    def test_queue_stuck_dedup_key(self) -> None:
+        adapter, queue = _make_adapter()
+        adapter._last_queue_processed = 10
+        adapter._stall_counter = _STUCK_POLL_THRESHOLD - 1
+
+        adapter._check_queue({
+            "queueCount": 5,
+            "processedCount": 10,
+        })
+
+        event = queue.put_nowait.call_args[0][0]
+        assert event.metadata.dedup_key == "tdarr:queue:stuck"
+
+
+# ---------------------------------------------------------------------------
+# Known fixes (in plex.yaml)
+# ---------------------------------------------------------------------------
+
+
+class TestKnownFixes:
+    def test_tdarr_worker_fix_in_plex_yaml(self) -> None:
+        from pathlib import Path
+
+        import yaml
+
+        fixes_path = (
+            Path(__file__).parent.parent.parent / "known_fixes" / "plex.yaml"
+        )
+        assert fixes_path.exists()
+
+        with fixes_path.open() as f:
+            data = yaml.safe_load(f)
+
+        fix_ids = {fix["id"] for fix in data["fixes"]}
+        assert "tdarr-worker-failed" in fix_ids
+
+
+# ---------------------------------------------------------------------------
+# Registry
+# ---------------------------------------------------------------------------
+
+
+class TestRegistry:
+    def test_tdarr_connector_registered(self) -> None:
+        from oasisagent.db.registry import CONNECTOR_TYPES
+
+        assert "tdarr" in CONNECTOR_TYPES
+        meta = CONNECTOR_TYPES["tdarr"]
+        assert meta.model is TdarrAdapterConfig
+        assert len(meta.secret_fields) == 0  # no secrets


### PR DESCRIPTION
## Summary

- **ServarrAdapter** (`oasisagent/ingestion/servarr.py`): Single adapter for Sonarr, Radarr, Prowlarr, and Bazarr. Polls `/api/vX/health` for health check issues and `/api/vX/queue` for stuck (>2h) and failed downloads. `app_type` config field selects API version (v3 for Sonarr/Radarr, v1 for Prowlarr/Bazarr).
- **QBittorrentAdapter** (`oasisagent/ingestion/qbittorrent.py`): Cookie-based session auth via `/api/v2/auth/login`. Polls transfer info for connectivity, errored torrents, and stalled downloads.
- **PlexAdapter** (`oasisagent/ingestion/plex.py`): X-Plex-Token auth. Server reachability check via `/identity` and library section scanning for empty/failed sections.
- **TautulliAdapter** (`oasisagent/ingestion/tautulli.py`): Polls `server_status` for Plex connectivity and `get_activity` for bandwidth threshold monitoring.
- **TdarrAdapter** (`oasisagent/ingestion/tdarr.py`): Polls `/api/v2/status` for worker health (online/offline transitions) and queue progress stall detection (configurable poll threshold).
- **OverseerrAdapter** (`oasisagent/ingestion/overseerr.py`): Polls `/api/v1/status` for server connectivity (Tier 2 integration).
- **Config models** added to `oasisagent/config.py` with Pydantic validation, `extra="forbid"`, and sensible defaults.
- **Registry** entries in `oasisagent/db/registry.py` with proper secret field mappings.
- **Form specs** in `oasisagent/ui/form_specs.py` for all six adapter types.
- **Known fixes** YAML files: `servarr.yaml` (3 fixes), `qbittorrent.yaml` (3 fixes), `plex.yaml` (4 fixes covering Plex, Tautulli, and Tdarr).
- All adapters use state-based dedup and follow the existing polling pattern with per-endpoint health isolation.
- `servarr` config is `list[ServarrAdapterConfig]` to allow multiple instances (one per Servarr app).

Closes #63

## Test plan

- [x] `ruff check` passes (zero errors)
- [x] 112 new tests across 6 test files covering config validation, adapter lifecycle, polling logic, state transitions, dedup, known fixes YAML, and registry entries
- [x] Full test suite: 2333 tests passing

🤖 Generated with [Claude Code](https://claude.com/claude-code)