### PR TITLE
Add N8N workflow execution health monitoring (#188)

### DIFF
--- a/known_fixes/n8n.yaml
+++ b/known_fixes/n8n.yaml
@@ -1,0 +1,39 @@
+fixes:
+  - id: n8n-execution-failed
+    match:
+      system: n8n
+      event_type: n8n_execution_failed
+    diagnosis: "N8N workflow execution failed — check workflow logic, node credentials, and connected service availability"
+    action:
+      type: recommend
+      handler: homeassistant
+      operation: notify
+      details:
+        message: |
+          N8N workflow execution failed. Steps:
+          1. Open the N8N UI and navigate to the failed execution
+          2. Check the error message on the failing node
+          3. Verify credentials for any external services (APIs, databases)
+          4. Check if connected services are reachable
+          5. Review recent workflow changes that may have introduced the failure
+          6. Re-run the execution manually after fixing the issue
+    risk_tier: recommend
+
+  - id: n8n-unreachable
+    match:
+      system: n8n
+      event_type: n8n_unreachable
+    diagnosis: "N8N service is unreachable — the workflow automation platform may be down or experiencing network issues"
+    action:
+      type: recommend
+      handler: homeassistant
+      operation: notify
+      details:
+        message: |
+          N8N service is unreachable. Steps:
+          1. Check if the N8N container/process is running
+          2. Verify network connectivity to the N8N host
+          3. Check N8N logs for startup errors or crashes
+          4. Verify the configured URL and port are correct
+          5. Check system resources (disk space, memory) on the N8N host
+    risk_tier: recommend

--- a/oasisagent/config.py
+++ b/oasisagent/config.py
@@ -542,6 +542,22 @@ class TdarrAdapterConfig(BaseModel):
     timeout: int = 10
 
 
+# -- N8N --------------------------------------------------------------------
+
+
+class N8nAdapterConfig(BaseModel):
+    """N8N workflow automation polling adapter configuration."""
+
+    model_config = ConfigDict(extra="forbid")
+
+    enabled: bool = False
+    url: str = ""
+    api_key: str = ""
+    poll_interval: int = 300
+    poll_executions: bool = True
+    timeout: int = 10
+
+
 # -- Overseerr ---------------------------------------------------------------
 
 
@@ -694,6 +710,7 @@ class IngestionConfig(BaseModel):
         default_factory=TautulliAdapterConfig,
     )
     tdarr: TdarrAdapterConfig = Field(default_factory=TdarrAdapterConfig)
+    n8n: N8nAdapterConfig = Field(default_factory=N8nAdapterConfig)
     overseerr: OverseerrAdapterConfig = Field(
         default_factory=OverseerrAdapterConfig,
     )

--- a/oasisagent/db/registry.py
+++ b/oasisagent/db/registry.py
@@ -34,6 +34,7 @@ from oasisagent.config import (
     LlmOptionsConfig,
     MqttIngestionConfig,
     MqttNotificationConfig,
+    N8nAdapterConfig,
     NpmAdapterConfig,
     OverseerrAdapterConfig,
     PlexAdapterConfig,
@@ -122,6 +123,10 @@ CONNECTOR_TYPES: dict[str, TypeMeta] = {
     ),
     "tdarr": TypeMeta(
         model=TdarrAdapterConfig,
+    ),
+    "n8n": TypeMeta(
+        model=N8nAdapterConfig,
+        secret_fields=frozenset({"api_key"}),
     ),
     "overseerr": TypeMeta(
         model=OverseerrAdapterConfig,

--- a/oasisagent/ingestion/n8n.py
+++ b/oasisagent/ingestion/n8n.py
@@ -1,0 +1,246 @@
+"""N8N workflow execution health monitoring adapter.
+
+Polls the N8N REST API for service health and failed workflow executions.
+
+Events emitted:
+- ``n8n_unreachable`` (ERROR) when N8N API is not reachable
+- ``n8n_recovered`` (INFO) when N8N API connectivity is restored
+- ``n8n_execution_failed`` (WARNING) when a workflow execution has failed
+"""
+
+from __future__ import annotations
+
+import asyncio
+import logging
+from datetime import UTC, datetime
+from typing import TYPE_CHECKING, Any
+
+import aiohttp
+
+from oasisagent.ingestion.base import IngestAdapter
+from oasisagent.models import Event, EventMetadata, Severity
+
+if TYPE_CHECKING:
+    from oasisagent.config import N8nAdapterConfig
+    from oasisagent.engine.queue import EventQueue
+
+logger = logging.getLogger(__name__)
+
+
+class N8nAdapter(IngestAdapter):
+    """Polls N8N for service health and failed workflow executions.
+
+    Uses state-based dedup for health status and time-based lookback
+    for execution failures (only reports new failures since last poll).
+    """
+
+    def __init__(
+        self, config: N8nAdapterConfig, queue: EventQueue,
+    ) -> None:
+        super().__init__(queue)
+        self._config = config
+        self._stopping = False
+        self._task: asyncio.Task[None] | None = None
+        self._connected = False
+
+        # State tracker for health dedup
+        self._service_ok: bool | None = None
+
+        # Time-based lookback for executions
+        self._last_execution_poll: datetime | None = None
+
+    @property
+    def name(self) -> str:
+        return "n8n"
+
+    def _headers(self) -> dict[str, str]:
+        return {"X-N8N-API-KEY": self._config.api_key}
+
+    async def start(self) -> None:
+        self._task = asyncio.create_task(
+            self._poll_loop(), name="n8n-poller",
+        )
+        await self._task
+
+    async def stop(self) -> None:
+        self._stopping = True
+        if self._task is not None:
+            self._task.cancel()
+            self._task = None
+
+    async def healthy(self) -> bool:
+        return self._connected
+
+    # -----------------------------------------------------------------
+    # Poll loop
+    # -----------------------------------------------------------------
+
+    async def _poll_loop(self) -> None:
+        timeout = aiohttp.ClientTimeout(total=self._config.timeout)
+
+        while not self._stopping:
+            try:
+                async with aiohttp.ClientSession(
+                    headers=self._headers(), timeout=timeout,
+                ) as session:
+                    await self._poll_health(session)
+                    if self._config.poll_executions:
+                        await self._poll_executions(session)
+                    self._connected = True
+            except asyncio.CancelledError:
+                return
+            except (TimeoutError, aiohttp.ClientError) as exc:
+                if self._connected:
+                    logger.warning("N8N: connection error: %s", exc)
+                self._connected = False
+
+                # Emit unreachable event on transition
+                was_ok = self._service_ok
+                self._service_ok = False
+                if was_ok is not None and was_ok:
+                    self._enqueue(Event(
+                        source=self.name,
+                        system="n8n",
+                        event_type="n8n_unreachable",
+                        entity_id="n8n",
+                        severity=Severity.ERROR,
+                        timestamp=datetime.now(tz=UTC),
+                        payload={},
+                        metadata=EventMetadata(
+                            dedup_key="n8n:service:status",
+                        ),
+                    ))
+            except Exception:
+                self._connected = False
+                logger.exception("N8N: unexpected error")
+
+            for _ in range(self._config.poll_interval):
+                if self._stopping:
+                    return
+                await asyncio.sleep(1)
+
+    # -----------------------------------------------------------------
+    # Health check
+    # -----------------------------------------------------------------
+
+    async def _poll_health(self, session: aiohttp.ClientSession) -> None:
+        """Poll the N8N API base to verify service reachability."""
+        url = f"{self._config.url}/api/v1/workflows?limit=1"
+        async with session.get(url) as resp:
+            resp.raise_for_status()
+            await resp.json(content_type=None)
+
+        is_ok = True
+        was_ok = self._service_ok
+        self._service_ok = is_ok
+
+        if was_ok is not None and not was_ok and is_ok:
+            self._enqueue(Event(
+                source=self.name,
+                system="n8n",
+                event_type="n8n_recovered",
+                entity_id="n8n",
+                severity=Severity.INFO,
+                timestamp=datetime.now(tz=UTC),
+                payload={},
+                metadata=EventMetadata(
+                    dedup_key="n8n:service:status",
+                ),
+            ))
+
+    # -----------------------------------------------------------------
+    # Execution failures
+    # -----------------------------------------------------------------
+
+    async def _poll_executions(self, session: aiohttp.ClientSession) -> None:
+        """Poll /api/v1/executions for failed workflow executions.
+
+        Uses time-based lookback: only reports executions that finished
+        after the last poll timestamp.
+        """
+        now = datetime.now(tz=UTC)
+        since = self._last_execution_poll
+        self._last_execution_poll = now
+
+        url = f"{self._config.url}/api/v1/executions"
+        params: dict[str, str] = {
+            "status": "error",
+            "limit": "10",
+        }
+        async with session.get(url, params=params) as resp:
+            resp.raise_for_status()
+            data: dict[str, Any] = await resp.json(content_type=None)
+
+        executions: list[dict[str, Any]] = data.get("data", [])
+
+        for execution in executions:
+            # Time-based filtering: skip executions from before last poll
+            finished_at = execution.get("stoppedAt") or execution.get("finishedAt", "")
+            if not finished_at:
+                continue
+
+            try:
+                finished_ts = datetime.fromisoformat(
+                    finished_at.replace("Z", "+00:00"),
+                )
+            except (ValueError, TypeError):
+                continue
+
+            # On first poll, only report recent failures (within poll_interval)
+            if since is None:
+                from datetime import timedelta
+                lookback = timedelta(seconds=self._config.poll_interval)
+                if finished_ts < now - lookback:
+                    continue
+            elif finished_ts <= since:
+                continue
+
+            exec_id = str(execution.get("id", ""))
+            workflow_name = ""
+            workflow_data = execution.get("workflowData") or {}
+            if isinstance(workflow_data, dict):
+                workflow_name = workflow_data.get("name", "")
+
+            error_message = ""
+            # N8N stores errors in lastNodeExecuted or in data
+            last_node = execution.get("data", {})
+            if isinstance(last_node, dict):
+                result_data = last_node.get("resultData", {})
+                if isinstance(result_data, dict):
+                    error_msg = result_data.get("error", {})
+                    if isinstance(error_msg, dict):
+                        error_message = error_msg.get("message", "")
+                    elif isinstance(error_msg, str):
+                        error_message = error_msg
+
+            self._enqueue(Event(
+                source=self.name,
+                system="n8n",
+                event_type="n8n_execution_failed",
+                entity_id=workflow_name or f"execution-{exec_id}",
+                severity=Severity.WARNING,
+                timestamp=datetime.now(tz=UTC),
+                payload={
+                    "execution_id": exec_id,
+                    "workflow_name": workflow_name,
+                    "error_message": error_message,
+                    "finished_at": finished_at,
+                },
+                metadata=EventMetadata(
+                    dedup_key=f"n8n:execution:{exec_id}",
+                ),
+            ))
+
+    # -----------------------------------------------------------------
+    # Helpers
+    # -----------------------------------------------------------------
+
+    def _enqueue(self, event: Event) -> None:
+        """Enqueue an event, logging on failure."""
+        try:
+            self._queue.put_nowait(event)
+        except Exception:
+            logger.warning(
+                "N8N: failed to enqueue event: %s/%s",
+                event.system, event.event_type,
+            )

--- a/oasisagent/ui/form_specs.py
+++ b/oasisagent/ui/form_specs.py
@@ -51,6 +51,7 @@ TYPE_DISPLAY_NAMES: dict[str, str] = {
     "plex": "Plex Media Server",
     "tautulli": "Tautulli",
     "tdarr": "Tdarr",
+    "n8n": "N8N",
     "overseerr": "Overseerr",
     "vaultwarden": "Vaultwarden",
     # Services
@@ -123,6 +124,10 @@ TYPE_DESCRIPTIONS: dict[str, str] = {
     "tdarr": (
         "Monitor Tdarr transcoding workers"
         " and queue progress"
+    ),
+    "n8n": (
+        "Monitor N8N workflow execution health"
+        " and failed runs"
     ),
     "overseerr": (
         "Monitor Overseerr server connectivity"
@@ -750,6 +755,36 @@ FORM_SPECS: dict[str, list[FieldSpec]] = {
         FieldSpec(
             "poll_interval", "Poll Interval (seconds)",
             "number", default=60,
+        ),
+        FieldSpec(
+            "timeout", "Request Timeout (seconds)",
+            "number", default=10, min_val=1,
+        ),
+    ],
+    "n8n": [
+        FieldSpec(
+            "url", "Server URL", "text",
+            help_text="e.g. http://localhost:5678",
+            required=True,
+        ),
+        FieldSpec(
+            "api_key", "API Key", "password",
+            help_text=(
+                "N8N Settings → API → Create API Key"
+            ),
+            required=True, group="Authentication",
+        ),
+        FieldSpec(
+            "poll_interval", "Poll Interval (seconds)",
+            "number", default=300,
+        ),
+        FieldSpec(
+            "poll_executions",
+            "Poll Failed Executions", "checkbox",
+            help_text=(
+                "Monitor for failed workflow executions"
+            ),
+            default=True, group="Polling",
         ),
         FieldSpec(
             "timeout", "Request Timeout (seconds)",

--- a/tests/test_ingestion/test_n8n.py
+++ b/tests/test_ingestion/test_n8n.py
@@ -1,0 +1,470 @@
+"""Tests for the N8N polling ingestion adapter."""
+
+from __future__ import annotations
+
+from datetime import UTC, datetime, timedelta
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+from pydantic import ValidationError
+
+from oasisagent.config import N8nAdapterConfig
+from oasisagent.ingestion.n8n import N8nAdapter
+from oasisagent.models import Event, EventMetadata, Severity
+
+
+def _make_config(**overrides: object) -> N8nAdapterConfig:
+    defaults: dict[str, object] = {
+        "enabled": True,
+        "url": "http://localhost:5678",
+        "api_key": "test-n8n-key",
+        "poll_interval": 300,
+        "poll_executions": True,
+        "timeout": 10,
+    }
+    defaults.update(overrides)
+    return N8nAdapterConfig(**defaults)  # type: ignore[arg-type]
+
+
+def _mock_queue() -> MagicMock:
+    return MagicMock()
+
+
+def _make_adapter(**overrides: object) -> tuple[N8nAdapter, MagicMock]:
+    config = _make_config(**overrides)
+    queue = _mock_queue()
+    adapter = N8nAdapter(config, queue)
+    return adapter, queue
+
+
+def _mock_response(data: object, status: int = 200) -> AsyncMock:
+    mock = AsyncMock()
+    mock.status = status
+    mock.raise_for_status = MagicMock()
+    mock.json = AsyncMock(return_value=data)
+    mock.__aenter__ = AsyncMock(return_value=mock)
+    mock.__aexit__ = AsyncMock(return_value=False)
+    return mock
+
+
+# ---------------------------------------------------------------------------
+# Config validation
+# ---------------------------------------------------------------------------
+
+
+class TestConfigValidation:
+    def test_defaults(self) -> None:
+        config = N8nAdapterConfig()
+        assert config.enabled is False
+        assert config.poll_interval == 300
+        assert config.poll_executions is True
+        assert config.timeout == 10
+
+    def test_extra_fields_forbidden(self) -> None:
+        with pytest.raises(ValidationError, match="Extra inputs"):
+            _make_config(bogus="nope")
+
+
+# ---------------------------------------------------------------------------
+# Adapter identity & lifecycle
+# ---------------------------------------------------------------------------
+
+
+class TestAdapterLifecycle:
+    def test_name(self) -> None:
+        adapter, _ = _make_adapter()
+        assert adapter.name == "n8n"
+
+    @pytest.mark.asyncio
+    async def test_healthy_initially_false(self) -> None:
+        adapter, _ = _make_adapter()
+        assert not await adapter.healthy()
+
+    @pytest.mark.asyncio
+    async def test_stop_sets_flag(self) -> None:
+        adapter, _ = _make_adapter()
+        await adapter.stop()
+        assert adapter._stopping is True
+
+    def test_headers(self) -> None:
+        adapter, _ = _make_adapter()
+        headers = adapter._headers()
+        assert headers["X-N8N-API-KEY"] == "test-n8n-key"
+
+
+# ---------------------------------------------------------------------------
+# Health polling
+# ---------------------------------------------------------------------------
+
+
+class TestHealthPolling:
+    @pytest.mark.asyncio
+    async def test_recovered_emits_event(self) -> None:
+        adapter, queue = _make_adapter()
+        adapter._service_ok = False
+
+        mock_session = AsyncMock()
+        mock_session.get = MagicMock(return_value=_mock_response(
+            {"data": []}, status=200,
+        ))
+
+        await adapter._poll_health(mock_session)
+
+        queue.put_nowait.assert_called_once()
+        event = queue.put_nowait.call_args[0][0]
+        assert event.event_type == "n8n_recovered"
+        assert event.severity == Severity.INFO
+
+    @pytest.mark.asyncio
+    async def test_already_ok_no_event(self) -> None:
+        adapter, queue = _make_adapter()
+        adapter._service_ok = True
+
+        mock_session = AsyncMock()
+        mock_session.get = MagicMock(return_value=_mock_response(
+            {"data": []}, status=200,
+        ))
+
+        await adapter._poll_health(mock_session)
+        queue.put_nowait.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_first_poll_ok_no_event(self) -> None:
+        adapter, queue = _make_adapter()
+
+        mock_session = AsyncMock()
+        mock_session.get = MagicMock(return_value=_mock_response(
+            {"data": []}, status=200,
+        ))
+
+        await adapter._poll_health(mock_session)
+        queue.put_nowait.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_dedup_key(self) -> None:
+        adapter, queue = _make_adapter()
+        adapter._service_ok = False
+
+        mock_session = AsyncMock()
+        mock_session.get = MagicMock(return_value=_mock_response(
+            {"data": []}, status=200,
+        ))
+
+        await adapter._poll_health(mock_session)
+
+        event = queue.put_nowait.call_args[0][0]
+        assert event.metadata.dedup_key == "n8n:service:status"
+
+
+# ---------------------------------------------------------------------------
+# Execution failure polling
+# ---------------------------------------------------------------------------
+
+
+class TestExecutionPolling:
+    @pytest.mark.asyncio
+    async def test_failed_execution_emits_event(self) -> None:
+        adapter, queue = _make_adapter()
+        # Set last poll to 10 minutes ago so execution is "new"
+        adapter._last_execution_poll = datetime.now(tz=UTC) - timedelta(minutes=10)
+
+        recent_time = (datetime.now(tz=UTC) - timedelta(minutes=2)).isoformat()
+
+        mock_session = AsyncMock()
+        mock_session.get = MagicMock(return_value=_mock_response({
+            "data": [
+                {
+                    "id": "12345",
+                    "stoppedAt": recent_time,
+                    "workflowData": {"name": "My Workflow"},
+                    "data": {
+                        "resultData": {
+                            "error": {"message": "Connection refused"},
+                        },
+                    },
+                },
+            ],
+        }))
+
+        await adapter._poll_executions(mock_session)
+
+        queue.put_nowait.assert_called_once()
+        event = queue.put_nowait.call_args[0][0]
+        assert event.event_type == "n8n_execution_failed"
+        assert event.severity == Severity.WARNING
+        assert event.entity_id == "My Workflow"
+        assert event.payload["execution_id"] == "12345"
+        assert event.payload["workflow_name"] == "My Workflow"
+        assert event.payload["error_message"] == "Connection refused"
+
+    @pytest.mark.asyncio
+    async def test_old_execution_ignored(self) -> None:
+        """Executions that finished before last poll should be skipped."""
+        adapter, queue = _make_adapter()
+        adapter._last_execution_poll = datetime.now(tz=UTC) - timedelta(minutes=5)
+
+        old_time = (datetime.now(tz=UTC) - timedelta(minutes=10)).isoformat()
+
+        mock_session = AsyncMock()
+        mock_session.get = MagicMock(return_value=_mock_response({
+            "data": [
+                {
+                    "id": "99",
+                    "stoppedAt": old_time,
+                    "workflowData": {"name": "Old Failure"},
+                    "data": {},
+                },
+            ],
+        }))
+
+        await adapter._poll_executions(mock_session)
+        queue.put_nowait.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_first_poll_lookback(self) -> None:
+        """First poll should only report failures within poll_interval."""
+        adapter, queue = _make_adapter(poll_interval=300)
+        # _last_execution_poll is None — first poll
+
+        recent_time = (datetime.now(tz=UTC) - timedelta(minutes=2)).isoformat()
+        old_time = (datetime.now(tz=UTC) - timedelta(minutes=10)).isoformat()
+
+        mock_session = AsyncMock()
+        mock_session.get = MagicMock(return_value=_mock_response({
+            "data": [
+                {
+                    "id": "1",
+                    "stoppedAt": recent_time,
+                    "workflowData": {"name": "Recent Fail"},
+                    "data": {},
+                },
+                {
+                    "id": "2",
+                    "stoppedAt": old_time,
+                    "workflowData": {"name": "Old Fail"},
+                    "data": {},
+                },
+            ],
+        }))
+
+        await adapter._poll_executions(mock_session)
+
+        # Only the recent execution should be reported
+        queue.put_nowait.assert_called_once()
+        event = queue.put_nowait.call_args[0][0]
+        assert event.payload["execution_id"] == "1"
+
+    @pytest.mark.asyncio
+    async def test_empty_executions_no_event(self) -> None:
+        adapter, queue = _make_adapter()
+
+        mock_session = AsyncMock()
+        mock_session.get = MagicMock(return_value=_mock_response({
+            "data": [],
+        }))
+
+        await adapter._poll_executions(mock_session)
+        queue.put_nowait.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_missing_stopped_at_skipped(self) -> None:
+        """Executions without a stoppedAt/finishedAt are skipped."""
+        adapter, queue = _make_adapter()
+        adapter._last_execution_poll = datetime.now(tz=UTC) - timedelta(minutes=10)
+
+        mock_session = AsyncMock()
+        mock_session.get = MagicMock(return_value=_mock_response({
+            "data": [
+                {
+                    "id": "77",
+                    "workflowData": {"name": "No Timestamp"},
+                    "data": {},
+                },
+            ],
+        }))
+
+        await adapter._poll_executions(mock_session)
+        queue.put_nowait.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_dedup_key_uses_execution_id(self) -> None:
+        adapter, queue = _make_adapter()
+        adapter._last_execution_poll = datetime.now(tz=UTC) - timedelta(minutes=10)
+
+        recent_time = (datetime.now(tz=UTC) - timedelta(minutes=2)).isoformat()
+
+        mock_session = AsyncMock()
+        mock_session.get = MagicMock(return_value=_mock_response({
+            "data": [
+                {
+                    "id": "42",
+                    "stoppedAt": recent_time,
+                    "workflowData": {"name": "Test"},
+                    "data": {},
+                },
+            ],
+        }))
+
+        await adapter._poll_executions(mock_session)
+
+        event = queue.put_nowait.call_args[0][0]
+        assert event.metadata.dedup_key == "n8n:execution:42"
+
+    @pytest.mark.asyncio
+    async def test_no_workflow_name_uses_execution_id(self) -> None:
+        """When workflowData is missing, entity_id falls back to execution ID."""
+        adapter, queue = _make_adapter()
+        adapter._last_execution_poll = datetime.now(tz=UTC) - timedelta(minutes=10)
+
+        recent_time = (datetime.now(tz=UTC) - timedelta(minutes=2)).isoformat()
+
+        mock_session = AsyncMock()
+        mock_session.get = MagicMock(return_value=_mock_response({
+            "data": [
+                {
+                    "id": "55",
+                    "stoppedAt": recent_time,
+                    "data": {},
+                },
+            ],
+        }))
+
+        await adapter._poll_executions(mock_session)
+
+        event = queue.put_nowait.call_args[0][0]
+        assert event.entity_id == "execution-55"
+
+    @pytest.mark.asyncio
+    async def test_error_message_from_string(self) -> None:
+        """Error can be a plain string instead of an object."""
+        adapter, queue = _make_adapter()
+        adapter._last_execution_poll = datetime.now(tz=UTC) - timedelta(minutes=10)
+
+        recent_time = (datetime.now(tz=UTC) - timedelta(minutes=2)).isoformat()
+
+        mock_session = AsyncMock()
+        mock_session.get = MagicMock(return_value=_mock_response({
+            "data": [
+                {
+                    "id": "66",
+                    "stoppedAt": recent_time,
+                    "workflowData": {"name": "String Error"},
+                    "data": {
+                        "resultData": {
+                            "error": "Something went wrong",
+                        },
+                    },
+                },
+            ],
+        }))
+
+        await adapter._poll_executions(mock_session)
+
+        event = queue.put_nowait.call_args[0][0]
+        assert event.payload["error_message"] == "Something went wrong"
+
+
+# ---------------------------------------------------------------------------
+# Known fixes
+# ---------------------------------------------------------------------------
+
+
+class TestKnownFixes:
+    def test_known_fixes_file_exists(self) -> None:
+        from pathlib import Path
+
+        import yaml
+
+        fixes_path = (
+            Path(__file__).parent.parent.parent / "known_fixes" / "n8n.yaml"
+        )
+        assert fixes_path.exists()
+
+        with fixes_path.open() as f:
+            data = yaml.safe_load(f)
+
+        assert "fixes" in data
+        fixes = data["fixes"]
+        assert len(fixes) >= 2
+
+        for fix in fixes:
+            assert "id" in fix
+            assert "match" in fix
+            assert "diagnosis" in fix
+            assert "action" in fix
+            assert "risk_tier" in fix
+
+    def test_known_fix_ids_unique(self) -> None:
+        from pathlib import Path
+
+        import yaml
+
+        fixes_path = (
+            Path(__file__).parent.parent.parent / "known_fixes" / "n8n.yaml"
+        )
+        with fixes_path.open() as f:
+            data = yaml.safe_load(f)
+
+        ids = [fix["id"] for fix in data["fixes"]]
+        assert len(ids) == len(set(ids))
+
+
+# ---------------------------------------------------------------------------
+# Registry
+# ---------------------------------------------------------------------------
+
+
+class TestRegistry:
+    def test_n8n_connector_registered(self) -> None:
+        from oasisagent.db.registry import CONNECTOR_TYPES
+
+        assert "n8n" in CONNECTOR_TYPES
+        meta = CONNECTOR_TYPES["n8n"]
+        assert meta.model is N8nAdapterConfig
+        assert "api_key" in meta.secret_fields
+
+
+# ---------------------------------------------------------------------------
+# Form specs
+# ---------------------------------------------------------------------------
+
+
+class TestFormSpecs:
+    def test_n8n_form_spec_exists(self) -> None:
+        from oasisagent.ui.form_specs import FORM_SPECS, TYPE_DESCRIPTIONS, TYPE_DISPLAY_NAMES
+
+        assert "n8n" in FORM_SPECS
+        assert "n8n" in TYPE_DISPLAY_NAMES
+        assert "n8n" in TYPE_DESCRIPTIONS
+
+        specs = FORM_SPECS["n8n"]
+        field_names = {s.name for s in specs}
+        assert "url" in field_names
+        assert "api_key" in field_names
+        assert "poll_interval" in field_names
+        assert "poll_executions" in field_names
+        assert "timeout" in field_names
+
+
+# ---------------------------------------------------------------------------
+# Enqueue error handling
+# ---------------------------------------------------------------------------
+
+
+class TestEnqueueErrorHandling:
+    def test_enqueue_failure_logged(self) -> None:
+        adapter, queue = _make_adapter()
+        queue.put_nowait.side_effect = RuntimeError("queue full")
+
+        event = Event(
+            source="n8n",
+            system="n8n",
+            event_type="test",
+            entity_id="test",
+            severity=Severity.INFO,
+            timestamp=datetime.now(tz=UTC),
+            payload={},
+            metadata=EventMetadata(dedup_key="test"),
+        )
+
+        adapter._enqueue(event)  # should not raise


### PR DESCRIPTION
## Summary
- Add `N8nAdapter` ingestion adapter that polls the N8N REST API for service health and failed workflow executions
- `_poll_health()`: state-based dedup tracking connected/disconnected, emits `n8n_unreachable` (ERROR) and `n8n_recovered` (INFO) on transitions
- `_poll_executions()`: time-based lookback polling `GET /api/v1/executions?status=error&limit=10`, emits `n8n_execution_failed` (WARNING) with workflow name and error message in payload
- `N8nAdapterConfig`: `url`, `api_key`, `poll_interval` (default 300), `poll_executions` (default True), `timeout`
- Register `n8n` connector type in `oasisagent/db/registry.py` with `api_key` as secret field
- Add form spec in `oasisagent/ui/form_specs.py` for web UI config
- Add known fixes: `n8n-execution-failed` and `n8n-unreachable` (both recommend + notify)
- 23 new tests covering config validation, lifecycle, health polling, execution polling, dedup, lookback, registry, and form specs

Closes #188

## Test plan
- [x] All 23 new tests pass (`pytest tests/test_ingestion/test_n8n.py -v`)
- [x] Full suite passes (2363 tests, 0 failures)
- [x] `ruff check` passes on all changed files

🤖 Generated with [Claude Code](https://claude.com/claude-code)