### PR TITLE
Add Vaultwarden health monitoring adapter (#189)

### DIFF
--- a/known_fixes/vaultwarden.yaml
+++ b/known_fixes/vaultwarden.yaml
@@ -1,0 +1,19 @@
+fixes:
+  - id: vaultwarden-unreachable
+    match:
+      system: vaultwarden
+      event_type: vaultwarden_unreachable
+    diagnosis: "Vaultwarden (Bitwarden) service is unreachable — critical security service down"
+    action:
+      type: escalate
+      handler: homeassistant
+      operation: notify
+      details:
+        message: |
+          Vaultwarden is unreachable — password manager is down. Checklist:
+          1. Check if the Vaultwarden container/service is running
+          2. Verify the host is reachable on the network
+          3. Check for resource exhaustion (disk full, memory)
+          4. Review Vaultwarden container logs for errors
+          5. Verify reverse proxy configuration if applicable
+    risk_tier: escalate

--- a/oasisagent/config.py
+++ b/oasisagent/config.py
@@ -536,6 +536,20 @@ class OverseerrAdapterConfig(BaseModel):
     timeout: int = 10
 
 
+# -- Vaultwarden -------------------------------------------------------------
+
+
+class VaultwardenAdapterConfig(BaseModel):
+    """Vaultwarden (Bitwarden) health-check adapter configuration."""
+
+    model_config = ConfigDict(extra="forbid")
+
+    enabled: bool = False
+    url: str = ""
+    poll_interval: int = 60
+    timeout: int = 10
+
+
 # -- Scanner ----------------------------------------------------------------
 
 
@@ -660,6 +674,9 @@ class IngestionConfig(BaseModel):
     tdarr: TdarrAdapterConfig = Field(default_factory=TdarrAdapterConfig)
     overseerr: OverseerrAdapterConfig = Field(
         default_factory=OverseerrAdapterConfig,
+    )
+    vaultwarden: VaultwardenAdapterConfig = Field(
+        default_factory=VaultwardenAdapterConfig,
     )
 
 

--- a/oasisagent/db/registry.py
+++ b/oasisagent/db/registry.py
@@ -48,6 +48,7 @@ from oasisagent.config import (
     UnifiAdapterConfig,
     UnifiHandlerConfig,
     UptimeKumaAdapterConfig,
+    VaultwardenAdapterConfig,
     WebhookNotificationConfig,
     WebhookSourceConfig,
 )
@@ -120,6 +121,9 @@ CONNECTOR_TYPES: dict[str, TypeMeta] = {
     "overseerr": TypeMeta(
         model=OverseerrAdapterConfig,
         secret_fields=frozenset({"api_key"}),
+    ),
+    "vaultwarden": TypeMeta(
+        model=VaultwardenAdapterConfig,
     ),
 }
 

--- a/oasisagent/ingestion/vaultwarden.py
+++ b/oasisagent/ingestion/vaultwarden.py
@@ -1,0 +1,161 @@
+"""Vaultwarden (Bitwarden) health-check ingestion adapter.
+
+Polls the Vaultwarden ``/alive`` endpoint to detect service outages.
+Vaultwarden is a lightweight Bitwarden-compatible server — its ``/alive``
+endpoint returns HTTP 200 when the service is healthy.
+
+Events emitted on state transitions:
+- ``vaultwarden_unreachable`` (ERROR) when the health check fails
+- ``vaultwarden_recovered`` (INFO) when the service comes back online
+"""
+
+from __future__ import annotations
+
+import asyncio
+import logging
+from datetime import UTC, datetime
+from typing import TYPE_CHECKING
+
+import aiohttp
+
+from oasisagent.ingestion.base import IngestAdapter
+from oasisagent.models import Event, EventMetadata, Severity
+
+if TYPE_CHECKING:
+    from oasisagent.config import VaultwardenAdapterConfig
+    from oasisagent.engine.queue import EventQueue
+
+logger = logging.getLogger(__name__)
+
+
+class VaultwardenAdapter(IngestAdapter):
+    """Polls Vaultwarden's ``/alive`` endpoint for service health.
+
+    State-based dedup ensures events only fire on transitions.
+    """
+
+    def __init__(
+        self, config: VaultwardenAdapterConfig, queue: EventQueue,
+    ) -> None:
+        super().__init__(queue)
+        self._config = config
+        self._stopping = False
+        self._task: asyncio.Task[None] | None = None
+        self._connected = False
+
+        # State tracker: None = first poll, True = healthy, False = down
+        self._service_ok: bool | None = None
+
+    @property
+    def name(self) -> str:
+        return "vaultwarden"
+
+    async def start(self) -> None:
+        self._task = asyncio.create_task(
+            self._poll_loop(), name="vaultwarden-poller",
+        )
+        await self._task
+
+    async def stop(self) -> None:
+        self._stopping = True
+        if self._task is not None:
+            self._task.cancel()
+            self._task = None
+
+    async def healthy(self) -> bool:
+        return self._connected
+
+    # -----------------------------------------------------------------
+    # Poll loop
+    # -----------------------------------------------------------------
+
+    async def _poll_loop(self) -> None:
+        timeout = aiohttp.ClientTimeout(total=self._config.timeout)
+
+        while not self._stopping:
+            try:
+                async with aiohttp.ClientSession(timeout=timeout) as session:
+                    await self._poll_health(session)
+                    self._connected = True
+            except asyncio.CancelledError:
+                return
+            except (TimeoutError, aiohttp.ClientError) as exc:
+                self._connected = False
+                self._handle_failure(str(exc))
+            except Exception:
+                self._connected = False
+                logger.exception("Vaultwarden: unexpected error")
+                self._handle_failure("unexpected error")
+
+            for _ in range(self._config.poll_interval):
+                if self._stopping:
+                    return
+                await asyncio.sleep(1)
+
+    # -----------------------------------------------------------------
+    # Health check
+    # -----------------------------------------------------------------
+
+    async def _poll_health(self, session: aiohttp.ClientSession) -> None:
+        """Poll ``/alive`` — a 200 response means healthy."""
+        url = f"{self._config.url.rstrip('/')}/alive"
+        async with session.get(url) as resp:
+            resp.raise_for_status()
+
+        is_ok = True
+        was_ok = self._service_ok
+        self._service_ok = is_ok
+
+        # Transition from down -> up
+        if was_ok is not None and not was_ok and is_ok:
+            self._enqueue(Event(
+                source=self.name,
+                system="vaultwarden",
+                event_type="vaultwarden_recovered",
+                entity_id="vaultwarden",
+                severity=Severity.INFO,
+                timestamp=datetime.now(tz=UTC),
+                payload={"url": self._config.url},
+                metadata=EventMetadata(
+                    dedup_key="vaultwarden:health",
+                ),
+            ))
+
+    def _handle_failure(self, reason: str) -> None:
+        """Handle a failed health check — emit event on transition."""
+        was_ok = self._service_ok
+        self._service_ok = False
+
+        # Transition from up -> down, or first poll is down
+        if was_ok is None or was_ok:
+            if was_ok is not None:
+                logger.warning("Vaultwarden: health check failed: %s", reason)
+            self._enqueue(Event(
+                source=self.name,
+                system="vaultwarden",
+                event_type="vaultwarden_unreachable",
+                entity_id="vaultwarden",
+                severity=Severity.ERROR,
+                timestamp=datetime.now(tz=UTC),
+                payload={
+                    "url": self._config.url,
+                    "reason": reason,
+                },
+                metadata=EventMetadata(
+                    dedup_key="vaultwarden:health",
+                ),
+            ))
+
+    # -----------------------------------------------------------------
+    # Helpers
+    # -----------------------------------------------------------------
+
+    def _enqueue(self, event: Event) -> None:
+        """Enqueue an event, logging on failure."""
+        try:
+            self._queue.put_nowait(event)
+        except Exception:
+            logger.warning(
+                "Vaultwarden: failed to enqueue event: %s/%s",
+                event.system, event.event_type,
+            )

--- a/oasisagent/ui/form_specs.py
+++ b/oasisagent/ui/form_specs.py
@@ -51,6 +51,7 @@ TYPE_DISPLAY_NAMES: dict[str, str] = {
     "tautulli": "Tautulli",
     "tdarr": "Tdarr",
     "overseerr": "Overseerr",
+    "vaultwarden": "Vaultwarden",
     # Services
     "llm_triage": "LLM Triage (T1)",
     "llm_reasoning": "LLM Reasoning (T2)",
@@ -120,6 +121,9 @@ TYPE_DESCRIPTIONS: dict[str, str] = {
     ),
     "overseerr": (
         "Monitor Overseerr server connectivity"
+    ),
+    "vaultwarden": (
+        "Monitor Vaultwarden (Bitwarden) service health"
     ),
     # Services
     "llm_triage": (
@@ -700,6 +704,21 @@ FORM_SPECS: dict[str, list[FieldSpec]] = {
         FieldSpec(
             "api_key", "API Key", "password",
             required=True, group="Authentication",
+        ),
+        FieldSpec(
+            "poll_interval", "Poll Interval (seconds)",
+            "number", default=60,
+        ),
+        FieldSpec(
+            "timeout", "Request Timeout (seconds)",
+            "number", default=10, min_val=1,
+        ),
+    ],
+    "vaultwarden": [
+        FieldSpec(
+            "url", "Server URL", "text",
+            help_text="e.g. http://localhost:8000",
+            required=True,
         ),
         FieldSpec(
             "poll_interval", "Poll Interval (seconds)",

--- a/tests/test_ingestion/test_vaultwarden.py
+++ b/tests/test_ingestion/test_vaultwarden.py
@@ -1,0 +1,266 @@
+"""Tests for the Vaultwarden health-check ingestion adapter."""
+
+from __future__ import annotations
+
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+from pydantic import ValidationError
+
+from oasisagent.config import VaultwardenAdapterConfig
+from oasisagent.ingestion.vaultwarden import VaultwardenAdapter
+from oasisagent.models import Severity
+
+
+def _make_config(**overrides: object) -> VaultwardenAdapterConfig:
+    defaults: dict[str, object] = {
+        "enabled": True,
+        "url": "http://localhost:8000",
+        "poll_interval": 60,
+        "timeout": 10,
+    }
+    defaults.update(overrides)
+    return VaultwardenAdapterConfig(**defaults)  # type: ignore[arg-type]
+
+
+def _mock_queue() -> MagicMock:
+    return MagicMock()
+
+
+def _make_adapter(**overrides: object) -> tuple[VaultwardenAdapter, MagicMock]:
+    config = _make_config(**overrides)
+    queue = _mock_queue()
+    adapter = VaultwardenAdapter(config, queue)
+    return adapter, queue
+
+
+def _mock_response(status: int = 200) -> AsyncMock:
+    mock = AsyncMock()
+    mock.status = status
+    mock.raise_for_status = MagicMock()
+    mock.__aenter__ = AsyncMock(return_value=mock)
+    mock.__aexit__ = AsyncMock(return_value=False)
+    return mock
+
+
+# ---------------------------------------------------------------------------
+# Config validation
+# ---------------------------------------------------------------------------
+
+
+class TestConfigValidation:
+    def test_defaults(self) -> None:
+        config = VaultwardenAdapterConfig()
+        assert config.enabled is False
+        assert config.poll_interval == 60
+        assert config.timeout == 10
+
+    def test_extra_fields_forbidden(self) -> None:
+        with pytest.raises(ValidationError, match="Extra inputs"):
+            _make_config(bogus="nope")
+
+
+# ---------------------------------------------------------------------------
+# Adapter identity & lifecycle
+# ---------------------------------------------------------------------------
+
+
+class TestAdapterLifecycle:
+    def test_name(self) -> None:
+        adapter, _ = _make_adapter()
+        assert adapter.name == "vaultwarden"
+
+    @pytest.mark.asyncio
+    async def test_healthy_initially_false(self) -> None:
+        adapter, _ = _make_adapter()
+        assert not await adapter.healthy()
+
+    @pytest.mark.asyncio
+    async def test_stop_sets_flag(self) -> None:
+        adapter, _ = _make_adapter()
+        await adapter.stop()
+        assert adapter._stopping is True
+
+
+# ---------------------------------------------------------------------------
+# Health polling — state transitions
+# ---------------------------------------------------------------------------
+
+
+class TestHealthPolling:
+    @pytest.mark.asyncio
+    async def test_first_poll_ok_no_event(self) -> None:
+        adapter, queue = _make_adapter()
+
+        mock_session = AsyncMock()
+        mock_session.get = MagicMock(return_value=_mock_response(200))
+
+        await adapter._poll_health(mock_session)
+        queue.put_nowait.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_first_poll_ok_then_ok_no_event(self) -> None:
+        adapter, queue = _make_adapter()
+
+        mock_session = AsyncMock()
+        mock_session.get = MagicMock(return_value=_mock_response(200))
+
+        await adapter._poll_health(mock_session)
+        await adapter._poll_health(mock_session)
+        queue.put_nowait.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_recovery_emits_event(self) -> None:
+        adapter, queue = _make_adapter()
+        adapter._service_ok = False
+
+        mock_session = AsyncMock()
+        mock_session.get = MagicMock(return_value=_mock_response(200))
+
+        await adapter._poll_health(mock_session)
+
+        queue.put_nowait.assert_called_once()
+        event = queue.put_nowait.call_args[0][0]
+        assert event.event_type == "vaultwarden_recovered"
+        assert event.severity == Severity.INFO
+        assert event.system == "vaultwarden"
+        assert event.source == "vaultwarden"
+
+    @pytest.mark.asyncio
+    async def test_dedup_key(self) -> None:
+        adapter, queue = _make_adapter()
+        adapter._service_ok = False
+
+        mock_session = AsyncMock()
+        mock_session.get = MagicMock(return_value=_mock_response(200))
+
+        await adapter._poll_health(mock_session)
+
+        event = queue.put_nowait.call_args[0][0]
+        assert event.metadata.dedup_key == "vaultwarden:health"
+
+
+# ---------------------------------------------------------------------------
+# Failure handling — state transitions
+# ---------------------------------------------------------------------------
+
+
+class TestFailureHandling:
+    def test_first_failure_emits_unreachable(self) -> None:
+        adapter, queue = _make_adapter()
+
+        adapter._handle_failure("connection refused")
+
+        queue.put_nowait.assert_called_once()
+        event = queue.put_nowait.call_args[0][0]
+        assert event.event_type == "vaultwarden_unreachable"
+        assert event.severity == Severity.ERROR
+        assert event.payload["reason"] == "connection refused"
+
+    def test_transition_up_to_down_emits(self) -> None:
+        adapter, queue = _make_adapter()
+        adapter._service_ok = True
+
+        adapter._handle_failure("timeout")
+
+        queue.put_nowait.assert_called_once()
+        event = queue.put_nowait.call_args[0][0]
+        assert event.event_type == "vaultwarden_unreachable"
+
+    def test_already_down_no_duplicate(self) -> None:
+        adapter, queue = _make_adapter()
+        adapter._service_ok = False
+
+        adapter._handle_failure("still down")
+
+        queue.put_nowait.assert_not_called()
+
+    def test_unreachable_dedup_key(self) -> None:
+        adapter, queue = _make_adapter()
+
+        adapter._handle_failure("refused")
+
+        event = queue.put_nowait.call_args[0][0]
+        assert event.metadata.dedup_key == "vaultwarden:health"
+
+
+# ---------------------------------------------------------------------------
+# URL construction
+# ---------------------------------------------------------------------------
+
+
+class TestUrlConstruction:
+    @pytest.mark.asyncio
+    async def test_trailing_slash_stripped(self) -> None:
+        adapter, _ = _make_adapter(url="http://localhost:8000/")
+
+        mock_session = AsyncMock()
+        mock_resp = _mock_response(200)
+        mock_session.get = MagicMock(return_value=mock_resp)
+
+        await adapter._poll_health(mock_session)
+
+        called_url = mock_session.get.call_args[0][0]
+        assert called_url == "http://localhost:8000/alive"
+
+
+# ---------------------------------------------------------------------------
+# Registry
+# ---------------------------------------------------------------------------
+
+
+class TestRegistry:
+    def test_vaultwarden_connector_registered(self) -> None:
+        from oasisagent.db.registry import CONNECTOR_TYPES
+
+        assert "vaultwarden" in CONNECTOR_TYPES
+        meta = CONNECTOR_TYPES["vaultwarden"]
+        assert meta.model is VaultwardenAdapterConfig
+        assert meta.secret_fields == frozenset()
+
+    def test_form_specs_exist(self) -> None:
+        from oasisagent.ui.form_specs import FORM_SPECS
+
+        assert "vaultwarden" in FORM_SPECS
+        specs = FORM_SPECS["vaultwarden"]
+        field_names = {s.name for s in specs}
+        assert "url" in field_names
+        assert "poll_interval" in field_names
+        assert "timeout" in field_names
+
+    def test_display_name(self) -> None:
+        from oasisagent.ui.form_specs import TYPE_DISPLAY_NAMES
+
+        assert TYPE_DISPLAY_NAMES["vaultwarden"] == "Vaultwarden"
+
+    def test_description(self) -> None:
+        from oasisagent.ui.form_specs import TYPE_DESCRIPTIONS
+
+        assert "vaultwarden" in TYPE_DESCRIPTIONS
+
+
+# ---------------------------------------------------------------------------
+# Known fixes
+# ---------------------------------------------------------------------------
+
+
+class TestKnownFixes:
+    def test_known_fix_exists(self) -> None:
+        from pathlib import Path
+
+        import yaml
+
+        fixes_path = Path(__file__).parent.parent.parent / "known_fixes" / "vaultwarden.yaml"
+        assert fixes_path.exists(), f"Missing known fix: {fixes_path}"
+
+        with fixes_path.open() as f:
+            data = yaml.safe_load(f)
+
+        fixes = data["fixes"]
+        fix_ids = {fix["id"] for fix in fixes}
+        assert "vaultwarden-unreachable" in fix_ids
+
+        unreachable = next(f for f in fixes if f["id"] == "vaultwarden-unreachable")
+        assert unreachable["match"]["system"] == "vaultwarden"
+        assert unreachable["match"]["event_type"] == "vaultwarden_unreachable"
+        assert unreachable["risk_tier"] == "escalate"


### PR DESCRIPTION
## Summary
- Add `VaultwardenAdapter` that polls the `/alive` endpoint for service health
- State-based dedup emits `vaultwarden_unreachable` (ERROR) on outage and `vaultwarden_recovered` (INFO) on return
- `VaultwardenAdapterConfig` with `url`, `poll_interval`, `timeout` — no auth needed
- Registered in `db/registry.py` (no secret fields) and `ui/form_specs.py`
- Known fix `vaultwarden-unreachable` with `risk_tier: escalate` (critical security service)
- 19 tests covering config validation, lifecycle, state transitions, dedup, URL construction, registry, and known fixes

Closes #189

## Test plan
- [x] `pytest tests/test_ingestion/test_vaultwarden.py` — 19 passed
- [x] `pytest --tb=short` — 2359 passed
- [x] `ruff check` — all checks passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)