### PR TITLE
Fix UniFi auto-disable to catch 403 in addition to 404

### DIFF
--- a/oasisagent/ingestion/unifi.py
+++ b/oasisagent/ingestion/unifi.py
@@ -105,7 +105,7 @@ class UnifiAdapter(IngestAdapter):
         if config.poll_dpi:
             self._endpoint_health["dpi"] = False
 
-        # Auto-disable endpoints that persistently return 404
+        # Auto-disable endpoints that persistently return 403/404
         self._404_counts: dict[str, int] = {}
         self._disabled_endpoints: set[str] = set()
 
@@ -209,7 +209,7 @@ class UnifiAdapter(IngestAdapter):
                 except asyncio.CancelledError:
                     return
                 except Exception as exc:
-                    if self._is_404(exc):
+                    if self._is_unsupported(exc):
                         count = self._404_counts.get(ep_name, 0) + 1
                         self._404_counts[ep_name] = count
                         if count >= _MAX_404_FAILURES:
@@ -762,7 +762,17 @@ class UnifiAdapter(IngestAdapter):
     # -----------------------------------------------------------------
 
     @staticmethod
-    def _is_404(exc: Exception) -> bool:
-        """Return True if the exception represents an HTTP 404 response."""
-        return isinstance(exc, aiohttp.ClientResponseError) and exc.status == 404
+    def _is_unsupported(exc: Exception) -> bool:
+        """Return True if the exception indicates an unsupported endpoint.
+
+        Matches 404 (not found) and 403 (forbidden) — both indicate the
+        endpoint is unavailable on this firmware or for this API user.
+        Transient 403s from session expiry are handled by the client's
+        automatic re-auth, so a 403 reaching here means the endpoint
+        itself is inaccessible.
+        """
+        return (
+            isinstance(exc, aiohttp.ClientResponseError)
+            and exc.status in (403, 404)
+        )
 

--- a/tests/test_ingestion/test_unifi.py
+++ b/tests/test_ingestion/test_unifi.py
@@ -1645,7 +1645,7 @@ class TestAutoDisable404:
                 await adapter._poll_anomalies()
                 adapter._404_counts.pop(ep_name, None)
             except Exception as exc:
-                if adapter._is_404(exc):
+                if adapter._is_unsupported(exc):
                     count = adapter._404_counts.get(ep_name, 0) + 1
                     adapter._404_counts[ep_name] = count
                     if count >= _MAX_404_FAILURES:
@@ -1697,8 +1697,8 @@ class TestAutoDisable404:
         assert "events" not in adapter._disabled_endpoints
 
     @pytest.mark.asyncio
-    async def test_is_404_detection(self) -> None:
-        """_is_404 correctly identifies 404 ClientResponseError."""
+    async def test_is_unsupported_detection(self) -> None:
+        """_is_unsupported correctly identifies 403/404 ClientResponseError."""
         import aiohttp
 
         exc_404 = aiohttp.ClientResponseError(
@@ -1706,6 +1706,12 @@ class TestAutoDisable404:
             history=(),
             status=404,
             message="Not Found",
+        )
+        exc_403 = aiohttp.ClientResponseError(
+            request_info=MagicMock(),
+            history=(),
+            status=403,
+            message="Forbidden",
         )
         exc_500 = aiohttp.ClientResponseError(
             request_info=MagicMock(),
@@ -1715,9 +1721,10 @@ class TestAutoDisable404:
         )
         exc_other = RuntimeError("connection lost")
 
-        assert UnifiAdapter._is_404(exc_404) is True
-        assert UnifiAdapter._is_404(exc_500) is False
-        assert UnifiAdapter._is_404(exc_other) is False
+        assert UnifiAdapter._is_unsupported(exc_404) is True
+        assert UnifiAdapter._is_unsupported(exc_403) is True
+        assert UnifiAdapter._is_unsupported(exc_500) is False
+        assert UnifiAdapter._is_unsupported(exc_other) is False
 
     @pytest.mark.asyncio
     async def test_poll_loop_auto_disables_on_404(self) -> None:
@@ -1764,7 +1771,7 @@ class TestAutoDisable404:
                     adapter._endpoint_health[ep_name] = True
                     adapter._404_counts.pop(ep_name, None)
                 except Exception as exc:
-                    if adapter._is_404(exc):
+                    if adapter._is_unsupported(exc):
                         count = adapter._404_counts.get(ep_name, 0) + 1
                         adapter._404_counts[ep_name] = count
                         if count >= 3:
@@ -1788,7 +1795,7 @@ class TestAutoDisable404:
             message="Server Error",
         )
 
-        assert not adapter._is_404(exc_500)
+        assert not adapter._is_unsupported(exc_500)
         assert adapter._404_counts.get("anomalies", 0) == 0
 
     @pytest.mark.asyncio


### PR DESCRIPTION
## Summary

- `stat/event` POST returns 403 on firmware that doesn't support it, but auto-disable only matched 404
- Renamed `_is_404()` to `_is_unsupported()` — now matches both 403 and 404
- Transient 403s from session expiry are handled by the client's re-auth before reaching the poll loop, so a 403 here means the endpoint is genuinely inaccessible

## Test plan

- [x] `test_is_unsupported_detection` — verifies 403 and 404 both return True, 500 and RuntimeError return False
- [x] `test_poll_loop_auto_disables_on_404` — integration test still passes
- [x] All 96 UniFi tests pass
- [x] ruff clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)