### PR TITLE
Allow multiple instances for Servarr connectors

### DIFF
--- a/oasisagent/ui/form_specs.py
+++ b/oasisagent/ui/form_specs.py
@@ -189,9 +189,16 @@ TYPE_DESCRIPTIONS: dict[str, str] = {
     "slack": "Send notifications via Slack Incoming Webhook",
 }
 
-# Types that only allow a single instance
+# Types that allow multiple instances (e.g., multiple Servarr apps)
+MULTI_INSTANCE_TYPES: frozenset[str] = frozenset({
+    "servarr",
+    "http_poller",
+    "webhook_receiver",
+})
+
+# Types that only allow a single instance (everything else)
 SINGLE_INSTANCE_TYPES: frozenset[str] = frozenset(
-    TYPE_DISPLAY_NAMES.keys()
+    TYPE_DISPLAY_NAMES.keys() - MULTI_INSTANCE_TYPES
 )
 
 


### PR DESCRIPTION
## Summary

- `SINGLE_INSTANCE_TYPES` was set to all connector types, blocking multiple Servarr instances
- Added `MULTI_INSTANCE_TYPES` frozenset with `servarr`, `http_poller`, and `webhook_receiver`
- `SINGLE_INSTANCE_TYPES` is now derived as the complement — everything not in multi-instance
- Users can now add separate connectors for Sonarr, Radarr, Prowlarr, and Bazarr

## Test plan

- [x] 269 form spec tests pass
- [x] ruff clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)