### PR TITLE
Extract _enqueue helper to IngestAdapter base class (#199)

### DIFF
--- a/oasisagent/ingestion/base.py
+++ b/oasisagent/ingestion/base.py
@@ -6,11 +6,15 @@ manages adapter lifecycle via start() and stop().
 
 from __future__ import annotations
 
+import logging
 from abc import ABC, abstractmethod
 from typing import TYPE_CHECKING
 
 if TYPE_CHECKING:
     from oasisagent.engine.queue import EventQueue
+    from oasisagent.models.event import Event
+
+logger = logging.getLogger(__name__)
 
 
 class IngestAdapter(ABC):
@@ -50,3 +54,15 @@ class IngestAdapter(ABC):
 
         Used by the agent for health checks and status reporting.
         """
+
+    def _enqueue(self, event: Event) -> None:
+        """Enqueue an event, logging on failure."""
+        try:
+            self._queue.put_nowait(event)
+        except Exception:
+            logger.warning(
+                "%s: failed to enqueue event: %s/%s",
+                self.name,
+                event.system,
+                event.event_type,
+            )

--- a/oasisagent/ingestion/cloudflare.py
+++ b/oasisagent/ingestion/cloudflare.py
@@ -388,16 +388,3 @@ class CloudflareAdapter(IngestAdapter):
                 ),
             ))
 
-    # -----------------------------------------------------------------
-    # Helpers
-    # -----------------------------------------------------------------
-
-    def _enqueue(self, event: Event) -> None:
-        """Enqueue an event, logging on failure."""
-        try:
-            self._queue.put_nowait(event)
-        except Exception:
-            logger.warning(
-                "Cloudflare adapter: failed to enqueue event: %s/%s",
-                event.system, event.event_type,
-            )

--- a/oasisagent/ingestion/frigate.py
+++ b/oasisagent/ingestion/frigate.py
@@ -319,16 +319,3 @@ class FrigateAdapter(IngestAdapter):
                     ),
                 ))
 
-    # -----------------------------------------------------------------
-    # Helpers
-    # -----------------------------------------------------------------
-
-    def _enqueue(self, event: Event) -> None:
-        """Enqueue an event, logging on failure."""
-        try:
-            self._queue.put_nowait(event)
-        except Exception:
-            logger.warning(
-                "Frigate adapter: failed to enqueue event: %s/%s",
-                event.system, event.event_type,
-            )

--- a/oasisagent/ingestion/http_poller.py
+++ b/oasisagent/ingestion/http_poller.py
@@ -330,12 +330,3 @@ class HttpPollerAdapter(IngestAdapter):
                 ),
             ))
 
-    def _enqueue(self, event: Event) -> None:
-        """Enqueue an event, logging on failure."""
-        try:
-            self._queue.put_nowait(event)
-        except Exception:
-            logger.warning(
-                "HTTP poller: failed to enqueue event: %s/%s",
-                event.system, event.event_type,
-            )

--- a/oasisagent/ingestion/n8n.py
+++ b/oasisagent/ingestion/n8n.py
@@ -231,16 +231,3 @@ class N8nAdapter(IngestAdapter):
                 ),
             ))
 
-    # -----------------------------------------------------------------
-    # Helpers
-    # -----------------------------------------------------------------
-
-    def _enqueue(self, event: Event) -> None:
-        """Enqueue an event, logging on failure."""
-        try:
-            self._queue.put_nowait(event)
-        except Exception:
-            logger.warning(
-                "N8N: failed to enqueue event: %s/%s",
-                event.system, event.event_type,
-            )

--- a/oasisagent/ingestion/npm.py
+++ b/oasisagent/ingestion/npm.py
@@ -372,16 +372,3 @@ class NpmAdapter(IngestAdapter):
         # Evict cleared dead hosts to prevent unbounded growth
         self._seen_dead_hosts = current_dead_ids
 
-    # -----------------------------------------------------------------
-    # Helpers
-    # -----------------------------------------------------------------
-
-    def _enqueue(self, event: Event) -> None:
-        """Enqueue an event, logging on failure."""
-        try:
-            self._queue.put_nowait(event)
-        except Exception:
-            logger.warning(
-                "NPM adapter: failed to enqueue event: %s/%s",
-                event.system, event.event_type,
-            )

--- a/oasisagent/ingestion/overseerr.py
+++ b/oasisagent/ingestion/overseerr.py
@@ -138,16 +138,3 @@ class OverseerrAdapter(IngestAdapter):
                 ),
             ))
 
-    # -----------------------------------------------------------------
-    # Helpers
-    # -----------------------------------------------------------------
-
-    def _enqueue(self, event: Event) -> None:
-        """Enqueue an event, logging on failure."""
-        try:
-            self._queue.put_nowait(event)
-        except Exception:
-            logger.warning(
-                "Overseerr: failed to enqueue event: %s/%s",
-                event.system, event.event_type,
-            )

--- a/oasisagent/ingestion/plex.py
+++ b/oasisagent/ingestion/plex.py
@@ -208,16 +208,3 @@ class PlexAdapter(IngestAdapter):
 
         self._library_errors = current_errors
 
-    # -----------------------------------------------------------------
-    # Helpers
-    # -----------------------------------------------------------------
-
-    def _enqueue(self, event: Event) -> None:
-        """Enqueue an event, logging on failure."""
-        try:
-            self._queue.put_nowait(event)
-        except Exception:
-            logger.warning(
-                "Plex: failed to enqueue event: %s/%s",
-                event.system, event.event_type,
-            )

--- a/oasisagent/ingestion/qbittorrent.py
+++ b/oasisagent/ingestion/qbittorrent.py
@@ -281,16 +281,3 @@ class QBittorrentAdapter(IngestAdapter):
 
         self._stalled_hashes = current_stalled
 
-    # -----------------------------------------------------------------
-    # Helpers
-    # -----------------------------------------------------------------
-
-    def _enqueue(self, event: Event) -> None:
-        """Enqueue an event, logging on failure."""
-        try:
-            self._queue.put_nowait(event)
-        except Exception:
-            logger.warning(
-                "qBittorrent: failed to enqueue event: %s/%s",
-                event.system, event.event_type,
-            )

--- a/oasisagent/ingestion/servarr.py
+++ b/oasisagent/ingestion/servarr.py
@@ -253,16 +253,3 @@ class ServarrAdapter(IngestAdapter):
         self._failed_ids = current_failed
         self._stuck_ids = current_stuck
 
-    # -----------------------------------------------------------------
-    # Helpers
-    # -----------------------------------------------------------------
-
-    def _enqueue(self, event: Event) -> None:
-        """Enqueue an event, logging on failure."""
-        try:
-            self._queue.put_nowait(event)
-        except Exception:
-            logger.warning(
-                "Servarr %s: failed to enqueue event: %s/%s",
-                self._config.app_type, event.system, event.event_type,
-            )

--- a/oasisagent/ingestion/tautulli.py
+++ b/oasisagent/ingestion/tautulli.py
@@ -240,12 +240,3 @@ class TautulliAdapter(IngestAdapter):
         """Build Tautulli API URL with command and API key."""
         return f"{self._config.url}/api/v2?apikey={self._config.api_key}&cmd={cmd}"
 
-    def _enqueue(self, event: Event) -> None:
-        """Enqueue an event, logging on failure."""
-        try:
-            self._queue.put_nowait(event)
-        except Exception:
-            logger.warning(
-                "Tautulli: failed to enqueue event: %s/%s",
-                event.system, event.event_type,
-            )

--- a/oasisagent/ingestion/tdarr.py
+++ b/oasisagent/ingestion/tdarr.py
@@ -239,16 +239,3 @@ class TdarrAdapter(IngestAdapter):
                 ),
             ))
 
-    # -----------------------------------------------------------------
-    # Helpers
-    # -----------------------------------------------------------------
-
-    def _enqueue(self, event: Event) -> None:
-        """Enqueue an event, logging on failure."""
-        try:
-            self._queue.put_nowait(event)
-        except Exception:
-            logger.warning(
-                "Tdarr: failed to enqueue event: %s/%s",
-                event.system, event.event_type,
-            )

--- a/oasisagent/ingestion/unifi.py
+++ b/oasisagent/ingestion/unifi.py
@@ -766,12 +766,3 @@ class UnifiAdapter(IngestAdapter):
         """Return True if the exception represents an HTTP 404 response."""
         return isinstance(exc, aiohttp.ClientResponseError) and exc.status == 404
 
-    def _enqueue(self, event: Event) -> None:
-        """Enqueue an event, logging on failure."""
-        try:
-            self._queue.put_nowait(event)
-        except Exception:
-            logger.warning(
-                "UniFi adapter: failed to enqueue event: %s/%s",
-                event.system, event.event_type,
-            )

--- a/oasisagent/ingestion/uptime_kuma.py
+++ b/oasisagent/ingestion/uptime_kuma.py
@@ -282,12 +282,3 @@ class UptimeKumaAdapter(IngestAdapter):
             ),
         )
 
-    def _enqueue(self, event: Event) -> None:
-        """Enqueue an event, logging on failure."""
-        try:
-            self._queue.put_nowait(event)
-        except Exception:
-            logger.warning(
-                "Uptime Kuma: failed to enqueue event: %s/%s",
-                event.system, event.event_type,
-            )

--- a/oasisagent/ingestion/vaultwarden.py
+++ b/oasisagent/ingestion/vaultwarden.py
@@ -146,16 +146,3 @@ class VaultwardenAdapter(IngestAdapter):
                 ),
             ))
 
-    # -----------------------------------------------------------------
-    # Helpers
-    # -----------------------------------------------------------------
-
-    def _enqueue(self, event: Event) -> None:
-        """Enqueue an event, logging on failure."""
-        try:
-            self._queue.put_nowait(event)
-        except Exception:
-            logger.warning(
-                "Vaultwarden: failed to enqueue event: %s/%s",
-                event.system, event.event_type,
-            )


### PR DESCRIPTION
## Summary
- Moved the identical `_enqueue(event)` try/except helper from 14 ingestion adapters into the `IngestAdapter` base class in `base.py`
- The base class method uses `self.name` for the log prefix, which correctly resolves to each adapter's name (e.g., `servarr_sonarr`, `cloudflare`, `unifi`)
- Net removal of 150 lines of duplicated code with no behavior change

Closes #199

## Test plan
- [x] All 2497 tests pass (`pytest --tb=short`)
- [x] `ruff check` passes with no issues
- [x] Verified no remaining `def _enqueue` definitions outside `base.py`
- [x] Verified all `self._enqueue()` call sites unchanged across all adapters

🤖 Generated with [Claude Code](https://claude.com/claude-code)