### PR TITLE
Fix Servarr known fix: match all Servarr app types

### DIFF
--- a/known_fixes/servarr.yaml
+++ b/known_fixes/servarr.yaml
@@ -1,7 +1,6 @@
 fixes:
   - id: servarr-health-issue
     match:
-      system: sonarr
       event_type: servarr_health_issue
     diagnosis: "Servarr app reports a health check failure — may indicate disk space, indexer, or import problems"
     action:


### PR DESCRIPTION
## Summary
- The `servarr-health-issue` known fix had `system: sonarr` in its match criteria, but the `ServarrAdapter` sets `system=self._config.app_type` which can be `radarr`, `prowlarr`, or `bazarr` — not just `sonarr`
- Removed the `system: sonarr` filter so the health fix matches on `event_type` only, consistent with the queue fixes in the same file
- The `event_type: servarr_health_issue` is unique enough to avoid false matches

## Test plan
- [x] All 2333 tests pass
- [x] Verified other fixes in `known_fixes/servarr.yaml` (`servarr-queue-stuck`, `servarr-queue-failed`) already match on `event_type` only — no changes needed
- [x] Ruff clean (YAML file, no Python changes)

🤖 Generated with [Claude Code](https://claude.com/claude-code)