### PR TITLE
Add Frigate NVR ingestion adapter (#187)

### DIFF
--- a/known_fixes/frigate.yaml
+++ b/known_fixes/frigate.yaml
@@ -1,0 +1,40 @@
+fixes:
+  - id: frigate-camera-offline
+    match:
+      system: frigate
+      event_type: frigate_camera_offline
+    diagnosis: "Frigate camera offline — camera FPS dropped to 0, stream may be disconnected"
+    action:
+      type: recommend
+      handler: notify
+      operation: notify
+      details:
+        message: |
+          Frigate camera offline. Investigation steps:
+          1. Check camera power and network connectivity
+          2. Verify RTSP/RTMP stream URL is correct in Frigate config
+          3. Check Frigate logs for stream decode errors
+          4. Verify camera is not in maintenance mode
+          5. Check if camera firmware needs updating
+          6. Try restarting the Frigate container if multiple cameras affected
+    risk_tier: recommend
+
+  - id: frigate-detector-slow
+    match:
+      system: frigate
+      event_type: frigate_detector_slow
+    diagnosis: "Frigate detector inference is slow — detection FPS below threshold"
+    action:
+      type: recommend
+      handler: notify
+      operation: notify
+      details:
+        message: |
+          Frigate detector running slow. Investigation steps:
+          1. Check system resource usage (CPU/GPU/Coral TPU)
+          2. Verify hardware detector (Coral) is connected and recognized
+          3. Check if too many cameras are assigned to the same detector
+          4. Review Frigate config for detection resolution settings
+          5. Check for thermal throttling on the detection hardware
+          6. Consider reducing detection FPS or resolution in Frigate config
+    risk_tier: recommend

--- a/oasisagent/clients/frigate.py
+++ b/oasisagent/clients/frigate.py
@@ -1,0 +1,76 @@
+"""Frigate NVR HTTP client.
+
+Thin wrapper around Frigate's REST API for fetching camera stats
+and detection events. Frigate's API is unauthenticated by default.
+
+Endpoints used:
+- ``GET /api/stats`` — per-camera FPS, process info, detector stats
+- ``GET /api/events`` — recent object detection events
+"""
+
+from __future__ import annotations
+
+import logging
+from typing import Any
+
+import aiohttp
+
+logger = logging.getLogger(__name__)
+
+
+class FrigateClient:
+    """Async HTTP client for Frigate NVR API."""
+
+    def __init__(self, url: str, timeout: int = 10) -> None:
+        self._base_url = url.rstrip("/")
+        self._timeout = aiohttp.ClientTimeout(total=timeout)
+        self._session: aiohttp.ClientSession | None = None
+
+    async def start(self) -> None:
+        """Create the HTTP session and verify connectivity."""
+        self._session = aiohttp.ClientSession(timeout=self._timeout)
+        # Verify connectivity with a stats call
+        async with self._session.get(f"{self._base_url}/api/stats") as resp:
+            resp.raise_for_status()
+
+    async def close(self) -> None:
+        """Close the HTTP session."""
+        if self._session is not None:
+            await self._session.close()
+            self._session = None
+
+    async def get_stats(self) -> dict[str, Any]:
+        """Fetch ``/api/stats`` — camera and detector statistics.
+
+        Returns the raw JSON dict from Frigate.
+        """
+        if self._session is None:
+            msg = "Client not started"
+            raise RuntimeError(msg)
+
+        async with self._session.get(f"{self._base_url}/api/stats") as resp:
+            resp.raise_for_status()
+            return await resp.json()  # type: ignore[no-any-return]
+
+    async def get_events(
+        self, after: float, limit: int = 50,
+    ) -> list[dict[str, Any]]:
+        """Fetch ``/api/events`` — recent detection events.
+
+        Args:
+            after: Unix timestamp. Only events after this time are returned.
+            limit: Maximum number of events to return.
+
+        Returns:
+            List of event dicts from Frigate.
+        """
+        if self._session is None:
+            msg = "Client not started"
+            raise RuntimeError(msg)
+
+        params = {"after": str(after), "limit": str(limit)}
+        async with self._session.get(
+            f"{self._base_url}/api/events", params=params,
+        ) as resp:
+            resp.raise_for_status()
+            return await resp.json()  # type: ignore[no-any-return]

--- a/oasisagent/config.py
+++ b/oasisagent/config.py
@@ -440,6 +440,23 @@ class UptimeKumaAdapterConfig(BaseModel):
     cert_critical_days: int = 7
 
 
+# -- Frigate NVR -------------------------------------------------------------
+
+
+class FrigateAdapterConfig(BaseModel):
+    """Frigate NVR polling adapter configuration."""
+
+    model_config = ConfigDict(extra="forbid")
+
+    enabled: bool = False
+    url: str = ""
+    poll_interval: int = 60
+    poll_events: bool = False
+    detector_fps_threshold: float = 5.0
+    detection_spike_threshold: int = 20
+    timeout: int = 10
+
+
 # -- Nginx Proxy Manager ----------------------------------------------------
 
 
@@ -700,6 +717,7 @@ class IngestionConfig(BaseModel):
     uptime_kuma: UptimeKumaAdapterConfig = Field(
         default_factory=UptimeKumaAdapterConfig,
     )
+    frigate: FrigateAdapterConfig = Field(default_factory=FrigateAdapterConfig)
     npm: NpmAdapterConfig = Field(default_factory=NpmAdapterConfig)
     servarr: list[ServarrAdapterConfig] = Field(default_factory=list)
     qbittorrent: QBittorrentAdapterConfig = Field(

--- a/oasisagent/db/registry.py
+++ b/oasisagent/db/registry.py
@@ -24,6 +24,7 @@ from oasisagent.config import (
     DiscordNotificationConfig,
     DockerHandlerConfig,
     EmailNotificationConfig,
+    FrigateAdapterConfig,
     GuardrailsConfig,
     HaHandlerConfig,
     HaLogPollerConfig,
@@ -100,6 +101,9 @@ CONNECTOR_TYPES: dict[str, TypeMeta] = {
     "uptime_kuma": TypeMeta(
         model=UptimeKumaAdapterConfig,
         secret_fields=frozenset({"api_key"}),
+    ),
+    "frigate": TypeMeta(
+        model=FrigateAdapterConfig,
     ),
     "npm": TypeMeta(
         model=NpmAdapterConfig,

--- a/oasisagent/ingestion/frigate.py
+++ b/oasisagent/ingestion/frigate.py
@@ -1,0 +1,334 @@
+"""Frigate NVR polling ingestion adapter.
+
+Polls the Frigate API for camera health (FPS stats) and optionally
+for detection event spikes. Emits events on state transitions.
+
+Two polling paths:
+- Camera stats: state-based dedup per camera (FPS → online/offline)
+- Detection events: count-based spike detection per camera per poll
+"""
+
+from __future__ import annotations
+
+import asyncio
+import logging
+import time
+from collections import defaultdict
+from datetime import UTC, datetime
+from typing import TYPE_CHECKING, Any
+
+from oasisagent.clients.frigate import FrigateClient
+from oasisagent.ingestion.base import IngestAdapter
+from oasisagent.models import Event, EventMetadata, Severity
+
+if TYPE_CHECKING:
+    from oasisagent.config import FrigateAdapterConfig
+    from oasisagent.engine.queue import EventQueue
+
+logger = logging.getLogger(__name__)
+
+
+class FrigateAdapter(IngestAdapter):
+    """Polls Frigate NVR for camera health and detection event spikes.
+
+    State-based dedup for camera online/offline transitions. Optional
+    detection event spike alerting (disabled by default).
+    """
+
+    def __init__(
+        self, config: FrigateAdapterConfig, queue: EventQueue,
+    ) -> None:
+        super().__init__(queue)
+        self._config = config
+        self._client = FrigateClient(
+            url=config.url,
+            timeout=config.timeout,
+        )
+        self._stopping = False
+        self._task: asyncio.Task[None] | None = None
+        self._connected = False
+
+        # State trackers
+        self._camera_states: dict[str, bool] = {}  # camera_name → is_online
+        self._detector_states: dict[str, bool] = {}  # detector_name → is_slow
+        self._last_event_poll: float = 0.0
+
+    @property
+    def name(self) -> str:
+        return "frigate"
+
+    async def start(self) -> None:
+        """Connect to Frigate API and start polling loop."""
+        backoff = 5
+        max_backoff = 300
+        while not self._stopping:
+            try:
+                await self._client.start()
+                self._connected = True
+                break
+            except asyncio.CancelledError:
+                return
+            except Exception as exc:
+                logger.error(
+                    "Frigate adapter: connection failed: %s "
+                    "(retrying in %ds)", exc, backoff,
+                )
+                self._connected = False
+                for _ in range(backoff):
+                    if self._stopping:
+                        return
+                    await asyncio.sleep(1)
+                backoff = min(backoff * 2, max_backoff)
+
+        self._task = asyncio.create_task(
+            self._poll_loop(), name="frigate-poller",
+        )
+        await self._task
+
+    async def stop(self) -> None:
+        """Stop polling and close the client."""
+        self._stopping = True
+        if self._task is not None:
+            self._task.cancel()
+            self._task = None
+        await self._client.close()
+        self._connected = False
+
+    async def healthy(self) -> bool:
+        return self._connected
+
+    # -----------------------------------------------------------------
+    # Poll loop
+    # -----------------------------------------------------------------
+
+    async def _poll_loop(self) -> None:
+        """Main polling loop — polls stats and optionally events."""
+        while not self._stopping:
+            try:
+                await self._poll_stats()
+
+                if self._config.poll_events:
+                    await self._poll_events()
+
+                self._connected = True
+            except asyncio.CancelledError:
+                return
+            except Exception as exc:
+                logger.warning("Frigate poll error: %s", exc)
+                self._connected = False
+
+            for _ in range(self._config.poll_interval):
+                if self._stopping:
+                    return
+                await asyncio.sleep(1)
+
+    # -----------------------------------------------------------------
+    # Stats polling (camera health + detector performance)
+    # -----------------------------------------------------------------
+
+    async def _poll_stats(self) -> None:
+        """Poll /api/stats for camera FPS and detector performance."""
+        stats = await self._client.get_stats()
+
+        self._check_cameras(stats)
+        self._check_detectors(stats)
+
+    def _check_cameras(self, stats: dict[str, Any]) -> None:
+        """Check each camera's FPS for online/offline transitions."""
+        current_cameras: set[str] = set()
+
+        for camera_name, camera_data in stats.items():
+            # Skip non-camera top-level keys
+            if not isinstance(camera_data, dict):
+                continue
+            if "camera_fps" not in camera_data:
+                continue
+
+            current_cameras.add(camera_name)
+            camera_fps = camera_data.get("camera_fps", 0)
+            is_online = camera_fps > 0
+
+            prev_online = self._camera_states.get(camera_name)
+            self._camera_states[camera_name] = is_online
+
+            if prev_online is None:
+                # First poll — only emit if offline
+                if not is_online:
+                    self._enqueue(Event(
+                        source=self.name,
+                        system="frigate",
+                        event_type="frigate_camera_offline",
+                        entity_id=camera_name,
+                        severity=Severity.ERROR,
+                        timestamp=datetime.now(tz=UTC),
+                        payload={
+                            "camera": camera_name,
+                            "camera_fps": camera_fps,
+                        },
+                        metadata=EventMetadata(
+                            dedup_key=f"frigate:camera:{camera_name}:status",
+                        ),
+                    ))
+            elif prev_online and not is_online:
+                # Was online, now offline
+                self._enqueue(Event(
+                    source=self.name,
+                    system="frigate",
+                    event_type="frigate_camera_offline",
+                    entity_id=camera_name,
+                    severity=Severity.ERROR,
+                    timestamp=datetime.now(tz=UTC),
+                    payload={
+                        "camera": camera_name,
+                        "camera_fps": camera_fps,
+                    },
+                    metadata=EventMetadata(
+                        dedup_key=f"frigate:camera:{camera_name}:status",
+                    ),
+                ))
+            elif not prev_online and is_online:
+                # Was offline, now recovered
+                self._enqueue(Event(
+                    source=self.name,
+                    system="frigate",
+                    event_type="frigate_camera_recovered",
+                    entity_id=camera_name,
+                    severity=Severity.INFO,
+                    timestamp=datetime.now(tz=UTC),
+                    payload={
+                        "camera": camera_name,
+                        "camera_fps": camera_fps,
+                    },
+                    metadata=EventMetadata(
+                        dedup_key=f"frigate:camera:{camera_name}:status",
+                    ),
+                ))
+
+        # Evict cameras no longer in stats to prevent unbounded growth
+        self._camera_states = {
+            k: v for k, v in self._camera_states.items()
+            if k in current_cameras
+        }
+
+    def _check_detectors(self, stats: dict[str, Any]) -> None:
+        """Check detector inference FPS against threshold."""
+        detectors = stats.get("detectors", {})
+        if not isinstance(detectors, dict):
+            return
+
+        for det_name, det_data in detectors.items():
+            if not isinstance(det_data, dict):
+                continue
+
+            inference_speed = det_data.get("inference_speed", 0)
+            # inference_speed is in ms — convert to FPS (0 = not running)
+            det_fps = 1000.0 / inference_speed if inference_speed > 0 else 0.0
+
+            is_slow = det_fps < self._config.detector_fps_threshold
+            was_slow = self._detector_states.get(det_name, False)
+            self._detector_states[det_name] = is_slow
+
+            if is_slow and not was_slow:
+                self._enqueue(Event(
+                    source=self.name,
+                    system="frigate",
+                    event_type="frigate_detector_slow",
+                    entity_id=det_name,
+                    severity=Severity.WARNING,
+                    timestamp=datetime.now(tz=UTC),
+                    payload={
+                        "detector": det_name,
+                        "inference_speed_ms": inference_speed,
+                        "detector_fps": round(det_fps, 2),
+                        "threshold_fps": self._config.detector_fps_threshold,
+                    },
+                    metadata=EventMetadata(
+                        dedup_key=f"frigate:detector:{det_name}:slow",
+                    ),
+                ))
+            elif was_slow and not is_slow:
+                self._enqueue(Event(
+                    source=self.name,
+                    system="frigate",
+                    event_type="frigate_detector_recovered",
+                    entity_id=det_name,
+                    severity=Severity.INFO,
+                    timestamp=datetime.now(tz=UTC),
+                    payload={
+                        "detector": det_name,
+                        "inference_speed_ms": inference_speed,
+                        "detector_fps": round(det_fps, 2),
+                        "threshold_fps": self._config.detector_fps_threshold,
+                    },
+                    metadata=EventMetadata(
+                        dedup_key=f"frigate:detector:{det_name}:slow",
+                    ),
+                ))
+
+    # -----------------------------------------------------------------
+    # Event polling (detection spike detection)
+    # -----------------------------------------------------------------
+
+    async def _poll_events(self) -> None:
+        """Poll /api/events for detection count spikes."""
+        now = time.time()
+        if self._last_event_poll == 0.0:
+            # First poll — set baseline, don't alert
+            self._last_event_poll = now
+            return
+
+        events = await self._client.get_events(
+            after=self._last_event_poll, limit=50,
+        )
+        self._last_event_poll = now
+
+        if not events:
+            return
+
+        # Count detections per camera
+        camera_counts: dict[str, int] = defaultdict(int)
+        for ev in events:
+            camera = ev.get("camera", "unknown")
+            camera_counts[camera] += 1
+
+        for camera, count in camera_counts.items():
+            if count >= self._config.detection_spike_threshold:
+                # Collect the labels detected
+                labels: set[str] = set()
+                for ev in events:
+                    if ev.get("camera") == camera:
+                        label = ev.get("label", "")
+                        if label:
+                            labels.add(label)
+
+                self._enqueue(Event(
+                    source=self.name,
+                    system="frigate",
+                    event_type="frigate_detection_spike",
+                    entity_id=camera,
+                    severity=Severity.WARNING,
+                    timestamp=datetime.now(tz=UTC),
+                    payload={
+                        "camera": camera,
+                        "detection_count": count,
+                        "threshold": self._config.detection_spike_threshold,
+                        "labels": sorted(labels),
+                    },
+                    metadata=EventMetadata(
+                        dedup_key=f"frigate:events:{camera}:spike",
+                    ),
+                ))
+
+    # -----------------------------------------------------------------
+    # Helpers
+    # -----------------------------------------------------------------
+
+    def _enqueue(self, event: Event) -> None:
+        """Enqueue an event, logging on failure."""
+        try:
+            self._queue.put_nowait(event)
+        except Exception:
+            logger.warning(
+                "Frigate adapter: failed to enqueue event: %s/%s",
+                event.system, event.event_type,
+            )

--- a/oasisagent/ui/form_specs.py
+++ b/oasisagent/ui/form_specs.py
@@ -45,6 +45,7 @@ TYPE_DISPLAY_NAMES: dict[str, str] = {
     "unifi": "UniFi Network",
     "cloudflare": "Cloudflare",
     "uptime_kuma": "Uptime Kuma",
+    "frigate": "Frigate NVR",
     "npm": "Nginx Proxy Manager",
     "servarr": "Servarr (Sonarr/Radarr/Prowlarr/Bazarr)",
     "qbittorrent": "qBittorrent",
@@ -100,6 +101,10 @@ TYPE_DESCRIPTIONS: dict[str, str] = {
     "uptime_kuma": (
         "Pull monitor status from Uptime Kuma's"
         " Prometheus endpoint"
+    ),
+    "frigate": (
+        "Monitor Frigate NVR camera health"
+        " and detection events"
     ),
     "npm": (
         "Monitor Nginx Proxy Manager proxy hosts,"
@@ -590,6 +595,50 @@ FORM_SPECS: dict[str, list[FieldSpec]] = {
         ),
     ],
 
+    "frigate": [
+        FieldSpec(
+            "url", "Frigate URL", "text",
+            help_text="e.g. http://192.168.1.130:8971",
+            required=True,
+        ),
+        FieldSpec(
+            "poll_interval", "Poll Interval (seconds)",
+            "number", default=60, min_val=5,
+        ),
+        FieldSpec(
+            "poll_events", "Poll Detection Events",
+            "checkbox",
+            help_text=(
+                "Track detection event spikes"
+                " (disabled by default)"
+            ),
+            default=False, group="Polling",
+        ),
+        FieldSpec(
+            "detector_fps_threshold",
+            "Detector FPS Threshold", "float",
+            help_text=(
+                "Alert when detector inference FPS"
+                " drops below this value"
+            ),
+            default=5.0, min_val=0.1,
+            group="Thresholds",
+        ),
+        FieldSpec(
+            "detection_spike_threshold",
+            "Detection Spike Threshold", "number",
+            help_text=(
+                "Detections per poll interval to"
+                " trigger a spike alert"
+            ),
+            default=20, min_val=1,
+            group="Thresholds",
+        ),
+        FieldSpec(
+            "timeout", "Request Timeout (seconds)",
+            "number", default=10, min_val=1,
+        ),
+    ],
     "npm": [
         FieldSpec(
             "url", "NPM URL", "text",

--- a/tests/test_ingestion/test_frigate.py
+++ b/tests/test_ingestion/test_frigate.py
@@ -1,0 +1,718 @@
+"""Tests for the Frigate NVR ingestion adapter."""
+
+from __future__ import annotations
+
+import asyncio
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+from pydantic import ValidationError
+
+from oasisagent.config import FrigateAdapterConfig
+from oasisagent.ingestion.frigate import FrigateAdapter
+from oasisagent.models import Severity
+
+
+def _make_config(**overrides: object) -> FrigateAdapterConfig:
+    defaults: dict[str, object] = {
+        "enabled": True,
+        "url": "http://frigate:8971",
+        "poll_interval": 60,
+        "poll_events": False,
+        "detector_fps_threshold": 5.0,
+        "detection_spike_threshold": 20,
+        "timeout": 10,
+    }
+    defaults.update(overrides)
+    return FrigateAdapterConfig(**defaults)  # type: ignore[arg-type]
+
+
+def _mock_queue() -> MagicMock:
+    return MagicMock()
+
+
+def _make_adapter(
+    **overrides: object,
+) -> tuple[FrigateAdapter, MagicMock]:
+    config = _make_config(**overrides)
+    queue = _mock_queue()
+    with patch("oasisagent.ingestion.frigate.FrigateClient"):
+        adapter = FrigateAdapter(config, queue)
+    return adapter, queue
+
+
+# ---------------------------------------------------------------------------
+# Config validation
+# ---------------------------------------------------------------------------
+
+
+class TestConfigValidation:
+    def test_defaults(self) -> None:
+        config = FrigateAdapterConfig()
+        assert config.enabled is False
+        assert config.poll_interval == 60
+        assert config.poll_events is False
+        assert config.detector_fps_threshold == 5.0
+        assert config.detection_spike_threshold == 20
+        assert config.timeout == 10
+
+    def test_extra_fields_forbidden(self) -> None:
+        with pytest.raises(ValidationError, match="Extra inputs"):
+            _make_config(bogus="nope")
+
+
+# ---------------------------------------------------------------------------
+# Adapter identity & lifecycle
+# ---------------------------------------------------------------------------
+
+
+class TestAdapterLifecycle:
+    def test_name(self) -> None:
+        adapter, _ = _make_adapter()
+        assert adapter.name == "frigate"
+
+    @pytest.mark.asyncio
+    async def test_healthy_initially_false(self) -> None:
+        adapter, _ = _make_adapter()
+        assert not await adapter.healthy()
+
+    @pytest.mark.asyncio
+    async def test_stop_sets_flag(self) -> None:
+        adapter, _ = _make_adapter()
+        adapter._client = AsyncMock()
+        await adapter.stop()
+        assert adapter._stopping is True
+        assert adapter._connected is False
+
+
+# ---------------------------------------------------------------------------
+# Camera stats polling
+# ---------------------------------------------------------------------------
+
+
+class TestCameraPolling:
+    @pytest.mark.asyncio
+    async def test_camera_offline_event(self) -> None:
+        """Camera was online, FPS drops to 0 -> emit offline event."""
+        adapter, queue = _make_adapter()
+        adapter._camera_states["front_door"] = True  # was online
+
+        adapter._client.get_stats = AsyncMock(return_value={
+            "front_door": {
+                "camera_fps": 0,
+                "process_fps": 0,
+            },
+            "detectors": {},
+        })
+
+        await adapter._poll_stats()
+
+        queue.put_nowait.assert_called_once()
+        event = queue.put_nowait.call_args[0][0]
+        assert event.event_type == "frigate_camera_offline"
+        assert event.severity == Severity.ERROR
+        assert event.entity_id == "front_door"
+        assert event.payload["camera_fps"] == 0
+
+    @pytest.mark.asyncio
+    async def test_camera_recovery_event(self) -> None:
+        """Camera was offline, FPS restored -> emit recovery event."""
+        adapter, queue = _make_adapter()
+        adapter._camera_states["front_door"] = False  # was offline
+
+        adapter._client.get_stats = AsyncMock(return_value={
+            "front_door": {
+                "camera_fps": 15.0,
+                "process_fps": 10.0,
+            },
+            "detectors": {},
+        })
+
+        await adapter._poll_stats()
+
+        queue.put_nowait.assert_called_once()
+        event = queue.put_nowait.call_args[0][0]
+        assert event.event_type == "frigate_camera_recovered"
+        assert event.severity == Severity.INFO
+        assert event.entity_id == "front_door"
+        assert event.payload["camera_fps"] == 15.0
+
+    @pytest.mark.asyncio
+    async def test_camera_same_state_no_event(self) -> None:
+        """Camera stays online -> no event."""
+        adapter, queue = _make_adapter()
+        adapter._camera_states["front_door"] = True
+
+        adapter._client.get_stats = AsyncMock(return_value={
+            "front_door": {
+                "camera_fps": 15.0,
+            },
+            "detectors": {},
+        })
+
+        await adapter._poll_stats()
+        queue.put_nowait.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_first_poll_online_no_event(self) -> None:
+        """First poll with healthy camera -> no event."""
+        adapter, queue = _make_adapter()
+
+        adapter._client.get_stats = AsyncMock(return_value={
+            "front_door": {
+                "camera_fps": 15.0,
+            },
+            "detectors": {},
+        })
+
+        await adapter._poll_stats()
+        queue.put_nowait.assert_not_called()
+        assert adapter._camera_states["front_door"] is True
+
+    @pytest.mark.asyncio
+    async def test_first_poll_offline_emits(self) -> None:
+        """First poll with offline camera -> emit event."""
+        adapter, queue = _make_adapter()
+
+        adapter._client.get_stats = AsyncMock(return_value={
+            "front_door": {
+                "camera_fps": 0,
+            },
+            "detectors": {},
+        })
+
+        await adapter._poll_stats()
+
+        queue.put_nowait.assert_called_once()
+        event = queue.put_nowait.call_args[0][0]
+        assert event.event_type == "frigate_camera_offline"
+
+    @pytest.mark.asyncio
+    async def test_camera_dedup_key(self) -> None:
+        adapter, queue = _make_adapter()
+        adapter._camera_states["backyard"] = True
+
+        adapter._client.get_stats = AsyncMock(return_value={
+            "backyard": {"camera_fps": 0},
+            "detectors": {},
+        })
+
+        await adapter._poll_stats()
+
+        event = queue.put_nowait.call_args[0][0]
+        assert event.metadata.dedup_key == "frigate:camera:backyard:status"
+
+    @pytest.mark.asyncio
+    async def test_multiple_cameras_independent(self) -> None:
+        """Each camera tracked independently."""
+        adapter, queue = _make_adapter()
+        adapter._camera_states["cam_a"] = True
+        adapter._camera_states["cam_b"] = True
+
+        adapter._client.get_stats = AsyncMock(return_value={
+            "cam_a": {"camera_fps": 0},      # offline
+            "cam_b": {"camera_fps": 15.0},    # still online
+            "detectors": {},
+        })
+
+        await adapter._poll_stats()
+
+        queue.put_nowait.assert_called_once()
+        event = queue.put_nowait.call_args[0][0]
+        assert event.entity_id == "cam_a"
+
+    @pytest.mark.asyncio
+    async def test_non_camera_keys_skipped(self) -> None:
+        """Top-level keys without camera_fps are skipped."""
+        adapter, queue = _make_adapter()
+
+        adapter._client.get_stats = AsyncMock(return_value={
+            "service": {"uptime": 12345},
+            "cpu_usages": {"1": 50.0},
+            "detectors": {"coral": {"inference_speed": 10.0}},
+            "front_door": {"camera_fps": 15.0},
+        })
+
+        await adapter._poll_stats()
+        # Only front_door is a camera — no events on first poll (healthy)
+        queue.put_nowait.assert_not_called()
+        assert "front_door" in adapter._camera_states
+        assert "service" not in adapter._camera_states
+        assert "cpu_usages" not in adapter._camera_states
+
+    @pytest.mark.asyncio
+    async def test_deleted_camera_evicted(self) -> None:
+        """Cameras removed from stats are evicted from tracker."""
+        adapter, _ = _make_adapter()
+        adapter._camera_states = {"cam_a": True, "cam_b": True}
+
+        adapter._client.get_stats = AsyncMock(return_value={
+            "cam_a": {"camera_fps": 15.0},
+            "detectors": {},
+        })
+
+        await adapter._poll_stats()
+
+        assert "cam_a" in adapter._camera_states
+        assert "cam_b" not in adapter._camera_states
+
+    @pytest.mark.asyncio
+    async def test_event_source_and_system(self) -> None:
+        adapter, queue = _make_adapter()
+
+        adapter._client.get_stats = AsyncMock(return_value={
+            "front_door": {"camera_fps": 0},
+            "detectors": {},
+        })
+
+        await adapter._poll_stats()
+
+        event = queue.put_nowait.call_args[0][0]
+        assert event.source == "frigate"
+        assert event.system == "frigate"
+
+
+# ---------------------------------------------------------------------------
+# Detector stats polling
+# ---------------------------------------------------------------------------
+
+
+class TestDetectorPolling:
+    @pytest.mark.asyncio
+    async def test_detector_slow_event(self) -> None:
+        """Detector inference speed too slow -> emit warning."""
+        adapter, queue = _make_adapter(detector_fps_threshold=5.0)
+
+        adapter._client.get_stats = AsyncMock(return_value={
+            "detectors": {
+                "coral": {
+                    "inference_speed": 500.0,  # 2 FPS, below 5.0 threshold
+                    "pid": 123,
+                },
+            },
+        })
+
+        await adapter._poll_stats()
+
+        queue.put_nowait.assert_called_once()
+        event = queue.put_nowait.call_args[0][0]
+        assert event.event_type == "frigate_detector_slow"
+        assert event.severity == Severity.WARNING
+        assert event.entity_id == "coral"
+        assert event.payload["inference_speed_ms"] == 500.0
+        assert event.payload["detector_fps"] == 2.0
+
+    @pytest.mark.asyncio
+    async def test_detector_fast_no_event(self) -> None:
+        """Detector inference speed above threshold -> no event."""
+        adapter, queue = _make_adapter(detector_fps_threshold=5.0)
+
+        adapter._client.get_stats = AsyncMock(return_value={
+            "detectors": {
+                "coral": {
+                    "inference_speed": 10.0,  # 100 FPS
+                },
+            },
+        })
+
+        await adapter._poll_stats()
+        queue.put_nowait.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_detector_recovery_event(self) -> None:
+        """Detector recovers from slow state -> emit recovery."""
+        adapter, queue = _make_adapter(detector_fps_threshold=5.0)
+        adapter._detector_states["coral"] = True  # was slow
+
+        adapter._client.get_stats = AsyncMock(return_value={
+            "detectors": {
+                "coral": {
+                    "inference_speed": 10.0,  # 100 FPS — recovered
+                },
+            },
+        })
+
+        await adapter._poll_stats()
+
+        queue.put_nowait.assert_called_once()
+        event = queue.put_nowait.call_args[0][0]
+        assert event.event_type == "frigate_detector_recovered"
+        assert event.severity == Severity.INFO
+
+    @pytest.mark.asyncio
+    async def test_detector_same_slow_state_dedup(self) -> None:
+        """Detector stays slow -> no duplicate event."""
+        adapter, queue = _make_adapter(detector_fps_threshold=5.0)
+        adapter._detector_states["coral"] = True
+
+        adapter._client.get_stats = AsyncMock(return_value={
+            "detectors": {
+                "coral": {"inference_speed": 500.0},
+            },
+        })
+
+        await adapter._poll_stats()
+        queue.put_nowait.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_detector_dedup_key(self) -> None:
+        adapter, queue = _make_adapter(detector_fps_threshold=5.0)
+
+        adapter._client.get_stats = AsyncMock(return_value={
+            "detectors": {
+                "coral": {"inference_speed": 500.0},
+            },
+        })
+
+        await adapter._poll_stats()
+
+        event = queue.put_nowait.call_args[0][0]
+        assert event.metadata.dedup_key == "frigate:detector:coral:slow"
+
+    @pytest.mark.asyncio
+    async def test_detector_zero_speed(self) -> None:
+        """Zero inference speed means detector not running -> slow."""
+        adapter, queue = _make_adapter(detector_fps_threshold=5.0)
+
+        adapter._client.get_stats = AsyncMock(return_value={
+            "detectors": {
+                "coral": {"inference_speed": 0},
+            },
+        })
+
+        await adapter._poll_stats()
+
+        queue.put_nowait.assert_called_once()
+        event = queue.put_nowait.call_args[0][0]
+        assert event.event_type == "frigate_detector_slow"
+
+    @pytest.mark.asyncio
+    async def test_no_detectors_key_no_error(self) -> None:
+        """Stats without detectors key should not error."""
+        adapter, queue = _make_adapter()
+
+        adapter._client.get_stats = AsyncMock(return_value={
+            "front_door": {"camera_fps": 15.0},
+        })
+
+        await adapter._poll_stats()
+        queue.put_nowait.assert_not_called()
+
+
+# ---------------------------------------------------------------------------
+# Event polling (detection spikes)
+# ---------------------------------------------------------------------------
+
+
+class TestEventPolling:
+    @pytest.mark.asyncio
+    async def test_first_poll_sets_baseline(self) -> None:
+        """First event poll sets timestamp, doesn't alert."""
+        adapter, queue = _make_adapter(poll_events=True)
+        assert adapter._last_event_poll == 0.0
+
+        await adapter._poll_events()
+
+        assert adapter._last_event_poll > 0.0
+        queue.put_nowait.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_spike_event(self) -> None:
+        """Detection count above threshold -> emit spike event."""
+        adapter, queue = _make_adapter(
+            poll_events=True, detection_spike_threshold=3,
+        )
+        adapter._last_event_poll = 1000.0
+
+        events = [
+            {"camera": "front_door", "label": "person"},
+            {"camera": "front_door", "label": "person"},
+            {"camera": "front_door", "label": "car"},
+        ]
+        adapter._client.get_events = AsyncMock(return_value=events)
+
+        await adapter._poll_events()
+
+        queue.put_nowait.assert_called_once()
+        event = queue.put_nowait.call_args[0][0]
+        assert event.event_type == "frigate_detection_spike"
+        assert event.severity == Severity.WARNING
+        assert event.entity_id == "front_door"
+        assert event.payload["detection_count"] == 3
+        assert set(event.payload["labels"]) == {"person", "car"}
+
+    @pytest.mark.asyncio
+    async def test_below_threshold_no_event(self) -> None:
+        """Detection count below threshold -> no event."""
+        adapter, queue = _make_adapter(
+            poll_events=True, detection_spike_threshold=10,
+        )
+        adapter._last_event_poll = 1000.0
+
+        events = [
+            {"camera": "front_door", "label": "person"},
+            {"camera": "front_door", "label": "car"},
+        ]
+        adapter._client.get_events = AsyncMock(return_value=events)
+
+        await adapter._poll_events()
+        queue.put_nowait.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_spike_per_camera(self) -> None:
+        """Spike is tracked per camera — only cameras above threshold alert."""
+        adapter, queue = _make_adapter(
+            poll_events=True, detection_spike_threshold=3,
+        )
+        adapter._last_event_poll = 1000.0
+
+        events = [
+            {"camera": "front_door", "label": "person"},
+            {"camera": "front_door", "label": "person"},
+            {"camera": "front_door", "label": "person"},
+            {"camera": "backyard", "label": "cat"},
+        ]
+        adapter._client.get_events = AsyncMock(return_value=events)
+
+        await adapter._poll_events()
+
+        # Only front_door hit threshold
+        queue.put_nowait.assert_called_once()
+        event = queue.put_nowait.call_args[0][0]
+        assert event.entity_id == "front_door"
+
+    @pytest.mark.asyncio
+    async def test_empty_events_no_alert(self) -> None:
+        """Empty event list -> no alert."""
+        adapter, queue = _make_adapter(poll_events=True)
+        adapter._last_event_poll = 1000.0
+
+        adapter._client.get_events = AsyncMock(return_value=[])
+
+        await adapter._poll_events()
+        queue.put_nowait.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_spike_dedup_key(self) -> None:
+        adapter, queue = _make_adapter(
+            poll_events=True, detection_spike_threshold=1,
+        )
+        adapter._last_event_poll = 1000.0
+
+        adapter._client.get_events = AsyncMock(return_value=[
+            {"camera": "garage", "label": "person"},
+        ])
+
+        await adapter._poll_events()
+
+        event = queue.put_nowait.call_args[0][0]
+        assert event.metadata.dedup_key == "frigate:events:garage:spike"
+
+
+# ---------------------------------------------------------------------------
+# Poll loop (events disabled by default)
+# ---------------------------------------------------------------------------
+
+
+class TestPollLoop:
+    @pytest.mark.asyncio
+    async def test_events_not_polled_by_default(self) -> None:
+        """When poll_events=False, _poll_events should not be called."""
+        adapter, _ = _make_adapter(poll_events=False)
+
+        poll_count = 0
+        original_get_stats = AsyncMock(return_value={"detectors": {}})
+
+        async def _get_stats_then_stop() -> dict:
+            nonlocal poll_count
+            poll_count += 1
+            result = await original_get_stats()
+            adapter._stopping = True
+            return result
+
+        adapter._client.get_stats = _get_stats_then_stop  # type: ignore[assignment]
+        adapter._poll_events = AsyncMock()  # type: ignore[method-assign]
+
+        with patch("oasisagent.ingestion.frigate.asyncio.sleep", new_callable=AsyncMock):
+            await adapter._poll_loop()
+
+        assert poll_count >= 1
+        adapter._poll_events.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_events_polled_when_enabled(self) -> None:
+        """When poll_events=True, _poll_events should be called."""
+        adapter, _ = _make_adapter(poll_events=True)
+
+        original_get_stats = AsyncMock(return_value={"detectors": {}})
+
+        async def _get_stats_then_stop() -> dict:
+            result = await original_get_stats()
+            return result
+
+        adapter._client.get_stats = _get_stats_then_stop  # type: ignore[assignment]
+
+        original_poll_events = AsyncMock()
+
+        async def _poll_events_then_stop() -> None:
+            await original_poll_events()
+            adapter._stopping = True
+
+        adapter._poll_events = _poll_events_then_stop  # type: ignore[method-assign]
+
+        with patch("oasisagent.ingestion.frigate.asyncio.sleep", new_callable=AsyncMock):
+            await adapter._poll_loop()
+
+        original_poll_events.assert_called_once()
+
+
+# ---------------------------------------------------------------------------
+# Startup retry
+# ---------------------------------------------------------------------------
+
+
+class TestStartupRetry:
+    @pytest.mark.asyncio
+    async def test_retries_on_connection_failure(self) -> None:
+        adapter, _ = _make_adapter()
+
+        call_count = 0
+        original_sleep = asyncio.sleep
+
+        async def _start_side_effect() -> None:
+            nonlocal call_count
+            call_count += 1
+            if call_count < 3:
+                raise ConnectionError("refused")
+
+        async def _noop_sleep(_: float) -> None:
+            await original_sleep(0)
+
+        adapter._client = AsyncMock()
+        adapter._client.start = AsyncMock(side_effect=_start_side_effect)
+        adapter._client.get_stats = AsyncMock(return_value={"detectors": {}})
+        adapter._client.close = AsyncMock()
+
+        with patch(
+            "oasisagent.ingestion.frigate.asyncio.sleep",
+            side_effect=_noop_sleep,
+        ):
+            task = asyncio.create_task(adapter.start())
+            for _ in range(200):
+                await original_sleep(0)
+            adapter._stopping = True
+            try:
+                await asyncio.wait_for(task, timeout=2.0)
+            except (TimeoutError, asyncio.CancelledError):
+                task.cancel()
+
+        assert call_count >= 3
+        assert adapter._connected is True
+
+
+# ---------------------------------------------------------------------------
+# Enqueue error handling
+# ---------------------------------------------------------------------------
+
+
+class TestEnqueueErrorHandling:
+    def test_enqueue_failure_logged(self) -> None:
+        adapter, queue = _make_adapter()
+        queue.put_nowait.side_effect = RuntimeError("queue full")
+
+        from datetime import UTC, datetime
+
+        from oasisagent.models import Event, EventMetadata
+
+        event = Event(
+            source="frigate",
+            system="frigate",
+            event_type="test",
+            entity_id="test",
+            severity=Severity.INFO,
+            timestamp=datetime.now(tz=UTC),
+            payload={},
+            metadata=EventMetadata(dedup_key="test"),
+        )
+
+        adapter._enqueue(event)  # should not raise
+
+
+# ---------------------------------------------------------------------------
+# Known fixes YAML
+# ---------------------------------------------------------------------------
+
+
+class TestKnownFixes:
+    def test_known_fixes_file_exists(self) -> None:
+        from pathlib import Path
+
+        import yaml
+
+        fixes_path = (
+            Path(__file__).parent.parent.parent / "known_fixes" / "frigate.yaml"
+        )
+        assert fixes_path.exists()
+
+        with fixes_path.open() as f:
+            data = yaml.safe_load(f)
+
+        assert "fixes" in data
+        fixes = data["fixes"]
+        assert len(fixes) >= 2
+
+        for fix in fixes:
+            assert "id" in fix
+            assert "match" in fix
+            assert fix["match"]["system"] == "frigate"
+            assert "diagnosis" in fix
+            assert "action" in fix
+            assert "risk_tier" in fix
+
+    def test_known_fix_ids_unique(self) -> None:
+        from pathlib import Path
+
+        import yaml
+
+        fixes_path = (
+            Path(__file__).parent.parent.parent / "known_fixes" / "frigate.yaml"
+        )
+        with fixes_path.open() as f:
+            data = yaml.safe_load(f)
+
+        ids = [fix["id"] for fix in data["fixes"]]
+        assert len(ids) == len(set(ids))
+
+    def test_known_fix_event_types_match_adapter(self) -> None:
+        from pathlib import Path
+
+        import yaml
+
+        fixes_path = (
+            Path(__file__).parent.parent.parent / "known_fixes" / "frigate.yaml"
+        )
+        with fixes_path.open() as f:
+            data = yaml.safe_load(f)
+
+        expected_types = {
+            "frigate_camera_offline",
+            "frigate_detector_slow",
+        }
+
+        fix_types = {fix["match"]["event_type"] for fix in data["fixes"]}
+        assert fix_types == expected_types
+
+
+# ---------------------------------------------------------------------------
+# Registry
+# ---------------------------------------------------------------------------
+
+
+class TestRegistry:
+    def test_frigate_connector_registered(self) -> None:
+        from oasisagent.db.registry import CONNECTOR_TYPES
+
+        assert "frigate" in CONNECTOR_TYPES
+        meta = CONNECTOR_TYPES["frigate"]
+        assert meta.model is FrigateAdapterConfig
+        assert meta.secret_fields == frozenset()  # no auth required


### PR DESCRIPTION
## Summary

- **FrigateAdapter** polls Frigate NVR's `/api/stats` for camera FPS and detector inference speed, emitting events on state transitions (camera offline/recovered, detector slow/recovered)
- **Optional detection event polling** via `/api/events` with per-camera spike detection (disabled by default via `poll_events: false`)
- **FrigateClient** — thin async HTTP wrapper for Frigate's unauthenticated REST API (`/api/stats`, `/api/events`)
- **FrigateAdapterConfig** — `url`, `poll_interval` (60s), `poll_events` (false), `detector_fps_threshold` (5.0), `detection_spike_threshold` (20), `timeout` (10s)
- Registered in `db/registry.py` (no secret fields — Frigate API is unauthenticated)
- Form specs added to `ui/form_specs.py` with Polling and Thresholds groups
- Known fixes: `frigate-camera-offline` (recommend/notify), `frigate-detector-slow` (recommend/notify)

Closes #187

## Test plan

- [x] 36 new tests in `tests/test_ingestion/test_frigate.py`
- [x] Config validation (defaults, extra fields forbidden)
- [x] Camera state transitions (offline, recovered, first-poll, dedup, eviction)
- [x] Detector slow/recovered transitions with dedup
- [x] Detection event spike detection (per-camera, threshold, first-poll baseline)
- [x] Poll loop: events not polled when disabled, polled when enabled
- [x] Startup retry with back-off
- [x] Enqueue error handling
- [x] Known fixes YAML validation (exists, IDs unique, event types match)
- [x] Registry entry validation
- [x] Full suite: 2376 tests passing
- [x] `ruff check` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)