### PR TITLE
Align adapter/handler docstrings with implemented behavior

### DIFF
--- a/oasisagent/clients/npm.py
+++ b/oasisagent/clients/npm.py
@@ -2,7 +2,8 @@
 
 JWT-based authentication: POST /api/tokens with email/password returns
 a JWT token used as ``Authorization: Bearer <token>``.  Tokens expire
-after a configurable period; the client transparently refreshes on 401.
+after a configurable period; the client transparently refreshes on
+401 or 403.
 
 Used by the NPM ingestion adapter to poll proxy hosts, certificates,
 and dead hosts.

--- a/oasisagent/handlers/homeassistant.py
+++ b/oasisagent/handlers/homeassistant.py
@@ -1,6 +1,6 @@
 """Home Assistant handler — executes actions via the HA REST API.
 
-Phase 1 operations: notify, restart_integration, reload_automations,
+Operations: notify, restart_integration, reload_automations,
 call_service, get_entity_state, get_error_log.
 
 ARCHITECTURE.md §8 defines the handler interface and HA-specific operations.

--- a/oasisagent/handlers/proxmox.py
+++ b/oasisagent/handlers/proxmox.py
@@ -9,7 +9,7 @@ is optional (``verify_ssl: false`` for self-signed certs).
 
 Auth header format: ``Authorization: PVEAPIToken=USER@REALM!TOKENID=UUID``
 
-ARCHITECTURE.md §8 and §16.7 define the handler interface and operations.
+ARCHITECTURE.md §8 and §17.5 define the handler interface and operations.
 """
 
 from __future__ import annotations

--- a/oasisagent/handlers/unifi.py
+++ b/oasisagent/handlers/unifi.py
@@ -3,7 +3,7 @@
 Operations: notify, restart_device, block_client, unblock_client.
 
 Uses the shared UnifiClient for session cookie auth and automatic
-re-auth on 401.
+re-auth on 401/403.
 """
 
 from __future__ import annotations

--- a/oasisagent/ingestion/ha_websocket.py
+++ b/oasisagent/ingestion/ha_websocket.py
@@ -1,7 +1,7 @@
 """Home Assistant WebSocket ingestion adapter.
 
-Connects to HA's WebSocket API, subscribes to state_changed,
-automation_triggered, and call_service events, and transforms
+Connects to HA's WebSocket API, subscribes to all events, and filters
+for state_changed, automation_triggered, and call_service. Transforms
 relevant events into canonical Event objects.
 """
 

--- a/oasisagent/ingestion/npm.py
+++ b/oasisagent/ingestion/npm.py
@@ -58,7 +58,7 @@ class NpmAdapter(IngestAdapter):
             self._endpoint_health["dead_hosts"] = False
 
         # Dedup trackers
-        # host_id -> "online" | "erroring" | "disabled"
+        # host_id -> "online" | "disabled"
         self._host_states: dict[int, str] = {}
         # cert_id -> "ok" | "warning" | "critical"
         self._cert_alert_state: dict[int, str] = {}


### PR DESCRIPTION
## Summary

Sweeps all adapter, handler, and client files to fix docstrings and comments that describe aspirational or outdated behavior rather than what the code actually does. Fixes six discrepancies:

- **`ingestion/npm.py`**: `_host_states` type comment listed `"erroring"` as a possible state, but code only produces `"online"` or `"disabled"`
- **`handlers/proxmox.py`**: Module docstring referenced `ARCHITECTURE.md §16.7` (notification channels) instead of `§17.5` (Proxmox handler)
- **`handlers/homeassistant.py`**: Module docstring said "Phase 1 operations" — outdated framing since Phase 1 is long complete; these are the current operations
- **`handlers/unifi.py`**: Module docstring said "re-auth on 401" but the `UnifiClient` re-auths on both 401 and 403
- **`clients/npm.py`**: Module docstring said "refreshes on 401" but the code also retries on 403
- **`ingestion/ha_websocket.py`**: Module docstring said "subscribes to state_changed, automation_triggered, and call_service events" but the adapter actually subscribes to all events and *filters* for those three

No code behavior changes — docs only.

Closes #201

## Test plan

- [x] `ruff check` passes on all modified files
- [x] `pytest --tb=short` — 2497 tests passing

🤖 Generated with [Claude Code](https://claude.com/claude-code)