### PR TITLE
Backport exponential backoff to all polling adapters

### DIFF
--- a/oasisagent/ingestion/n8n.py
+++ b/oasisagent/ingestion/n8n.py
@@ -77,6 +77,8 @@ class N8nAdapter(IngestAdapter):
 
     async def _poll_loop(self) -> None:
         timeout = aiohttp.ClientTimeout(total=self._config.timeout)
+        backoff = self._config.poll_interval
+        max_backoff = 300
 
         while not self._stopping:
             try:
@@ -87,12 +89,14 @@ class N8nAdapter(IngestAdapter):
                     if self._config.poll_executions:
                         await self._poll_executions(session)
                     self._connected = True
+                    backoff = self._config.poll_interval  # reset on success
             except asyncio.CancelledError:
                 return
             except (TimeoutError, aiohttp.ClientError) as exc:
                 if self._connected:
                     logger.warning("N8N: connection error: %s", exc)
                 self._connected = False
+                backoff = min(backoff * 2, max_backoff)
 
                 # Emit unreachable event on transition
                 was_ok = self._service_ok
@@ -113,8 +117,10 @@ class N8nAdapter(IngestAdapter):
             except Exception:
                 self._connected = False
                 logger.exception("N8N: unexpected error")
+                backoff = min(backoff * 2, max_backoff)
 
-            for _ in range(self._config.poll_interval):
+            wait = self._config.poll_interval if self._connected else backoff
+            for _ in range(wait):
                 if self._stopping:
                     return
                 await asyncio.sleep(1)

--- a/oasisagent/ingestion/npm.py
+++ b/oasisagent/ingestion/npm.py
@@ -70,12 +70,28 @@ class NpmAdapter(IngestAdapter):
         return "npm"
 
     async def start(self) -> None:
-        """Connect to NPM API and start the polling loop."""
-        try:
-            await self._client.connect()
-        except Exception as exc:
-            logger.error("NPM adapter: connection failed: %s", exc)
-            return
+        """Connect to NPM API and start the polling loop.
+
+        Uses exponential backoff on connection failure (5s -> 300s max).
+        """
+        backoff = 5
+        max_backoff = 300
+        while not self._stopping:
+            try:
+                await self._client.connect()
+                break
+            except asyncio.CancelledError:
+                return
+            except Exception as exc:
+                logger.error(
+                    "NPM adapter: connection failed: %s "
+                    "(retrying in %ds)", exc, backoff,
+                )
+                for _ in range(backoff):
+                    if self._stopping:
+                        return
+                    await asyncio.sleep(1)
+                backoff = min(backoff * 2, max_backoff)
 
         self._task = asyncio.create_task(
             self._poll_loop(), name="npm-poller",

--- a/oasisagent/ingestion/overseerr.py
+++ b/oasisagent/ingestion/overseerr.py
@@ -72,6 +72,8 @@ class OverseerrAdapter(IngestAdapter):
 
     async def _poll_loop(self) -> None:
         timeout = aiohttp.ClientTimeout(total=self._config.timeout)
+        backoff = self._config.poll_interval
+        max_backoff = 300
 
         while not self._stopping:
             try:
@@ -80,17 +82,21 @@ class OverseerrAdapter(IngestAdapter):
                 ) as session:
                     await self._poll_status(session)
                     self._connected = True
+                    backoff = self._config.poll_interval  # reset on success
             except asyncio.CancelledError:
                 return
             except (TimeoutError, aiohttp.ClientError) as exc:
                 if self._connected:
                     logger.warning("Overseerr: connection error: %s", exc)
                 self._connected = False
+                backoff = min(backoff * 2, max_backoff)
             except Exception:
                 self._connected = False
                 logger.exception("Overseerr: unexpected error")
+                backoff = min(backoff * 2, max_backoff)
 
-            for _ in range(self._config.poll_interval):
+            wait = self._config.poll_interval if self._connected else backoff
+            for _ in range(wait):
                 if self._stopping:
                     return
                 await asyncio.sleep(1)

--- a/oasisagent/ingestion/plex.py
+++ b/oasisagent/ingestion/plex.py
@@ -77,6 +77,8 @@ class PlexAdapter(IngestAdapter):
 
     async def _poll_loop(self) -> None:
         timeout = aiohttp.ClientTimeout(total=self._config.timeout)
+        backoff = self._config.poll_interval
+        max_backoff = 300
 
         while not self._stopping:
             try:
@@ -87,16 +89,23 @@ class PlexAdapter(IngestAdapter):
                     if reachable:
                         await self._poll_libraries(session)
                     self._connected = reachable
+                    if reachable:
+                        backoff = self._config.poll_interval  # reset on success
+                    else:
+                        backoff = min(backoff * 2, max_backoff)
             except asyncio.CancelledError:
                 return
             except (TimeoutError, aiohttp.ClientError) as exc:
                 self._handle_unreachable(str(exc))
                 self._connected = False
+                backoff = min(backoff * 2, max_backoff)
             except Exception:
                 self._connected = False
                 logger.exception("Plex: unexpected error")
+                backoff = min(backoff * 2, max_backoff)
 
-            for _ in range(self._config.poll_interval):
+            wait = self._config.poll_interval if self._connected else backoff
+            for _ in range(wait):
                 if self._stopping:
                     return
                 await asyncio.sleep(1)

--- a/oasisagent/ingestion/qbittorrent.py
+++ b/oasisagent/ingestion/qbittorrent.py
@@ -106,6 +106,8 @@ class QBittorrentAdapter(IngestAdapter):
     # -----------------------------------------------------------------
 
     async def _poll_loop(self) -> None:
+        backoff = self._config.poll_interval
+        max_backoff = 300
         while not self._stopping:
             try:
                 session = await self._ensure_session()
@@ -113,6 +115,7 @@ class QBittorrentAdapter(IngestAdapter):
                 await self._poll_errored_torrents(session)
                 await self._poll_stalled_torrents(session)
                 self._connected = True
+                backoff = self._config.poll_interval  # reset on success
             except asyncio.CancelledError:
                 return
             except (TimeoutError, aiohttp.ClientError) as exc:
@@ -123,14 +126,17 @@ class QBittorrentAdapter(IngestAdapter):
                 if self._session and not self._session.closed:
                     await self._session.close()
                 self._session = None
+                backoff = min(backoff * 2, max_backoff)
             except Exception:
                 self._connected = False
                 logger.exception("qBittorrent: unexpected error")
                 if self._session and not self._session.closed:
                     await self._session.close()
                 self._session = None
+                backoff = min(backoff * 2, max_backoff)
 
-            for _ in range(self._config.poll_interval):
+            wait = self._config.poll_interval if self._connected else backoff
+            for _ in range(wait):
                 if self._stopping:
                     return
                 await asyncio.sleep(1)

--- a/oasisagent/ingestion/servarr.py
+++ b/oasisagent/ingestion/servarr.py
@@ -94,6 +94,8 @@ class ServarrAdapter(IngestAdapter):
 
     async def _poll_loop(self) -> None:
         timeout = aiohttp.ClientTimeout(total=self._config.timeout)
+        backoff = self._config.poll_interval
+        max_backoff = 300
 
         while not self._stopping:
             try:
@@ -103,6 +105,7 @@ class ServarrAdapter(IngestAdapter):
                     await self._poll_health(session)
                     await self._poll_queue(session)
                     self._connected = True
+                    backoff = self._config.poll_interval  # reset on success
             except asyncio.CancelledError:
                 return
             except (TimeoutError, aiohttp.ClientError) as exc:
@@ -112,14 +115,17 @@ class ServarrAdapter(IngestAdapter):
                         self._config.app_type, exc,
                     )
                 self._connected = False
+                backoff = min(backoff * 2, max_backoff)
             except Exception:
                 self._connected = False
                 logger.exception(
                     "Servarr %s: unexpected error",
                     self._config.app_type,
                 )
+                backoff = min(backoff * 2, max_backoff)
 
-            for _ in range(self._config.poll_interval):
+            wait = self._config.poll_interval if self._connected else backoff
+            for _ in range(wait):
                 if self._stopping:
                     return
                 await asyncio.sleep(1)

--- a/oasisagent/ingestion/tautulli.py
+++ b/oasisagent/ingestion/tautulli.py
@@ -76,6 +76,8 @@ class TautulliAdapter(IngestAdapter):
 
     async def _poll_loop(self) -> None:
         timeout = aiohttp.ClientTimeout(total=self._config.timeout)
+        backoff = self._config.poll_interval
+        max_backoff = 300
 
         while not self._stopping:
             try:
@@ -83,17 +85,21 @@ class TautulliAdapter(IngestAdapter):
                     await self._poll_server_status(session)
                     await self._poll_activity(session)
                     self._connected = True
+                    backoff = self._config.poll_interval  # reset on success
             except asyncio.CancelledError:
                 return
             except (TimeoutError, aiohttp.ClientError) as exc:
                 if self._connected:
                     logger.warning("Tautulli: connection error: %s", exc)
                 self._connected = False
+                backoff = min(backoff * 2, max_backoff)
             except Exception:
                 self._connected = False
                 logger.exception("Tautulli: unexpected error")
+                backoff = min(backoff * 2, max_backoff)
 
-            for _ in range(self._config.poll_interval):
+            wait = self._config.poll_interval if self._connected else backoff
+            for _ in range(wait):
                 if self._stopping:
                     return
                 await asyncio.sleep(1)

--- a/oasisagent/ingestion/tdarr.py
+++ b/oasisagent/ingestion/tdarr.py
@@ -76,23 +76,29 @@ class TdarrAdapter(IngestAdapter):
 
     async def _poll_loop(self) -> None:
         timeout = aiohttp.ClientTimeout(total=self._config.timeout)
+        backoff = self._config.poll_interval
+        max_backoff = 300
 
         while not self._stopping:
             try:
                 async with aiohttp.ClientSession(timeout=timeout) as session:
                     await self._poll_status(session)
                     self._connected = True
+                    backoff = self._config.poll_interval  # reset on success
             except asyncio.CancelledError:
                 return
             except (TimeoutError, aiohttp.ClientError) as exc:
                 if self._connected:
                     logger.warning("Tdarr: connection error: %s", exc)
                 self._connected = False
+                backoff = min(backoff * 2, max_backoff)
             except Exception:
                 self._connected = False
                 logger.exception("Tdarr: unexpected error")
+                backoff = min(backoff * 2, max_backoff)
 
-            for _ in range(self._config.poll_interval):
+            wait = self._config.poll_interval if self._connected else backoff
+            for _ in range(wait):
                 if self._stopping:
                     return
                 await asyncio.sleep(1)

--- a/oasisagent/ingestion/vaultwarden.py
+++ b/oasisagent/ingestion/vaultwarden.py
@@ -71,23 +71,29 @@ class VaultwardenAdapter(IngestAdapter):
 
     async def _poll_loop(self) -> None:
         timeout = aiohttp.ClientTimeout(total=self._config.timeout)
+        backoff = self._config.poll_interval
+        max_backoff = 300
 
         while not self._stopping:
             try:
                 async with aiohttp.ClientSession(timeout=timeout) as session:
                     await self._poll_health(session)
                     self._connected = True
+                    backoff = self._config.poll_interval  # reset on success
             except asyncio.CancelledError:
                 return
             except (TimeoutError, aiohttp.ClientError) as exc:
                 self._connected = False
                 self._handle_failure(str(exc))
+                backoff = min(backoff * 2, max_backoff)
             except Exception:
                 self._connected = False
                 logger.exception("Vaultwarden: unexpected error")
                 self._handle_failure("unexpected error")
+                backoff = min(backoff * 2, max_backoff)
 
-            for _ in range(self._config.poll_interval):
+            wait = self._config.poll_interval if self._connected else backoff
+            for _ in range(wait):
                 if self._stopping:
                     return
                 await asyncio.sleep(1)

--- a/tests/test_ingestion/test_n8n.py
+++ b/tests/test_ingestion/test_n8n.py
@@ -2,8 +2,9 @@
 
 from __future__ import annotations
 
+import asyncio
 from datetime import UTC, datetime, timedelta
-from unittest.mock import AsyncMock, MagicMock
+from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
 from pydantic import ValidationError
@@ -407,6 +408,105 @@ class TestKnownFixes:
 
         ids = [fix["id"] for fix in data["fixes"]]
         assert len(ids) == len(set(ids))
+
+
+# ---------------------------------------------------------------------------
+# Poll loop backoff
+# ---------------------------------------------------------------------------
+
+
+class TestPollLoopBackoff:
+    @pytest.mark.asyncio
+    async def test_backoff_increases_on_repeated_failures(self) -> None:
+        """Poll loop uses exponential backoff when service is persistently down."""
+        adapter, _ = _make_adapter(poll_interval=10)
+
+        poll_count = 0
+        sleep_totals: list[int] = []
+        current_total = 0
+
+        original_sleep = asyncio.sleep
+
+        async def _tracking_sleep(_: float) -> None:
+            nonlocal current_total
+            current_total += 1
+            await original_sleep(0)
+
+        async def _fail_poll(_session: object) -> None:
+            nonlocal poll_count, current_total
+            if poll_count > 0:
+                sleep_totals.append(current_total)
+                current_total = 0
+            poll_count += 1
+            if poll_count >= 4:
+                adapter._stopping = True
+                return
+            import aiohttp
+            raise aiohttp.ClientError("connection refused")
+
+        adapter._poll_health = _fail_poll  # type: ignore[method-assign]
+        adapter._poll_executions = AsyncMock()  # type: ignore[method-assign]
+
+        with patch(
+            "oasisagent.ingestion.n8n.aiohttp.ClientSession",
+        ) as mock_cs, patch(
+            "oasisagent.ingestion.n8n.asyncio.sleep",
+            side_effect=_tracking_sleep,
+        ):
+            mock_session = AsyncMock()
+            mock_cs.return_value.__aenter__ = AsyncMock(return_value=mock_session)
+            mock_cs.return_value.__aexit__ = AsyncMock(return_value=False)
+            await adapter._poll_loop()
+
+        assert len(sleep_totals) >= 2
+        for i in range(1, len(sleep_totals)):
+            assert sleep_totals[i] >= sleep_totals[i - 1]
+
+    @pytest.mark.asyncio
+    async def test_backoff_resets_on_success(self) -> None:
+        """Backoff resets to poll_interval after a successful poll."""
+        adapter, _ = _make_adapter(poll_interval=10)
+
+        poll_count = 0
+        sleep_totals: list[int] = []
+        current_total = 0
+
+        original_sleep = asyncio.sleep
+
+        async def _tracking_sleep(_: float) -> None:
+            nonlocal current_total
+            current_total += 1
+            await original_sleep(0)
+
+        async def _poll_health(session: object) -> None:
+            nonlocal poll_count, current_total
+            if poll_count > 0:
+                sleep_totals.append(current_total)
+                current_total = 0
+            poll_count += 1
+            if poll_count == 1:
+                import aiohttp
+                raise aiohttp.ClientError("down")
+            if poll_count >= 3:
+                adapter._stopping = True
+                return
+
+        adapter._poll_health = _poll_health  # type: ignore[method-assign]
+        adapter._poll_executions = AsyncMock()  # type: ignore[method-assign]
+
+        with patch(
+            "oasisagent.ingestion.n8n.aiohttp.ClientSession",
+        ) as mock_cs, patch(
+            "oasisagent.ingestion.n8n.asyncio.sleep",
+            side_effect=_tracking_sleep,
+        ):
+            mock_session = AsyncMock()
+            mock_cs.return_value.__aenter__ = AsyncMock(return_value=mock_session)
+            mock_cs.return_value.__aexit__ = AsyncMock(return_value=False)
+            await adapter._poll_loop()
+
+        assert len(sleep_totals) >= 2
+        assert sleep_totals[-1] == adapter._config.poll_interval
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_ingestion/test_npm.py
+++ b/tests/test_ingestion/test_npm.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import asyncio
 from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
@@ -89,13 +90,108 @@ class TestAdapterLifecycle:
         assert all(v is False for v in adapter._endpoint_health.values())
 
     @pytest.mark.asyncio
-    async def test_start_connection_failure(self) -> None:
+    async def test_start_connection_failure_retries(self) -> None:
+        """Start retries with backoff on connection failure, not silent death."""
         adapter, _ = _make_adapter()
+        call_count = 0
+
+        async def _connect_side_effect() -> None:
+            nonlocal call_count
+            call_count += 1
+            if call_count < 3:
+                raise ConnectionError("refused")
+
+        adapter._client.connect = AsyncMock(side_effect=_connect_side_effect)
+
+        original_sleep = asyncio.sleep
+
+        async def _noop_sleep(_: float) -> None:
+            await original_sleep(0)
+
+        with patch(
+            "oasisagent.ingestion.npm.asyncio.sleep",
+            side_effect=_noop_sleep,
+        ):
+            task = asyncio.create_task(adapter.start())
+            for _ in range(200):
+                await original_sleep(0)
+            adapter._stopping = True
+            try:
+                await asyncio.wait_for(task, timeout=2.0)
+            except (TimeoutError, asyncio.CancelledError):
+                task.cancel()
+
+        assert call_count >= 3
+
+
+# ---------------------------------------------------------------------------
+# Startup retry
+# ---------------------------------------------------------------------------
+
+
+class TestStartupRetry:
+    @pytest.mark.asyncio
+    async def test_retries_on_connection_failure(self) -> None:
+        adapter, _ = _make_adapter()
+
+        call_count = 0
+        original_sleep = asyncio.sleep
+
+        async def _connect_side_effect() -> None:
+            nonlocal call_count
+            call_count += 1
+            if call_count < 3:
+                raise ConnectionError("refused")
+
+        async def _noop_sleep(_: float) -> None:
+            await original_sleep(0)
+
+        adapter._client = AsyncMock()
+        adapter._client.connect = AsyncMock(side_effect=_connect_side_effect)
+        adapter._client.close = AsyncMock()
+
+        with patch(
+            "oasisagent.ingestion.npm.asyncio.sleep",
+            side_effect=_noop_sleep,
+        ):
+            task = asyncio.create_task(adapter.start())
+            for _ in range(200):
+                await original_sleep(0)
+            adapter._stopping = True
+            try:
+                await asyncio.wait_for(task, timeout=2.0)
+            except (TimeoutError, asyncio.CancelledError):
+                task.cancel()
+
+        assert call_count >= 3
+
+    @pytest.mark.asyncio
+    async def test_stops_during_backoff(self) -> None:
+        """Setting _stopping during backoff causes start() to return."""
+        adapter, _ = _make_adapter()
+
         adapter._client.connect = AsyncMock(
             side_effect=ConnectionError("refused"),
         )
-        await adapter.start()
-        assert not await adapter.healthy()
+
+        original_sleep = asyncio.sleep
+        sleep_count = 0
+
+        async def _sleep_then_stop(_: float) -> None:
+            nonlocal sleep_count
+            sleep_count += 1
+            if sleep_count >= 3:
+                adapter._stopping = True
+            await original_sleep(0)
+
+        with patch(
+            "oasisagent.ingestion.npm.asyncio.sleep",
+            side_effect=_sleep_then_stop,
+        ):
+            await asyncio.wait_for(adapter.start(), timeout=2.0)
+
+        # Should have exited cleanly
+        assert adapter._stopping is True
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_ingestion/test_overseerr.py
+++ b/tests/test_ingestion/test_overseerr.py
@@ -2,7 +2,8 @@
 
 from __future__ import annotations
 
-from unittest.mock import AsyncMock, MagicMock
+import asyncio
+from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
 from pydantic import ValidationError
@@ -145,6 +146,103 @@ class TestStatusPolling:
 
         event = queue.put_nowait.call_args[0][0]
         assert event.metadata.dedup_key == "overseerr:server:status"
+
+
+# ---------------------------------------------------------------------------
+# Poll loop backoff
+# ---------------------------------------------------------------------------
+
+
+class TestPollLoopBackoff:
+    @pytest.mark.asyncio
+    async def test_backoff_increases_on_repeated_failures(self) -> None:
+        """Poll loop uses exponential backoff when service is persistently down."""
+        adapter, _ = _make_adapter(poll_interval=10)
+
+        poll_count = 0
+        sleep_totals: list[int] = []
+        current_total = 0
+
+        original_sleep = asyncio.sleep
+
+        async def _tracking_sleep(_: float) -> None:
+            nonlocal current_total
+            current_total += 1
+            await original_sleep(0)
+
+        async def _fail_poll(_session: object) -> None:
+            nonlocal poll_count, current_total
+            if poll_count > 0:
+                sleep_totals.append(current_total)
+                current_total = 0
+            poll_count += 1
+            if poll_count >= 4:
+                adapter._stopping = True
+                return
+            import aiohttp
+            raise aiohttp.ClientError("connection refused")
+
+        adapter._poll_status = _fail_poll  # type: ignore[method-assign]
+
+        with patch(
+            "oasisagent.ingestion.overseerr.aiohttp.ClientSession",
+        ) as mock_cs, patch(
+            "oasisagent.ingestion.overseerr.asyncio.sleep",
+            side_effect=_tracking_sleep,
+        ):
+            mock_session = AsyncMock()
+            mock_cs.return_value.__aenter__ = AsyncMock(return_value=mock_session)
+            mock_cs.return_value.__aexit__ = AsyncMock(return_value=False)
+            await adapter._poll_loop()
+
+        assert len(sleep_totals) >= 2
+        for i in range(1, len(sleep_totals)):
+            assert sleep_totals[i] >= sleep_totals[i - 1]
+
+    @pytest.mark.asyncio
+    async def test_backoff_resets_on_success(self) -> None:
+        """Backoff resets to poll_interval after a successful poll."""
+        adapter, _ = _make_adapter(poll_interval=10)
+
+        poll_count = 0
+        sleep_totals: list[int] = []
+        current_total = 0
+
+        original_sleep = asyncio.sleep
+
+        async def _tracking_sleep(_: float) -> None:
+            nonlocal current_total
+            current_total += 1
+            await original_sleep(0)
+
+        async def _poll_status(session: object) -> None:
+            nonlocal poll_count, current_total
+            if poll_count > 0:
+                sleep_totals.append(current_total)
+                current_total = 0
+            poll_count += 1
+            if poll_count == 1:
+                import aiohttp
+                raise aiohttp.ClientError("down")
+            if poll_count >= 3:
+                adapter._stopping = True
+                return
+
+        adapter._poll_status = _poll_status  # type: ignore[method-assign]
+
+        with patch(
+            "oasisagent.ingestion.overseerr.aiohttp.ClientSession",
+        ) as mock_cs, patch(
+            "oasisagent.ingestion.overseerr.asyncio.sleep",
+            side_effect=_tracking_sleep,
+        ):
+            mock_session = AsyncMock()
+            mock_cs.return_value.__aenter__ = AsyncMock(return_value=mock_session)
+            mock_cs.return_value.__aexit__ = AsyncMock(return_value=False)
+            await adapter._poll_loop()
+
+        assert len(sleep_totals) >= 2
+        assert sleep_totals[-1] == adapter._config.poll_interval
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_ingestion/test_plex.py
+++ b/tests/test_ingestion/test_plex.py
@@ -2,7 +2,8 @@
 
 from __future__ import annotations
 
-from unittest.mock import AsyncMock, MagicMock
+import asyncio
+from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
 from pydantic import ValidationError
@@ -316,6 +317,107 @@ class TestKnownFixes:
 
         ids = [fix["id"] for fix in data["fixes"]]
         assert len(ids) == len(set(ids))
+
+
+# ---------------------------------------------------------------------------
+# Poll loop backoff
+# ---------------------------------------------------------------------------
+
+
+class TestPollLoopBackoff:
+    @pytest.mark.asyncio
+    async def test_backoff_increases_on_repeated_failures(self) -> None:
+        """Poll loop uses exponential backoff when service is persistently down."""
+        adapter, _ = _make_adapter(poll_interval=10)
+
+        poll_count = 0
+        sleep_totals: list[int] = []
+        current_total = 0
+
+        original_sleep = asyncio.sleep
+
+        async def _tracking_sleep(_: float) -> None:
+            nonlocal current_total
+            current_total += 1
+            await original_sleep(0)
+
+        async def _fail_check(_session: object) -> bool:
+            nonlocal poll_count, current_total
+            if poll_count > 0:
+                sleep_totals.append(current_total)
+                current_total = 0
+            poll_count += 1
+            if poll_count >= 4:
+                adapter._stopping = True
+                return False
+            import aiohttp
+            raise aiohttp.ClientError("connection refused")
+
+        adapter._check_server = _fail_check  # type: ignore[method-assign]
+        adapter._poll_libraries = AsyncMock()  # type: ignore[method-assign]
+
+        with patch(
+            "oasisagent.ingestion.plex.aiohttp.ClientSession",
+        ) as mock_cs, patch(
+            "oasisagent.ingestion.plex.asyncio.sleep",
+            side_effect=_tracking_sleep,
+        ):
+            mock_session = AsyncMock()
+            mock_cs.return_value.__aenter__ = AsyncMock(return_value=mock_session)
+            mock_cs.return_value.__aexit__ = AsyncMock(return_value=False)
+            await adapter._poll_loop()
+
+        assert len(sleep_totals) >= 2
+        for i in range(1, len(sleep_totals)):
+            assert sleep_totals[i] >= sleep_totals[i - 1]
+
+    @pytest.mark.asyncio
+    async def test_backoff_resets_on_success(self) -> None:
+        """Backoff resets to poll_interval after a successful poll."""
+        adapter, _ = _make_adapter(poll_interval=10)
+
+        poll_count = 0
+        sleep_totals: list[int] = []
+        current_total = 0
+
+        original_sleep = asyncio.sleep
+
+        async def _tracking_sleep(_: float) -> None:
+            nonlocal current_total
+            current_total += 1
+            await original_sleep(0)
+
+        async def _check_server(session: object) -> bool:
+            nonlocal poll_count, current_total
+            if poll_count > 0:
+                sleep_totals.append(current_total)
+                current_total = 0
+            poll_count += 1
+            if poll_count == 1:
+                import aiohttp
+                raise aiohttp.ClientError("down")
+            if poll_count >= 3:
+                adapter._stopping = True
+                return True
+            adapter._server_reachable = True
+            return True
+
+        adapter._check_server = _check_server  # type: ignore[method-assign]
+        adapter._poll_libraries = AsyncMock()  # type: ignore[method-assign]
+
+        with patch(
+            "oasisagent.ingestion.plex.aiohttp.ClientSession",
+        ) as mock_cs, patch(
+            "oasisagent.ingestion.plex.asyncio.sleep",
+            side_effect=_tracking_sleep,
+        ):
+            mock_session = AsyncMock()
+            mock_cs.return_value.__aenter__ = AsyncMock(return_value=mock_session)
+            mock_cs.return_value.__aexit__ = AsyncMock(return_value=False)
+            await adapter._poll_loop()
+
+        assert len(sleep_totals) >= 2
+        assert sleep_totals[-1] == adapter._config.poll_interval
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_ingestion/test_qbittorrent.py
+++ b/tests/test_ingestion/test_qbittorrent.py
@@ -2,7 +2,8 @@
 
 from __future__ import annotations
 
-from unittest.mock import AsyncMock, MagicMock
+import asyncio
+from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
 from pydantic import ValidationError
@@ -325,6 +326,96 @@ class TestKnownFixes:
 
         ids = [fix["id"] for fix in data["fixes"]]
         assert len(ids) == len(set(ids))
+
+
+# ---------------------------------------------------------------------------
+# Poll loop backoff
+# ---------------------------------------------------------------------------
+
+
+class TestPollLoopBackoff:
+    @pytest.mark.asyncio
+    async def test_backoff_increases_on_repeated_failures(self) -> None:
+        """Poll loop uses exponential backoff when service is persistently down."""
+        adapter, _ = _make_adapter(poll_interval=10)
+
+        poll_count = 0
+        sleep_totals: list[int] = []
+        current_total = 0
+
+        original_sleep = asyncio.sleep
+
+        async def _tracking_sleep(_: float) -> None:
+            nonlocal current_total
+            current_total += 1
+            await original_sleep(0)
+
+        async def _fail_session() -> None:
+            nonlocal poll_count, current_total
+            if poll_count > 0:
+                sleep_totals.append(current_total)
+                current_total = 0
+            poll_count += 1
+            if poll_count >= 4:
+                adapter._stopping = True
+                return MagicMock()
+            import aiohttp
+            raise aiohttp.ClientError("connection refused")
+
+        adapter._ensure_session = _fail_session  # type: ignore[method-assign]
+
+        with patch(
+            "oasisagent.ingestion.qbittorrent.asyncio.sleep",
+            side_effect=_tracking_sleep,
+        ):
+            await adapter._poll_loop()
+
+        assert len(sleep_totals) >= 2
+        for i in range(1, len(sleep_totals)):
+            assert sleep_totals[i] >= sleep_totals[i - 1]
+
+    @pytest.mark.asyncio
+    async def test_backoff_resets_on_success(self) -> None:
+        """Backoff resets to poll_interval after a successful poll."""
+        adapter, _ = _make_adapter(poll_interval=10)
+
+        poll_count = 0
+        sleep_totals: list[int] = []
+        current_total = 0
+
+        original_sleep = asyncio.sleep
+
+        async def _tracking_sleep(_: float) -> None:
+            nonlocal current_total
+            current_total += 1
+            await original_sleep(0)
+
+        async def _ensure_session() -> MagicMock:
+            nonlocal poll_count, current_total
+            if poll_count > 0:
+                sleep_totals.append(current_total)
+                current_total = 0
+            poll_count += 1
+            if poll_count == 1:
+                import aiohttp
+                raise aiohttp.ClientError("down")
+            if poll_count >= 3:
+                adapter._stopping = True
+            return MagicMock()
+
+        adapter._ensure_session = _ensure_session  # type: ignore[method-assign]
+        adapter._poll_transfer_info = AsyncMock()  # type: ignore[method-assign]
+        adapter._poll_errored_torrents = AsyncMock()  # type: ignore[method-assign]
+        adapter._poll_stalled_torrents = AsyncMock()  # type: ignore[method-assign]
+
+        with patch(
+            "oasisagent.ingestion.qbittorrent.asyncio.sleep",
+            side_effect=_tracking_sleep,
+        ):
+            await adapter._poll_loop()
+
+        assert len(sleep_totals) >= 2
+        assert sleep_totals[-1] == adapter._config.poll_interval
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_ingestion/test_servarr.py
+++ b/tests/test_ingestion/test_servarr.py
@@ -2,7 +2,8 @@
 
 from __future__ import annotations
 
-from unittest.mock import AsyncMock, MagicMock
+import asyncio
+from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
 from pydantic import ValidationError
@@ -414,6 +415,105 @@ class TestKnownFixes:
 
         ids = [fix["id"] for fix in data["fixes"]]
         assert len(ids) == len(set(ids))
+
+
+# ---------------------------------------------------------------------------
+# Poll loop backoff
+# ---------------------------------------------------------------------------
+
+
+class TestPollLoopBackoff:
+    @pytest.mark.asyncio
+    async def test_backoff_increases_on_repeated_failures(self) -> None:
+        """Poll loop uses exponential backoff when service is persistently down."""
+        adapter, _ = _make_adapter(poll_interval=10)
+
+        poll_count = 0
+        sleep_totals: list[int] = []
+        current_total = 0
+
+        original_sleep = asyncio.sleep
+
+        async def _tracking_sleep(_: float) -> None:
+            nonlocal current_total
+            current_total += 1
+            await original_sleep(0)
+
+        async def _fail_poll(_session: object) -> None:
+            nonlocal poll_count, current_total
+            if poll_count > 0:
+                sleep_totals.append(current_total)
+                current_total = 0
+            poll_count += 1
+            if poll_count >= 4:
+                adapter._stopping = True
+                return
+            import aiohttp
+            raise aiohttp.ClientError("connection refused")
+
+        adapter._poll_health = _fail_poll  # type: ignore[method-assign]
+        adapter._poll_queue = AsyncMock()  # type: ignore[method-assign]
+
+        with patch(
+            "oasisagent.ingestion.servarr.aiohttp.ClientSession",
+        ) as mock_cs, patch(
+            "oasisagent.ingestion.servarr.asyncio.sleep",
+            side_effect=_tracking_sleep,
+        ):
+            mock_session = AsyncMock()
+            mock_cs.return_value.__aenter__ = AsyncMock(return_value=mock_session)
+            mock_cs.return_value.__aexit__ = AsyncMock(return_value=False)
+            await adapter._poll_loop()
+
+        assert len(sleep_totals) >= 2
+        for i in range(1, len(sleep_totals)):
+            assert sleep_totals[i] >= sleep_totals[i - 1]
+
+    @pytest.mark.asyncio
+    async def test_backoff_resets_on_success(self) -> None:
+        """Backoff resets to poll_interval after a successful poll."""
+        adapter, _ = _make_adapter(poll_interval=10)
+
+        poll_count = 0
+        sleep_totals: list[int] = []
+        current_total = 0
+
+        original_sleep = asyncio.sleep
+
+        async def _tracking_sleep(_: float) -> None:
+            nonlocal current_total
+            current_total += 1
+            await original_sleep(0)
+
+        async def _poll_health(session: object) -> None:
+            nonlocal poll_count, current_total
+            if poll_count > 0:
+                sleep_totals.append(current_total)
+                current_total = 0
+            poll_count += 1
+            if poll_count == 1:
+                import aiohttp
+                raise aiohttp.ClientError("down")
+            if poll_count >= 3:
+                adapter._stopping = True
+                return
+
+        adapter._poll_health = _poll_health  # type: ignore[method-assign]
+        adapter._poll_queue = AsyncMock()  # type: ignore[method-assign]
+
+        with patch(
+            "oasisagent.ingestion.servarr.aiohttp.ClientSession",
+        ) as mock_cs, patch(
+            "oasisagent.ingestion.servarr.asyncio.sleep",
+            side_effect=_tracking_sleep,
+        ):
+            mock_session = AsyncMock()
+            mock_cs.return_value.__aenter__ = AsyncMock(return_value=mock_session)
+            mock_cs.return_value.__aexit__ = AsyncMock(return_value=False)
+            await adapter._poll_loop()
+
+        assert len(sleep_totals) >= 2
+        assert sleep_totals[-1] == adapter._config.poll_interval
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_ingestion/test_tautulli.py
+++ b/tests/test_ingestion/test_tautulli.py
@@ -2,7 +2,8 @@
 
 from __future__ import annotations
 
-from unittest.mock import AsyncMock, MagicMock
+import asyncio
+from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
 from pydantic import ValidationError
@@ -345,6 +346,105 @@ class TestBandwidthPolling:
 
         event = queue.put_nowait.call_args[0][0]
         assert event.metadata.dedup_key == "tautulli:bandwidth"
+
+
+# ---------------------------------------------------------------------------
+# Poll loop backoff
+# ---------------------------------------------------------------------------
+
+
+class TestPollLoopBackoff:
+    @pytest.mark.asyncio
+    async def test_backoff_increases_on_repeated_failures(self) -> None:
+        """Poll loop uses exponential backoff when service is persistently down."""
+        adapter, _ = _make_adapter(poll_interval=10)
+
+        poll_count = 0
+        sleep_totals: list[int] = []
+        current_total = 0
+
+        original_sleep = asyncio.sleep
+
+        async def _tracking_sleep(_: float) -> None:
+            nonlocal current_total
+            current_total += 1
+            await original_sleep(0)
+
+        async def _fail_poll(_session: object) -> None:
+            nonlocal poll_count, current_total
+            if poll_count > 0:
+                sleep_totals.append(current_total)
+                current_total = 0
+            poll_count += 1
+            if poll_count >= 4:
+                adapter._stopping = True
+                return
+            import aiohttp
+            raise aiohttp.ClientError("connection refused")
+
+        adapter._poll_server_status = _fail_poll  # type: ignore[method-assign]
+        adapter._poll_activity = AsyncMock()  # type: ignore[method-assign]
+
+        with patch(
+            "oasisagent.ingestion.tautulli.aiohttp.ClientSession",
+        ) as mock_cs, patch(
+            "oasisagent.ingestion.tautulli.asyncio.sleep",
+            side_effect=_tracking_sleep,
+        ):
+            mock_session = AsyncMock()
+            mock_cs.return_value.__aenter__ = AsyncMock(return_value=mock_session)
+            mock_cs.return_value.__aexit__ = AsyncMock(return_value=False)
+            await adapter._poll_loop()
+
+        assert len(sleep_totals) >= 2
+        for i in range(1, len(sleep_totals)):
+            assert sleep_totals[i] >= sleep_totals[i - 1]
+
+    @pytest.mark.asyncio
+    async def test_backoff_resets_on_success(self) -> None:
+        """Backoff resets to poll_interval after a successful poll."""
+        adapter, _ = _make_adapter(poll_interval=10)
+
+        poll_count = 0
+        sleep_totals: list[int] = []
+        current_total = 0
+
+        original_sleep = asyncio.sleep
+
+        async def _tracking_sleep(_: float) -> None:
+            nonlocal current_total
+            current_total += 1
+            await original_sleep(0)
+
+        async def _poll_status(session: object) -> None:
+            nonlocal poll_count, current_total
+            if poll_count > 0:
+                sleep_totals.append(current_total)
+                current_total = 0
+            poll_count += 1
+            if poll_count == 1:
+                import aiohttp
+                raise aiohttp.ClientError("down")
+            if poll_count >= 3:
+                adapter._stopping = True
+                return
+
+        adapter._poll_server_status = _poll_status  # type: ignore[method-assign]
+        adapter._poll_activity = AsyncMock()  # type: ignore[method-assign]
+
+        with patch(
+            "oasisagent.ingestion.tautulli.aiohttp.ClientSession",
+        ) as mock_cs, patch(
+            "oasisagent.ingestion.tautulli.asyncio.sleep",
+            side_effect=_tracking_sleep,
+        ):
+            mock_session = AsyncMock()
+            mock_cs.return_value.__aenter__ = AsyncMock(return_value=mock_session)
+            mock_cs.return_value.__aexit__ = AsyncMock(return_value=False)
+            await adapter._poll_loop()
+
+        assert len(sleep_totals) >= 2
+        assert sleep_totals[-1] == adapter._config.poll_interval
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_ingestion/test_tdarr.py
+++ b/tests/test_ingestion/test_tdarr.py
@@ -2,7 +2,8 @@
 
 from __future__ import annotations
 
-from unittest.mock import MagicMock
+import asyncio
+from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
 from pydantic import ValidationError
@@ -267,6 +268,103 @@ class TestKnownFixes:
 
         fix_ids = {fix["id"] for fix in data["fixes"]}
         assert "tdarr-worker-failed" in fix_ids
+
+
+# ---------------------------------------------------------------------------
+# Poll loop backoff
+# ---------------------------------------------------------------------------
+
+
+class TestPollLoopBackoff:
+    @pytest.mark.asyncio
+    async def test_backoff_increases_on_repeated_failures(self) -> None:
+        """Poll loop uses exponential backoff when service is persistently down."""
+        adapter, _ = _make_adapter(poll_interval=10)
+
+        poll_count = 0
+        sleep_totals: list[int] = []
+        current_total = 0
+
+        original_sleep = asyncio.sleep
+
+        async def _tracking_sleep(_: float) -> None:
+            nonlocal current_total
+            current_total += 1
+            await original_sleep(0)
+
+        async def _fail_poll(_session: object) -> None:
+            nonlocal poll_count, current_total
+            if poll_count > 0:
+                sleep_totals.append(current_total)
+                current_total = 0
+            poll_count += 1
+            if poll_count >= 4:
+                adapter._stopping = True
+                return
+            import aiohttp
+            raise aiohttp.ClientError("connection refused")
+
+        adapter._poll_status = _fail_poll  # type: ignore[method-assign]
+
+        with patch(
+            "oasisagent.ingestion.tdarr.aiohttp.ClientSession",
+        ) as mock_cs, patch(
+            "oasisagent.ingestion.tdarr.asyncio.sleep",
+            side_effect=_tracking_sleep,
+        ):
+            mock_session = AsyncMock()
+            mock_cs.return_value.__aenter__ = AsyncMock(return_value=mock_session)
+            mock_cs.return_value.__aexit__ = AsyncMock(return_value=False)
+            await adapter._poll_loop()
+
+        assert len(sleep_totals) >= 2
+        for i in range(1, len(sleep_totals)):
+            assert sleep_totals[i] >= sleep_totals[i - 1]
+
+    @pytest.mark.asyncio
+    async def test_backoff_resets_on_success(self) -> None:
+        """Backoff resets to poll_interval after a successful poll."""
+        adapter, _ = _make_adapter(poll_interval=10)
+
+        poll_count = 0
+        sleep_totals: list[int] = []
+        current_total = 0
+
+        original_sleep = asyncio.sleep
+
+        async def _tracking_sleep(_: float) -> None:
+            nonlocal current_total
+            current_total += 1
+            await original_sleep(0)
+
+        async def _poll_status(session: object) -> None:
+            nonlocal poll_count, current_total
+            if poll_count > 0:
+                sleep_totals.append(current_total)
+                current_total = 0
+            poll_count += 1
+            if poll_count == 1:
+                import aiohttp
+                raise aiohttp.ClientError("down")
+            if poll_count >= 3:
+                adapter._stopping = True
+                return
+
+        adapter._poll_status = _poll_status  # type: ignore[method-assign]
+
+        with patch(
+            "oasisagent.ingestion.tdarr.aiohttp.ClientSession",
+        ) as mock_cs, patch(
+            "oasisagent.ingestion.tdarr.asyncio.sleep",
+            side_effect=_tracking_sleep,
+        ):
+            mock_session = AsyncMock()
+            mock_cs.return_value.__aenter__ = AsyncMock(return_value=mock_session)
+            mock_cs.return_value.__aexit__ = AsyncMock(return_value=False)
+            await adapter._poll_loop()
+
+        assert len(sleep_totals) >= 2
+        assert sleep_totals[-1] == adapter._config.poll_interval
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_ingestion/test_vaultwarden.py
+++ b/tests/test_ingestion/test_vaultwarden.py
@@ -2,7 +2,8 @@
 
 from __future__ import annotations
 
-from unittest.mock import AsyncMock, MagicMock
+import asyncio
+from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
 from pydantic import ValidationError
@@ -202,6 +203,106 @@ class TestUrlConstruction:
 
         called_url = mock_session.get.call_args[0][0]
         assert called_url == "http://localhost:8000/alive"
+
+
+# ---------------------------------------------------------------------------
+# Poll loop backoff
+# ---------------------------------------------------------------------------
+
+
+class TestPollLoopBackoff:
+    @pytest.mark.asyncio
+    async def test_backoff_increases_on_repeated_failures(self) -> None:
+        """Poll loop uses exponential backoff when service is persistently down."""
+        adapter, _ = _make_adapter(poll_interval=10)
+
+        poll_count = 0
+        sleep_totals: list[int] = []
+        current_total = 0
+
+        original_sleep = asyncio.sleep
+
+        async def _tracking_sleep(_: float) -> None:
+            nonlocal current_total
+            current_total += 1
+            await original_sleep(0)
+
+        async def _fail_poll(_session: object) -> None:
+            nonlocal poll_count, current_total
+            if poll_count > 0:
+                sleep_totals.append(current_total)
+                current_total = 0
+            poll_count += 1
+            if poll_count >= 4:
+                adapter._stopping = True
+                return
+            import aiohttp
+            raise aiohttp.ClientError("connection refused")
+
+        adapter._poll_health = _fail_poll  # type: ignore[method-assign]
+
+        with patch(
+            "oasisagent.ingestion.vaultwarden.aiohttp.ClientSession",
+        ) as mock_cs, patch(
+            "oasisagent.ingestion.vaultwarden.asyncio.sleep",
+            side_effect=_tracking_sleep,
+        ):
+            mock_session = AsyncMock()
+            mock_cs.return_value.__aenter__ = AsyncMock(return_value=mock_session)
+            mock_cs.return_value.__aexit__ = AsyncMock(return_value=False)
+            await adapter._poll_loop()
+
+        # Each subsequent wait should be >= the previous (exponential backoff)
+        assert len(sleep_totals) >= 2
+        for i in range(1, len(sleep_totals)):
+            assert sleep_totals[i] >= sleep_totals[i - 1]
+
+    @pytest.mark.asyncio
+    async def test_backoff_resets_on_success(self) -> None:
+        """Backoff resets to poll_interval after a successful poll."""
+        adapter, _ = _make_adapter(poll_interval=10)
+
+        poll_count = 0
+        sleep_totals: list[int] = []
+        current_total = 0
+
+        original_sleep = asyncio.sleep
+
+        async def _tracking_sleep(_: float) -> None:
+            nonlocal current_total
+            current_total += 1
+            await original_sleep(0)
+
+        async def _poll_health(session: object) -> None:
+            nonlocal poll_count, current_total
+            if poll_count > 0:
+                sleep_totals.append(current_total)
+                current_total = 0
+            poll_count += 1
+            if poll_count == 1:
+                import aiohttp
+                raise aiohttp.ClientError("down")
+            if poll_count >= 3:
+                adapter._stopping = True
+                return
+            # Success on poll 2
+
+        adapter._poll_health = _poll_health  # type: ignore[method-assign]
+
+        with patch(
+            "oasisagent.ingestion.vaultwarden.aiohttp.ClientSession",
+        ) as mock_cs, patch(
+            "oasisagent.ingestion.vaultwarden.asyncio.sleep",
+            side_effect=_tracking_sleep,
+        ):
+            mock_session = AsyncMock()
+            mock_cs.return_value.__aenter__ = AsyncMock(return_value=mock_session)
+            mock_cs.return_value.__aexit__ = AsyncMock(return_value=False)
+            await adapter._poll_loop()
+
+        # After success, wait should be poll_interval (10), not backoff
+        assert len(sleep_totals) >= 2
+        assert sleep_totals[-1] == adapter._config.poll_interval
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary
- **NPM adapter**: Add startup exponential backoff around `NpmClient.connect()` (5s -> 300s max), matching Frigate's pattern. Previously silently died on initial connection failure.
- **Per-poll adapters** (Vaultwarden, N8N, Servarr, Plex, Tautulli, Tdarr, Overseerr, qBittorrent): Add exponential backoff in the poll loop. On failure, wait time doubles (capped at 300s). On success, resets to `poll_interval`. Previously retried at fixed `poll_interval` even during extended outages.
- **18 new tests** across 9 adapter test files: verify backoff increases on repeated failures and resets on recovery.

Closes #198

## Test plan
- [x] `pytest --tb=short` — 2515 tests passing
- [x] `ruff check` — clean
- [ ] Review NPM startup backoff matches Frigate pattern
- [ ] Review per-poll adapters use backoff only when `_connected is False`
- [ ] Verify backoff caps at 300s and resets to `poll_interval` on success

🤖 Generated with [Claude Code](https://claude.com/claude-code)