### PR TITLE
Add Nginx Proxy Manager ingestion adapter (#190)

### DIFF
--- a/known_fixes/npm.yaml
+++ b/known_fixes/npm.yaml
@@ -1,0 +1,57 @@
+fixes:
+  - id: npm-proxy-host-error
+    match:
+      system: npm
+      event_type: npm_proxy_host_error
+    diagnosis: "Nginx Proxy Manager proxy host is erroring or disabled"
+    action:
+      type: recommend
+      handler: homeassistant
+      operation: notify
+      details:
+        message: |
+          NPM proxy host error detected. Checklist:
+          1. Check if the proxy host was intentionally disabled
+          2. Verify the upstream service is running and reachable
+          3. Check NPM logs for SSL or connectivity errors
+          4. Verify the forward host/port are correct in NPM
+          5. Check for DNS resolution issues on the NPM host
+    risk_tier: recommend
+
+  - id: npm-certificate-expiring
+    match:
+      system: npm
+      event_type: npm_certificate_expiring
+    diagnosis: "NPM-managed SSL certificate is approaching expiration — auto-renewal may have failed"
+    action:
+      type: recommend
+      handler: homeassistant
+      operation: notify
+      details:
+        message: |
+          NPM certificate expiring soon. Steps:
+          1. Check NPM dashboard for certificate renewal status
+          2. Verify Let's Encrypt ACME challenge is reachable (port 80)
+          3. Check NPM logs for renewal errors
+          4. Verify DNS records point to the correct IP
+          5. Try manually triggering renewal from NPM UI
+          6. Check if rate limits have been hit (Let's Encrypt)
+    risk_tier: recommend
+
+  - id: npm-dead-host
+    match:
+      system: npm
+      event_type: npm_dead_host_detected
+    diagnosis: "NPM dead host detected — a configured 404 host is active"
+    action:
+      type: recommend
+      handler: homeassistant
+      operation: notify
+      details:
+        message: |
+          Dead host detected in Nginx Proxy Manager. Consider:
+          1. Review the dead host entry in NPM dashboard
+          2. Determine if the dead host was intentional (custom 404)
+          3. Check if a proxy host should be created instead
+          4. Verify domain DNS records are correct
+    risk_tier: recommend

--- a/oasisagent/clients/npm.py
+++ b/oasisagent/clients/npm.py
@@ -1,0 +1,152 @@
+"""Nginx Proxy Manager API client.
+
+JWT-based authentication: POST /api/tokens with email/password returns
+a JWT token used as ``Authorization: Bearer <token>``.  Tokens expire
+after a configurable period; the client transparently refreshes on 401.
+
+Used by the NPM ingestion adapter to poll proxy hosts, certificates,
+and dead hosts.
+"""
+
+from __future__ import annotations
+
+import logging
+from typing import Any
+
+import aiohttp
+
+logger = logging.getLogger(__name__)
+
+
+class NpmClient:
+    """HTTP client for the Nginx Proxy Manager API.
+
+    Args:
+        url: NPM base URL (e.g., ``http://192.168.1.50:81``).
+        email: Admin email for authentication.
+        password: Admin password for authentication.
+        timeout: Request timeout in seconds.
+    """
+
+    def __init__(
+        self,
+        url: str,
+        email: str,
+        password: str,
+        *,
+        timeout: int = 10,
+    ) -> None:
+        self._base_url = url.rstrip("/")
+        self._email = email
+        self._password = password
+        self._timeout = timeout
+        self._session: aiohttp.ClientSession | None = None
+        self._token: str | None = None
+
+    # -----------------------------------------------------------------
+    # Lifecycle
+    # -----------------------------------------------------------------
+
+    async def connect(self) -> None:
+        """Create the HTTP session and authenticate."""
+        self._session = aiohttp.ClientSession(
+            timeout=aiohttp.ClientTimeout(total=self._timeout),
+        )
+        await self._authenticate()
+
+    async def close(self) -> None:
+        """Close the HTTP session."""
+        if self._session is not None:
+            await self._session.close()
+            self._session = None
+            self._token = None
+
+    async def healthy(self) -> bool:
+        """Check if the client has a valid session and token."""
+        if self._session is None or self._token is None:
+            return False
+        try:
+            await self.get("/api/nginx/proxy-hosts?limit=1")
+            return True
+        except Exception:
+            return False
+
+    # -----------------------------------------------------------------
+    # Authentication
+    # -----------------------------------------------------------------
+
+    async def _authenticate(self) -> None:
+        """POST credentials to /api/tokens to obtain a JWT."""
+        assert self._session is not None
+
+        url = f"{self._base_url}/api/tokens"
+        payload = {"identity": self._email, "secret": self._password}
+
+        async with self._session.post(url, json=payload) as resp:
+            if resp.status != 200:
+                body = await resp.text()
+                self._token = None
+                msg = f"NPM login failed (HTTP {resp.status}): {body[:200]}"
+                raise ConnectionError(msg)
+
+            data = await resp.json()
+            self._token = data.get("token") or data.get("access_token", "")
+            if not self._token:
+                msg = "NPM login response missing token"
+                raise ConnectionError(msg)
+
+        logger.info("NPM client: authenticated to %s", self._base_url)
+
+    # -----------------------------------------------------------------
+    # Requests
+    # -----------------------------------------------------------------
+
+    async def get(self, path: str) -> dict[str, Any] | list[dict[str, Any]]:
+        """GET a JSON endpoint. Retries once on 401 (token refresh).
+
+        Returns the parsed JSON response body.
+        Raises on non-2xx after retry.
+        """
+        if self._session is None:
+            msg = "NPM client not connected -- call connect() first"
+            raise RuntimeError(msg)
+
+        url = f"{self._base_url}{path}"
+        headers = self._auth_headers()
+
+        async with self._session.get(url, headers=headers) as resp:
+            if resp.status in (401, 403):
+                # Token expired -- re-authenticate and retry once
+                await self._authenticate()
+                headers = self._auth_headers()
+                async with self._session.get(url, headers=headers) as retry_resp:
+                    if retry_resp.status >= 400:
+                        body = await retry_resp.text()
+                        msg = (
+                            f"NPM GET {path} failed after re-auth"
+                            f" (HTTP {retry_resp.status}): {body[:200]}"
+                        )
+                        raise aiohttp.ClientResponseError(
+                            retry_resp.request_info, retry_resp.history,
+                            status=retry_resp.status, message=msg,
+                        )
+                    return await retry_resp.json()
+
+            if resp.status >= 400:
+                body = await resp.text()
+                msg = f"NPM GET {path} failed (HTTP {resp.status}): {body[:200]}"
+                raise aiohttp.ClientResponseError(
+                    resp.request_info, resp.history,
+                    status=resp.status, message=msg,
+                )
+            return await resp.json()
+
+    # -----------------------------------------------------------------
+    # Helpers
+    # -----------------------------------------------------------------
+
+    def _auth_headers(self) -> dict[str, str]:
+        """Build authorization headers with current token."""
+        if self._token:
+            return {"Authorization": f"Bearer {self._token}"}
+        return {}

--- a/oasisagent/config.py
+++ b/oasisagent/config.py
@@ -440,6 +440,27 @@ class UptimeKumaAdapterConfig(BaseModel):
     cert_critical_days: int = 7
 
 
+# -- Nginx Proxy Manager ----------------------------------------------------
+
+
+class NpmAdapterConfig(BaseModel):
+    """Nginx Proxy Manager polling adapter configuration."""
+
+    model_config = ConfigDict(extra="forbid")
+
+    enabled: bool = False
+    url: str = ""
+    email: str = ""
+    password: str = ""
+    poll_interval: int = 300
+    poll_proxy_hosts: bool = True
+    poll_certificates: bool = True
+    poll_dead_hosts: bool = True
+    cert_warning_days: int = 14
+    cert_critical_days: int = 7
+    timeout: int = 10
+
+
 # -- Servarr (Sonarr/Radarr/Prowlarr/Bazarr) --------------------------------
 
 
@@ -649,6 +670,7 @@ class IngestionConfig(BaseModel):
     uptime_kuma: UptimeKumaAdapterConfig = Field(
         default_factory=UptimeKumaAdapterConfig,
     )
+    npm: NpmAdapterConfig = Field(default_factory=NpmAdapterConfig)
     servarr: list[ServarrAdapterConfig] = Field(default_factory=list)
     qbittorrent: QBittorrentAdapterConfig = Field(
         default_factory=QBittorrentAdapterConfig,

--- a/oasisagent/db/registry.py
+++ b/oasisagent/db/registry.py
@@ -34,6 +34,7 @@ from oasisagent.config import (
     LlmOptionsConfig,
     MqttIngestionConfig,
     MqttNotificationConfig,
+    NpmAdapterConfig,
     OverseerrAdapterConfig,
     PlexAdapterConfig,
     PortainerHandlerConfig,
@@ -97,6 +98,10 @@ CONNECTOR_TYPES: dict[str, TypeMeta] = {
     "uptime_kuma": TypeMeta(
         model=UptimeKumaAdapterConfig,
         secret_fields=frozenset({"api_key"}),
+    ),
+    "npm": TypeMeta(
+        model=NpmAdapterConfig,
+        secret_fields=frozenset({"password"}),
     ),
     "servarr": TypeMeta(
         model=ServarrAdapterConfig,

--- a/oasisagent/ingestion/npm.py
+++ b/oasisagent/ingestion/npm.py
@@ -1,0 +1,387 @@
+"""Nginx Proxy Manager polling ingestion adapter.
+
+Polls the NPM API for proxy host status, certificate expiry, and dead
+hosts. Emits events on state transitions or threshold crossings.
+
+Three separate polling paths:
+- Proxy hosts: state-based dedup (host_id -> enabled + forwarding status)
+- Certificates: threshold-based (days until expiry)
+- Dead hosts: point-in-time dedup (set of dead host IDs)
+"""
+
+from __future__ import annotations
+
+import asyncio
+import logging
+from datetime import UTC, datetime
+from typing import TYPE_CHECKING, Any
+
+from oasisagent.clients.npm import NpmClient
+from oasisagent.ingestion.base import IngestAdapter
+from oasisagent.models import Event, EventMetadata, Severity
+
+if TYPE_CHECKING:
+    from oasisagent.config import NpmAdapterConfig
+    from oasisagent.engine.queue import EventQueue
+
+logger = logging.getLogger(__name__)
+
+
+class NpmAdapter(IngestAdapter):
+    """Polls Nginx Proxy Manager for proxy host health, certs, and dead hosts.
+
+    Per-endpoint health isolation ensures one failing endpoint does not
+    mark the entire adapter as unhealthy.
+    """
+
+    def __init__(
+        self, config: NpmAdapterConfig, queue: EventQueue,
+    ) -> None:
+        super().__init__(queue)
+        self._config = config
+        self._client = NpmClient(
+            url=config.url,
+            email=config.email,
+            password=config.password,
+            timeout=config.timeout,
+        )
+        self._stopping = False
+        self._task: asyncio.Task[None] | None = None
+
+        # Per-endpoint health tracking
+        self._endpoint_health: dict[str, bool] = {}
+        if self._config.poll_proxy_hosts:
+            self._endpoint_health["proxy_hosts"] = False
+        if self._config.poll_certificates:
+            self._endpoint_health["certificates"] = False
+        if self._config.poll_dead_hosts:
+            self._endpoint_health["dead_hosts"] = False
+
+        # Dedup trackers
+        # host_id -> "online" | "erroring" | "disabled"
+        self._host_states: dict[int, str] = {}
+        # cert_id -> "ok" | "warning" | "critical"
+        self._cert_alert_state: dict[int, str] = {}
+        # set of dead host IDs currently tracked
+        self._seen_dead_hosts: set[int] = set()
+
+    @property
+    def name(self) -> str:
+        return "npm"
+
+    async def start(self) -> None:
+        """Connect to NPM API and start the polling loop."""
+        try:
+            await self._client.connect()
+        except Exception as exc:
+            logger.error("NPM adapter: connection failed: %s", exc)
+            return
+
+        self._task = asyncio.create_task(
+            self._poll_loop(), name="npm-poller",
+        )
+        await self._task
+
+    async def stop(self) -> None:
+        self._stopping = True
+        if self._task is not None:
+            self._task.cancel()
+        await self._client.close()
+        for key in self._endpoint_health:
+            self._endpoint_health[key] = False
+
+    async def healthy(self) -> bool:
+        if not self._endpoint_health:
+            return False
+        return any(self._endpoint_health.values())
+
+    def health_detail(self) -> dict[str, str]:
+        """Per-endpoint health for dashboard display."""
+        return {
+            endpoint: ("connected" if ok else "disconnected")
+            for endpoint, ok in self._endpoint_health.items()
+        }
+
+    # -----------------------------------------------------------------
+    # Poll loop
+    # -----------------------------------------------------------------
+
+    async def _poll_loop(self) -> None:
+        """Main polling loop -- polls all enabled endpoints each interval."""
+        while not self._stopping:
+            if self._config.poll_proxy_hosts:
+                try:
+                    await self._poll_proxy_hosts()
+                    self._endpoint_health["proxy_hosts"] = True
+                except asyncio.CancelledError:
+                    return
+                except Exception as exc:
+                    logger.warning("NPM proxy hosts poll error: %s", exc)
+                    self._endpoint_health["proxy_hosts"] = False
+
+            if self._config.poll_certificates:
+                try:
+                    await self._poll_certificates()
+                    self._endpoint_health["certificates"] = True
+                except asyncio.CancelledError:
+                    return
+                except Exception as exc:
+                    logger.warning("NPM certificates poll error: %s", exc)
+                    self._endpoint_health["certificates"] = False
+
+            if self._config.poll_dead_hosts:
+                try:
+                    await self._poll_dead_hosts()
+                    self._endpoint_health["dead_hosts"] = True
+                except asyncio.CancelledError:
+                    return
+                except Exception as exc:
+                    logger.warning("NPM dead hosts poll error: %s", exc)
+                    self._endpoint_health["dead_hosts"] = False
+
+            for _ in range(self._config.poll_interval):
+                if self._stopping:
+                    return
+                await asyncio.sleep(1)
+
+    # -----------------------------------------------------------------
+    # Proxy host polling
+    # -----------------------------------------------------------------
+
+    async def _poll_proxy_hosts(self) -> None:
+        """Poll proxy host status for state transitions."""
+        data = await self._client.get("/api/nginx/proxy-hosts")
+        hosts: list[dict[str, Any]] = data if isinstance(data, list) else []
+
+        for host in hosts:
+            host_id = host.get("id")
+            if host_id is None:
+                continue
+
+            enabled = host.get("enabled", 1)
+            # NPM sets forward_host/forward_port; online_status is not a
+            # native field, but enabled=0 means disabled, and error fields
+            # or certificate_id=0 may indicate issues.
+            domain_names = host.get("domain_names", [])
+            entity = domain_names[0] if domain_names else str(host_id)
+
+            # Determine current status
+            current = "disabled" if not enabled else "online"
+
+            prev = self._host_states.get(host_id)
+            self._host_states[host_id] = current
+
+            if prev is not None and prev != current:
+                if current == "disabled":
+                    self._enqueue(Event(
+                        source=self.name,
+                        system="npm",
+                        event_type="npm_proxy_host_error",
+                        entity_id=entity,
+                        severity=Severity.WARNING,
+                        timestamp=datetime.now(tz=UTC),
+                        payload={
+                            "host_id": host_id,
+                            "domain_names": domain_names,
+                            "status": current,
+                            "previous_status": prev,
+                        },
+                        metadata=EventMetadata(
+                            dedup_key=f"npm:proxy_host:{host_id}:status",
+                        ),
+                    ))
+                elif prev != "online":
+                    self._enqueue(Event(
+                        source=self.name,
+                        system="npm",
+                        event_type="npm_proxy_host_recovered",
+                        entity_id=entity,
+                        severity=Severity.INFO,
+                        timestamp=datetime.now(tz=UTC),
+                        payload={
+                            "host_id": host_id,
+                            "domain_names": domain_names,
+                            "status": current,
+                            "previous_status": prev,
+                        },
+                        metadata=EventMetadata(
+                            dedup_key=f"npm:proxy_host:{host_id}:status",
+                        ),
+                    ))
+            elif prev is None and current != "online":
+                # First poll, host already in error state
+                self._enqueue(Event(
+                    source=self.name,
+                    system="npm",
+                    event_type="npm_proxy_host_error",
+                    entity_id=entity,
+                    severity=Severity.WARNING,
+                    timestamp=datetime.now(tz=UTC),
+                    payload={
+                        "host_id": host_id,
+                        "domain_names": domain_names,
+                        "status": current,
+                    },
+                    metadata=EventMetadata(
+                        dedup_key=f"npm:proxy_host:{host_id}:status",
+                    ),
+                ))
+
+        # Evict removed hosts to prevent unbounded growth
+        current_ids = {h.get("id") for h in hosts} - {None}
+        self._host_states = {
+            k: v for k, v in self._host_states.items() if k in current_ids
+        }
+
+    # -----------------------------------------------------------------
+    # Certificate polling
+    # -----------------------------------------------------------------
+
+    async def _poll_certificates(self) -> None:
+        """Poll certificates for expiry threshold crossings."""
+        data = await self._client.get("/api/nginx/certificates")
+        certs: list[dict[str, Any]] = data if isinstance(data, list) else []
+
+        for cert in certs:
+            cert_id = cert.get("id")
+            if cert_id is None:
+                continue
+
+            expires_on = cert.get("expires_on", "")
+            if not expires_on:
+                continue
+
+            try:
+                expiry = datetime.fromisoformat(
+                    expires_on.replace("Z", "+00:00"),
+                )
+            except ValueError:
+                continue
+
+            days_remaining = (expiry - datetime.now(tz=UTC)).days
+            domain_names = cert.get("domain_names", [])
+            entity = domain_names[0] if domain_names else str(cert_id)
+            nice_name = cert.get("nice_name", entity)
+
+            self._check_cert_expiry(cert_id, entity, nice_name, days_remaining, domain_names)
+
+    def _check_cert_expiry(
+        self,
+        cert_id: int,
+        entity: str,
+        nice_name: str,
+        days_remaining: int,
+        domain_names: list[str],
+    ) -> None:
+        """Emit events on certificate expiry threshold transitions."""
+        if days_remaining <= self._config.cert_critical_days:
+            new_state = "critical"
+            severity = Severity.ERROR
+        elif days_remaining <= self._config.cert_warning_days:
+            new_state = "warning"
+            severity = Severity.WARNING
+        else:
+            new_state = "ok"
+            severity = Severity.INFO  # only used if recovering
+
+        prev_state = self._cert_alert_state.get(cert_id, "ok")
+        self._cert_alert_state[cert_id] = new_state
+
+        if new_state == prev_state:
+            return
+
+        if new_state in ("warning", "critical"):
+            self._enqueue(Event(
+                source=self.name,
+                system="npm",
+                event_type="npm_certificate_expiring",
+                entity_id=entity,
+                severity=severity,
+                timestamp=datetime.now(tz=UTC),
+                payload={
+                    "cert_id": cert_id,
+                    "nice_name": nice_name,
+                    "domain_names": domain_names,
+                    "days_remaining": days_remaining,
+                    "level": new_state,
+                },
+                metadata=EventMetadata(
+                    dedup_key=f"npm:cert:{cert_id}:expiry",
+                ),
+            ))
+        elif prev_state in ("warning", "critical"):
+            # Certificate renewed
+            self._enqueue(Event(
+                source=self.name,
+                system="npm",
+                event_type="npm_certificate_renewed",
+                entity_id=entity,
+                severity=Severity.INFO,
+                timestamp=datetime.now(tz=UTC),
+                payload={
+                    "cert_id": cert_id,
+                    "nice_name": nice_name,
+                    "domain_names": domain_names,
+                    "days_remaining": days_remaining,
+                },
+                metadata=EventMetadata(
+                    dedup_key=f"npm:cert:{cert_id}:expiry",
+                ),
+            ))
+
+    # -----------------------------------------------------------------
+    # Dead host polling
+    # -----------------------------------------------------------------
+
+    async def _poll_dead_hosts(self) -> None:
+        """Poll dead hosts for new entries."""
+        data = await self._client.get("/api/nginx/dead-hosts")
+        dead_hosts: list[dict[str, Any]] = data if isinstance(data, list) else []
+
+        current_dead_ids: set[int] = set()
+
+        for host in dead_hosts:
+            host_id = host.get("id")
+            if host_id is None:
+                continue
+
+            current_dead_ids.add(host_id)
+
+            if host_id in self._seen_dead_hosts:
+                continue
+
+            domain_names = host.get("domain_names", [])
+            entity = domain_names[0] if domain_names else str(host_id)
+
+            self._enqueue(Event(
+                source=self.name,
+                system="npm",
+                event_type="npm_dead_host_detected",
+                entity_id=entity,
+                severity=Severity.WARNING,
+                timestamp=datetime.now(tz=UTC),
+                payload={
+                    "host_id": host_id,
+                    "domain_names": domain_names,
+                },
+                metadata=EventMetadata(
+                    dedup_key=f"npm:dead_host:{host_id}",
+                ),
+            ))
+
+        # Evict cleared dead hosts to prevent unbounded growth
+        self._seen_dead_hosts = current_dead_ids
+
+    # -----------------------------------------------------------------
+    # Helpers
+    # -----------------------------------------------------------------
+
+    def _enqueue(self, event: Event) -> None:
+        """Enqueue an event, logging on failure."""
+        try:
+            self._queue.put_nowait(event)
+        except Exception:
+            logger.warning(
+                "NPM adapter: failed to enqueue event: %s/%s",
+                event.system, event.event_type,
+            )

--- a/oasisagent/ui/form_specs.py
+++ b/oasisagent/ui/form_specs.py
@@ -45,6 +45,7 @@ TYPE_DISPLAY_NAMES: dict[str, str] = {
     "unifi": "UniFi Network",
     "cloudflare": "Cloudflare",
     "uptime_kuma": "Uptime Kuma",
+    "npm": "Nginx Proxy Manager",
     "servarr": "Servarr (Sonarr/Radarr/Prowlarr/Bazarr)",
     "qbittorrent": "qBittorrent",
     "plex": "Plex Media Server",
@@ -97,6 +98,10 @@ TYPE_DESCRIPTIONS: dict[str, str] = {
     "uptime_kuma": (
         "Pull monitor status from Uptime Kuma's"
         " Prometheus endpoint"
+    ),
+    "npm": (
+        "Monitor Nginx Proxy Manager proxy hosts,"
+        " certificates, and dead hosts"
     ),
     "servarr": (
         "Monitor Sonarr, Radarr, Prowlarr, or Bazarr"
@@ -573,6 +578,62 @@ FORM_SPECS: dict[str, list[FieldSpec]] = {
                 " within N days"
             ),
             default=7, min_val=1,
+        ),
+    ],
+
+    "npm": [
+        FieldSpec(
+            "url", "NPM URL", "text",
+            help_text="e.g. http://192.168.1.50:81",
+            required=True,
+        ),
+        FieldSpec(
+            "email", "Admin Email", "text",
+            help_text="NPM admin login email",
+            required=True, group="Authentication",
+        ),
+        FieldSpec(
+            "password", "Password", "password",
+            help_text="NPM admin login password",
+            required=True, group="Authentication",
+        ),
+        FieldSpec(
+            "poll_interval", "Poll Interval (seconds)",
+            "number", default=300,
+        ),
+        FieldSpec(
+            "poll_proxy_hosts", "Poll Proxy Hosts",
+            "checkbox", default=True, group="Polling",
+        ),
+        FieldSpec(
+            "poll_certificates", "Poll Certificates",
+            "checkbox", default=True, group="Polling",
+        ),
+        FieldSpec(
+            "poll_dead_hosts", "Poll Dead Hosts",
+            "checkbox", default=True, group="Polling",
+        ),
+        FieldSpec(
+            "cert_warning_days",
+            "Cert Warning (days)", "number",
+            help_text=(
+                "Warn when certificate expires"
+                " within N days"
+            ),
+            default=14, min_val=1,
+        ),
+        FieldSpec(
+            "cert_critical_days",
+            "Cert Critical (days)", "number",
+            help_text=(
+                "Alert when certificate expires"
+                " within N days"
+            ),
+            default=7, min_val=1,
+        ),
+        FieldSpec(
+            "timeout", "Request Timeout (seconds)",
+            "number", default=10, min_val=1,
         ),
     ],
 

--- a/tests/test_clients/test_npm_client.py
+++ b/tests/test_clients/test_npm_client.py
@@ -1,0 +1,148 @@
+"""Tests for the Nginx Proxy Manager API client."""
+
+from __future__ import annotations
+
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import aiohttp
+import pytest
+
+from oasisagent.clients.npm import NpmClient
+
+
+@pytest.fixture
+def client() -> NpmClient:
+    return NpmClient(
+        url="http://npm.local:81",
+        email="admin@example.com",
+        password="secret",
+        timeout=5,
+    )
+
+
+class TestLifecycle:
+    @pytest.mark.asyncio
+    async def test_connect_authenticates(self, client: NpmClient) -> None:
+        mock_session = AsyncMock()
+        mock_resp = AsyncMock()
+        mock_resp.status = 200
+        mock_resp.json = AsyncMock(return_value={"token": "jwt-abc"})
+        mock_resp.__aenter__ = AsyncMock(return_value=mock_resp)
+        mock_resp.__aexit__ = AsyncMock(return_value=False)
+        mock_session.post = MagicMock(return_value=mock_resp)
+
+        with patch("oasisagent.clients.npm.aiohttp.ClientSession", return_value=mock_session):
+            await client.connect()
+
+        assert client._token == "jwt-abc"
+
+    @pytest.mark.asyncio
+    async def test_connect_failure_raises(self, client: NpmClient) -> None:
+        mock_session = AsyncMock()
+        mock_resp = AsyncMock()
+        mock_resp.status = 401
+        mock_resp.text = AsyncMock(return_value="bad creds")
+        mock_resp.__aenter__ = AsyncMock(return_value=mock_resp)
+        mock_resp.__aexit__ = AsyncMock(return_value=False)
+        mock_session.post = MagicMock(return_value=mock_resp)
+
+        with (
+            patch("oasisagent.clients.npm.aiohttp.ClientSession", return_value=mock_session),
+            pytest.raises(ConnectionError, match="NPM login failed"),
+        ):
+            await client.connect()
+
+    @pytest.mark.asyncio
+    async def test_close_clears_state(self, client: NpmClient) -> None:
+        client._session = AsyncMock()
+        client._token = "jwt-abc"
+        await client.close()
+        assert client._session is None
+        assert client._token is None
+
+
+class TestGet:
+    @pytest.mark.asyncio
+    async def test_get_not_connected_raises(self, client: NpmClient) -> None:
+        with pytest.raises(RuntimeError, match="not connected"):
+            await client.get("/api/nginx/proxy-hosts")
+
+    @pytest.mark.asyncio
+    async def test_get_success(self, client: NpmClient) -> None:
+        client._session = AsyncMock()
+        client._token = "jwt-abc"
+
+        mock_resp = AsyncMock()
+        mock_resp.status = 200
+        mock_resp.json = AsyncMock(return_value=[{"id": 1}])
+        mock_resp.__aenter__ = AsyncMock(return_value=mock_resp)
+        mock_resp.__aexit__ = AsyncMock(return_value=False)
+        client._session.get = MagicMock(return_value=mock_resp)
+
+        result = await client.get("/api/nginx/proxy-hosts")
+        assert result == [{"id": 1}]
+
+    @pytest.mark.asyncio
+    async def test_get_401_retries_with_new_token(self, client: NpmClient) -> None:
+        client._session = AsyncMock()
+        client._token = "old-token"
+
+        # First call returns 401
+        mock_resp_401 = AsyncMock()
+        mock_resp_401.status = 401
+        mock_resp_401.__aenter__ = AsyncMock(return_value=mock_resp_401)
+        mock_resp_401.__aexit__ = AsyncMock(return_value=False)
+
+        # Re-auth response
+        mock_auth_resp = AsyncMock()
+        mock_auth_resp.status = 200
+        mock_auth_resp.json = AsyncMock(return_value={"token": "new-token"})
+        mock_auth_resp.__aenter__ = AsyncMock(return_value=mock_auth_resp)
+        mock_auth_resp.__aexit__ = AsyncMock(return_value=False)
+
+        # Retry response
+        mock_resp_200 = AsyncMock()
+        mock_resp_200.status = 200
+        mock_resp_200.json = AsyncMock(return_value=[{"id": 1}])
+        mock_resp_200.__aenter__ = AsyncMock(return_value=mock_resp_200)
+        mock_resp_200.__aexit__ = AsyncMock(return_value=False)
+
+        # get returns 401 first, then 200 on retry
+        client._session.get = MagicMock(
+            side_effect=[mock_resp_401, mock_resp_200],
+        )
+        client._session.post = MagicMock(return_value=mock_auth_resp)
+
+        result = await client.get("/api/nginx/proxy-hosts")
+        assert result == [{"id": 1}]
+        assert client._token == "new-token"
+
+    @pytest.mark.asyncio
+    async def test_get_error_raises(self, client: NpmClient) -> None:
+        client._session = AsyncMock()
+        client._token = "jwt-abc"
+
+        mock_resp = AsyncMock()
+        mock_resp.status = 500
+        mock_resp.text = AsyncMock(return_value="Internal error")
+        mock_resp.json = AsyncMock(return_value={"error": "fail"})
+        mock_resp.request_info = MagicMock()
+        mock_resp.history = ()
+        mock_resp.__aenter__ = AsyncMock(return_value=mock_resp)
+        mock_resp.__aexit__ = AsyncMock(return_value=False)
+        client._session.get = MagicMock(return_value=mock_resp)
+
+        with pytest.raises(aiohttp.ClientResponseError):
+            await client.get("/api/nginx/proxy-hosts")
+
+
+class TestAuthHeaders:
+    def test_auth_headers_with_token(self, client: NpmClient) -> None:
+        client._token = "my-jwt"
+        headers = client._auth_headers()
+        assert headers == {"Authorization": "Bearer my-jwt"}
+
+    def test_auth_headers_without_token(self, client: NpmClient) -> None:
+        client._token = None
+        headers = client._auth_headers()
+        assert headers == {}

--- a/tests/test_ingestion/test_npm.py
+++ b/tests/test_ingestion/test_npm.py
@@ -1,0 +1,670 @@
+"""Tests for the Nginx Proxy Manager polling ingestion adapter."""
+
+from __future__ import annotations
+
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+from pydantic import ValidationError
+
+from oasisagent.config import NpmAdapterConfig
+from oasisagent.ingestion.npm import NpmAdapter
+from oasisagent.models import Severity
+
+
+def _make_config(**overrides: object) -> NpmAdapterConfig:
+    defaults: dict[str, object] = {
+        "enabled": True,
+        "url": "http://npm.local:81",
+        "email": "admin@example.com",
+        "password": "secret",
+        "poll_interval": 300,
+        "poll_proxy_hosts": True,
+        "poll_certificates": True,
+        "poll_dead_hosts": True,
+        "cert_warning_days": 14,
+        "cert_critical_days": 7,
+        "timeout": 10,
+    }
+    defaults.update(overrides)
+    return NpmAdapterConfig(**defaults)  # type: ignore[arg-type]
+
+
+def _mock_queue() -> MagicMock:
+    return MagicMock()
+
+
+def _make_adapter(
+    **overrides: object,
+) -> tuple[NpmAdapter, MagicMock]:
+    config = _make_config(**overrides)
+    queue = _mock_queue()
+    with patch("oasisagent.ingestion.npm.NpmClient"):
+        adapter = NpmAdapter(config, queue)
+    return adapter, queue
+
+
+# ---------------------------------------------------------------------------
+# Config validation
+# ---------------------------------------------------------------------------
+
+
+class TestConfigValidation:
+    def test_defaults(self) -> None:
+        config = NpmAdapterConfig()
+        assert config.enabled is False
+        assert config.poll_interval == 300
+        assert config.poll_proxy_hosts is True
+        assert config.poll_certificates is True
+        assert config.poll_dead_hosts is True
+        assert config.cert_warning_days == 14
+        assert config.cert_critical_days == 7
+
+    def test_extra_fields_forbidden(self) -> None:
+        with pytest.raises(ValidationError, match="Extra inputs"):
+            _make_config(bogus="nope")
+
+
+# ---------------------------------------------------------------------------
+# Adapter identity & lifecycle
+# ---------------------------------------------------------------------------
+
+
+class TestAdapterLifecycle:
+    def test_name(self) -> None:
+        adapter, _ = _make_adapter()
+        assert adapter.name == "npm"
+
+    @pytest.mark.asyncio
+    async def test_healthy_initially_false(self) -> None:
+        adapter, _ = _make_adapter()
+        assert not await adapter.healthy()
+
+    @pytest.mark.asyncio
+    async def test_stop_sets_flag(self) -> None:
+        adapter, _ = _make_adapter()
+        adapter._client = AsyncMock()
+        await adapter.stop()
+        assert adapter._stopping is True
+        assert all(v is False for v in adapter._endpoint_health.values())
+
+    @pytest.mark.asyncio
+    async def test_start_connection_failure(self) -> None:
+        adapter, _ = _make_adapter()
+        adapter._client.connect = AsyncMock(
+            side_effect=ConnectionError("refused"),
+        )
+        await adapter.start()
+        assert not await adapter.healthy()
+
+
+# ---------------------------------------------------------------------------
+# Per-endpoint health tracking
+# ---------------------------------------------------------------------------
+
+
+class TestEndpointHealth:
+    def test_endpoint_health_initial_state(self) -> None:
+        """All endpoints start False before first poll."""
+        adapter, _ = _make_adapter()
+        assert adapter._endpoint_health == {
+            "proxy_hosts": False,
+            "certificates": False,
+            "dead_hosts": False,
+        }
+
+    @pytest.mark.asyncio
+    async def test_healthy_any_endpoint_up(self) -> None:
+        adapter, _ = _make_adapter()
+        adapter._endpoint_health["proxy_hosts"] = True
+        adapter._endpoint_health["certificates"] = False
+        assert await adapter.healthy() is True
+
+    @pytest.mark.asyncio
+    async def test_healthy_all_endpoints_down(self) -> None:
+        adapter, _ = _make_adapter()
+        assert await adapter.healthy() is False
+
+    @pytest.mark.asyncio
+    async def test_healthy_no_endpoints_enabled(self) -> None:
+        adapter, _ = _make_adapter(
+            poll_proxy_hosts=False,
+            poll_certificates=False,
+            poll_dead_hosts=False,
+        )
+        assert adapter._endpoint_health == {}
+        assert await adapter.healthy() is False
+
+    def test_health_detail_returns_per_endpoint_status(self) -> None:
+        adapter, _ = _make_adapter()
+        adapter._endpoint_health["proxy_hosts"] = True
+        adapter._endpoint_health["certificates"] = False
+        adapter._endpoint_health["dead_hosts"] = True
+
+        detail = adapter.health_detail()
+        assert detail == {
+            "proxy_hosts": "connected",
+            "certificates": "disconnected",
+            "dead_hosts": "connected",
+        }
+
+    @pytest.mark.asyncio
+    async def test_poll_proxy_hosts_failure_isolates_others(self) -> None:
+        """Proxy host failure does not affect certs or dead hosts health."""
+        adapter, _ = _make_adapter()
+
+        async def _fail_proxy_hosts() -> None:
+            msg = "proxy timeout"
+            raise RuntimeError(msg)
+
+        adapter._poll_proxy_hosts = _fail_proxy_hosts  # type: ignore[method-assign]
+        adapter._poll_certificates = AsyncMock()  # type: ignore[method-assign]
+        adapter._poll_dead_hosts = AsyncMock()  # type: ignore[method-assign]
+
+        adapter._stopping = False
+
+        async def _stop_after_one(*_args: object, **_kwargs: object) -> None:
+            adapter._stopping = True
+
+        with patch("asyncio.sleep", new=_stop_after_one):
+            await adapter._poll_loop()
+
+        assert adapter._endpoint_health["proxy_hosts"] is False
+        assert adapter._endpoint_health["certificates"] is True
+        assert adapter._endpoint_health["dead_hosts"] is True
+
+    @pytest.mark.asyncio
+    async def test_stop_clears_endpoint_health(self) -> None:
+        adapter, _ = _make_adapter()
+        adapter._endpoint_health["proxy_hosts"] = True
+        adapter._endpoint_health["certificates"] = True
+        adapter._endpoint_health["dead_hosts"] = True
+
+        adapter._client = AsyncMock()
+        await adapter.stop()
+
+        assert all(v is False for v in adapter._endpoint_health.values())
+
+
+# ---------------------------------------------------------------------------
+# Proxy host polling
+# ---------------------------------------------------------------------------
+
+
+class TestProxyHostPolling:
+    @pytest.mark.asyncio
+    async def test_host_disabled_event(self) -> None:
+        adapter, queue = _make_adapter()
+        adapter._host_states[1] = "online"
+
+        adapter._client.get = AsyncMock(return_value=[{
+            "id": 1,
+            "enabled": 0,
+            "domain_names": ["app.shearer.live"],
+        }])
+
+        await adapter._poll_proxy_hosts()
+
+        queue.put_nowait.assert_called_once()
+        event = queue.put_nowait.call_args[0][0]
+        assert event.event_type == "npm_proxy_host_error"
+        assert event.severity == Severity.WARNING
+        assert event.entity_id == "app.shearer.live"
+        assert event.payload["status"] == "disabled"
+        assert event.payload["previous_status"] == "online"
+
+    @pytest.mark.asyncio
+    async def test_host_recovery_event(self) -> None:
+        adapter, queue = _make_adapter()
+        adapter._host_states[1] = "disabled"
+
+        adapter._client.get = AsyncMock(return_value=[{
+            "id": 1,
+            "enabled": 1,
+            "domain_names": ["app.shearer.live"],
+        }])
+
+        await adapter._poll_proxy_hosts()
+
+        queue.put_nowait.assert_called_once()
+        event = queue.put_nowait.call_args[0][0]
+        assert event.event_type == "npm_proxy_host_recovered"
+        assert event.severity == Severity.INFO
+
+    @pytest.mark.asyncio
+    async def test_same_status_no_event(self) -> None:
+        adapter, queue = _make_adapter()
+        adapter._host_states[1] = "online"
+
+        adapter._client.get = AsyncMock(return_value=[{
+            "id": 1,
+            "enabled": 1,
+            "domain_names": ["app.shearer.live"],
+        }])
+
+        await adapter._poll_proxy_hosts()
+        queue.put_nowait.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_first_poll_online_no_event(self) -> None:
+        adapter, queue = _make_adapter()
+
+        adapter._client.get = AsyncMock(return_value=[{
+            "id": 1,
+            "enabled": 1,
+            "domain_names": ["app.shearer.live"],
+        }])
+
+        await adapter._poll_proxy_hosts()
+        queue.put_nowait.assert_not_called()
+        assert adapter._host_states[1] == "online"
+
+    @pytest.mark.asyncio
+    async def test_first_poll_disabled_emits(self) -> None:
+        adapter, queue = _make_adapter()
+
+        adapter._client.get = AsyncMock(return_value=[{
+            "id": 1,
+            "enabled": 0,
+            "domain_names": ["app.shearer.live"],
+        }])
+
+        await adapter._poll_proxy_hosts()
+
+        queue.put_nowait.assert_called_once()
+        event = queue.put_nowait.call_args[0][0]
+        assert event.event_type == "npm_proxy_host_error"
+
+    @pytest.mark.asyncio
+    async def test_host_dedup_key(self) -> None:
+        adapter, queue = _make_adapter()
+        adapter._host_states[1] = "online"
+
+        adapter._client.get = AsyncMock(return_value=[{
+            "id": 1,
+            "enabled": 0,
+            "domain_names": ["app.shearer.live"],
+        }])
+
+        await adapter._poll_proxy_hosts()
+
+        event = queue.put_nowait.call_args[0][0]
+        assert event.metadata.dedup_key == "npm:proxy_host:1:status"
+
+    @pytest.mark.asyncio
+    async def test_removed_host_evicted_from_tracker(self) -> None:
+        adapter, _queue = _make_adapter()
+        adapter._host_states = {1: "online", 2: "online"}
+
+        adapter._client.get = AsyncMock(return_value=[{
+            "id": 1,
+            "enabled": 1,
+            "domain_names": ["app.shearer.live"],
+        }])
+
+        await adapter._poll_proxy_hosts()
+
+        assert 1 in adapter._host_states
+        assert 2 not in adapter._host_states
+
+    @pytest.mark.asyncio
+    async def test_no_domain_names_uses_host_id(self) -> None:
+        adapter, queue = _make_adapter()
+
+        adapter._client.get = AsyncMock(return_value=[{
+            "id": 42,
+            "enabled": 0,
+            "domain_names": [],
+        }])
+
+        await adapter._poll_proxy_hosts()
+
+        event = queue.put_nowait.call_args[0][0]
+        assert event.entity_id == "42"
+
+
+# ---------------------------------------------------------------------------
+# Certificate polling
+# ---------------------------------------------------------------------------
+
+
+class TestCertificatePolling:
+    @pytest.mark.asyncio
+    async def test_cert_warning_event(self) -> None:
+        from datetime import UTC, datetime, timedelta
+
+        adapter, queue = _make_adapter()
+        expires = datetime.now(tz=UTC) + timedelta(days=10)
+
+        adapter._client.get = AsyncMock(return_value=[{
+            "id": 1,
+            "domain_names": ["app.shearer.live"],
+            "nice_name": "App Cert",
+            "expires_on": expires.strftime("%Y-%m-%dT%H:%M:%SZ"),
+        }])
+
+        await adapter._poll_certificates()
+
+        queue.put_nowait.assert_called_once()
+        event = queue.put_nowait.call_args[0][0]
+        assert event.event_type == "npm_certificate_expiring"
+        assert event.severity == Severity.WARNING
+        assert event.entity_id == "app.shearer.live"
+        assert event.payload["level"] == "warning"
+        assert event.payload["nice_name"] == "App Cert"
+
+    @pytest.mark.asyncio
+    async def test_cert_critical_event(self) -> None:
+        from datetime import UTC, datetime, timedelta
+
+        adapter, queue = _make_adapter()
+        expires = datetime.now(tz=UTC) + timedelta(days=3)
+
+        adapter._client.get = AsyncMock(return_value=[{
+            "id": 1,
+            "domain_names": ["app.shearer.live"],
+            "nice_name": "App Cert",
+            "expires_on": expires.strftime("%Y-%m-%dT%H:%M:%SZ"),
+        }])
+
+        await adapter._poll_certificates()
+
+        queue.put_nowait.assert_called_once()
+        event = queue.put_nowait.call_args[0][0]
+        assert event.severity == Severity.ERROR
+        assert event.payload["level"] == "critical"
+
+    @pytest.mark.asyncio
+    async def test_cert_ok_no_event(self) -> None:
+        from datetime import UTC, datetime, timedelta
+
+        adapter, queue = _make_adapter()
+        expires = datetime.now(tz=UTC) + timedelta(days=90)
+
+        adapter._client.get = AsyncMock(return_value=[{
+            "id": 1,
+            "domain_names": ["app.shearer.live"],
+            "nice_name": "App Cert",
+            "expires_on": expires.strftime("%Y-%m-%dT%H:%M:%SZ"),
+        }])
+
+        await adapter._poll_certificates()
+        queue.put_nowait.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_cert_renewed_event(self) -> None:
+        from datetime import UTC, datetime, timedelta
+
+        adapter, queue = _make_adapter()
+        adapter._cert_alert_state[1] = "warning"
+        expires = datetime.now(tz=UTC) + timedelta(days=90)
+
+        adapter._client.get = AsyncMock(return_value=[{
+            "id": 1,
+            "domain_names": ["app.shearer.live"],
+            "nice_name": "App Cert",
+            "expires_on": expires.strftime("%Y-%m-%dT%H:%M:%SZ"),
+        }])
+
+        await adapter._poll_certificates()
+
+        queue.put_nowait.assert_called_once()
+        event = queue.put_nowait.call_args[0][0]
+        assert event.event_type == "npm_certificate_renewed"
+        assert event.severity == Severity.INFO
+
+    @pytest.mark.asyncio
+    async def test_cert_same_state_no_duplicate(self) -> None:
+        from datetime import UTC, datetime, timedelta
+
+        adapter, queue = _make_adapter()
+        adapter._cert_alert_state[1] = "warning"
+        expires = datetime.now(tz=UTC) + timedelta(days=10)
+
+        adapter._client.get = AsyncMock(return_value=[{
+            "id": 1,
+            "domain_names": ["app.shearer.live"],
+            "nice_name": "App Cert",
+            "expires_on": expires.strftime("%Y-%m-%dT%H:%M:%SZ"),
+        }])
+
+        await adapter._poll_certificates()
+        queue.put_nowait.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_cert_warning_to_critical_transition(self) -> None:
+        from datetime import UTC, datetime, timedelta
+
+        adapter, queue = _make_adapter()
+        adapter._cert_alert_state[1] = "warning"
+        expires = datetime.now(tz=UTC) + timedelta(days=3)
+
+        adapter._client.get = AsyncMock(return_value=[{
+            "id": 1,
+            "domain_names": ["app.shearer.live"],
+            "nice_name": "App Cert",
+            "expires_on": expires.strftime("%Y-%m-%dT%H:%M:%SZ"),
+        }])
+
+        await adapter._poll_certificates()
+
+        queue.put_nowait.assert_called_once()
+        event = queue.put_nowait.call_args[0][0]
+        assert event.severity == Severity.ERROR
+        assert event.payload["level"] == "critical"
+
+    @pytest.mark.asyncio
+    async def test_cert_dedup_key(self) -> None:
+        from datetime import UTC, datetime, timedelta
+
+        adapter, queue = _make_adapter()
+        expires = datetime.now(tz=UTC) + timedelta(days=5)
+
+        adapter._client.get = AsyncMock(return_value=[{
+            "id": 42,
+            "domain_names": ["my.domain.com"],
+            "nice_name": "My Cert",
+            "expires_on": expires.strftime("%Y-%m-%dT%H:%M:%SZ"),
+        }])
+
+        await adapter._poll_certificates()
+
+        event = queue.put_nowait.call_args[0][0]
+        assert event.metadata.dedup_key == "npm:cert:42:expiry"
+
+
+# ---------------------------------------------------------------------------
+# Dead host polling
+# ---------------------------------------------------------------------------
+
+
+class TestDeadHostPolling:
+    @pytest.mark.asyncio
+    async def test_new_dead_host_emits_event(self) -> None:
+        adapter, queue = _make_adapter()
+
+        adapter._client.get = AsyncMock(return_value=[{
+            "id": 1,
+            "domain_names": ["dead.shearer.live"],
+        }])
+
+        await adapter._poll_dead_hosts()
+
+        queue.put_nowait.assert_called_once()
+        event = queue.put_nowait.call_args[0][0]
+        assert event.event_type == "npm_dead_host_detected"
+        assert event.severity == Severity.WARNING
+        assert event.entity_id == "dead.shearer.live"
+        assert event.payload["host_id"] == 1
+
+    @pytest.mark.asyncio
+    async def test_seen_dead_host_no_duplicate(self) -> None:
+        adapter, queue = _make_adapter()
+        adapter._seen_dead_hosts = {1}
+
+        adapter._client.get = AsyncMock(return_value=[{
+            "id": 1,
+            "domain_names": ["dead.shearer.live"],
+        }])
+
+        await adapter._poll_dead_hosts()
+        queue.put_nowait.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_cleared_dead_host_evicted(self) -> None:
+        adapter, _queue = _make_adapter()
+        adapter._seen_dead_hosts = {1, 2}
+
+        adapter._client.get = AsyncMock(return_value=[{
+            "id": 1,
+            "domain_names": ["dead.shearer.live"],
+        }])
+
+        await adapter._poll_dead_hosts()
+        assert adapter._seen_dead_hosts == {1}
+
+    @pytest.mark.asyncio
+    async def test_dead_host_dedup_key(self) -> None:
+        adapter, queue = _make_adapter()
+
+        adapter._client.get = AsyncMock(return_value=[{
+            "id": 42,
+            "domain_names": ["dead.example.com"],
+        }])
+
+        await adapter._poll_dead_hosts()
+
+        event = queue.put_nowait.call_args[0][0]
+        assert event.metadata.dedup_key == "npm:dead_host:42"
+
+    @pytest.mark.asyncio
+    async def test_empty_dead_hosts_no_event(self) -> None:
+        adapter, queue = _make_adapter()
+
+        adapter._client.get = AsyncMock(return_value=[])
+
+        await adapter._poll_dead_hosts()
+        queue.put_nowait.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_no_domain_names_uses_host_id(self) -> None:
+        adapter, queue = _make_adapter()
+
+        adapter._client.get = AsyncMock(return_value=[{
+            "id": 99,
+            "domain_names": [],
+        }])
+
+        await adapter._poll_dead_hosts()
+
+        event = queue.put_nowait.call_args[0][0]
+        assert event.entity_id == "99"
+
+
+# ---------------------------------------------------------------------------
+# Enqueue error handling
+# ---------------------------------------------------------------------------
+
+
+class TestEnqueueErrorHandling:
+    def test_enqueue_failure_logged(self) -> None:
+        adapter, queue = _make_adapter()
+        queue.put_nowait.side_effect = RuntimeError("queue full")
+
+        from datetime import UTC, datetime
+
+        from oasisagent.models import Event, EventMetadata
+
+        event = Event(
+            source="npm",
+            system="npm",
+            event_type="test",
+            entity_id="test",
+            severity=Severity.INFO,
+            timestamp=datetime.now(tz=UTC),
+            payload={},
+            metadata=EventMetadata(dedup_key="test"),
+        )
+
+        adapter._enqueue(event)  # should not raise
+
+
+# ---------------------------------------------------------------------------
+# Known fixes YAML
+# ---------------------------------------------------------------------------
+
+
+class TestKnownFixes:
+    def test_known_fixes_file_exists(self) -> None:
+        from pathlib import Path
+
+        import yaml
+
+        fixes_path = (
+            Path(__file__).parent.parent.parent / "known_fixes" / "npm.yaml"
+        )
+        assert fixes_path.exists()
+
+        with fixes_path.open() as f:
+            data = yaml.safe_load(f)
+
+        assert "fixes" in data
+        fixes = data["fixes"]
+        assert len(fixes) >= 3
+
+        for fix in fixes:
+            assert "id" in fix
+            assert "match" in fix
+            assert fix["match"]["system"] == "npm"
+            assert "diagnosis" in fix
+            assert "action" in fix
+            assert "risk_tier" in fix
+
+    def test_known_fix_ids_unique(self) -> None:
+        from pathlib import Path
+
+        import yaml
+
+        fixes_path = (
+            Path(__file__).parent.parent.parent / "known_fixes" / "npm.yaml"
+        )
+        with fixes_path.open() as f:
+            data = yaml.safe_load(f)
+
+        ids = [fix["id"] for fix in data["fixes"]]
+        assert len(ids) == len(set(ids))
+
+    def test_known_fix_event_types_match_adapter(self) -> None:
+        from pathlib import Path
+
+        import yaml
+
+        fixes_path = (
+            Path(__file__).parent.parent.parent / "known_fixes" / "npm.yaml"
+        )
+        with fixes_path.open() as f:
+            data = yaml.safe_load(f)
+
+        expected_types = {
+            "npm_proxy_host_error",
+            "npm_certificate_expiring",
+            "npm_dead_host_detected",
+        }
+
+        fix_types = {fix["match"]["event_type"] for fix in data["fixes"]}
+        assert fix_types == expected_types
+
+
+# ---------------------------------------------------------------------------
+# Registry
+# ---------------------------------------------------------------------------
+
+
+class TestRegistry:
+    def test_npm_connector_registered(self) -> None:
+        from oasisagent.db.registry import CONNECTOR_TYPES
+
+        assert "npm" in CONNECTOR_TYPES
+        meta = CONNECTOR_TYPES["npm"]
+        assert meta.model is NpmAdapterConfig
+        assert "password" in meta.secret_fields


### PR DESCRIPTION
## Summary

- Add `NpmAdapter` ingestion adapter polling NPM for proxy host status, certificate expiry, and dead hosts
- Add `NpmClient` HTTP client with JWT auth and automatic token refresh on 401/403
- Three polling endpoints with per-endpoint health isolation (same pattern as Cloudflare adapter):
  - `_poll_proxy_hosts()` — state-based dedup by host ID, emits `npm_proxy_host_error` / `npm_proxy_host_recovered`
  - `_poll_certificates()` — threshold-based (14d warning, 7d critical), emits `npm_certificate_expiring` / `npm_certificate_renewed`
  - `_poll_dead_hosts()` — point-in-time dedup, emits `npm_dead_host_detected`
- Register `NpmAdapterConfig` in config, registry (password as secret field), and form specs
- Add `known_fixes/npm.yaml` with 3 fix entries (proxy host error, cert expiring, dead host)

Closes #190

## Test plan

- [x] 48 new tests pass (adapter + client)
- [x] Full suite: 2388 tests passing
- [x] `ruff check` clean on all new/modified files
- [ ] Deploy to staging and verify NPM API connectivity
- [ ] Confirm proxy host state changes produce events
- [ ] Confirm certificate expiry thresholds trigger correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)