### PR TITLE
Migrate Orchestrator startup to DB-first component building

### DIFF
--- a/oasisagent/db/registry.py
+++ b/oasisagent/db/registry.py
@@ -59,10 +59,18 @@ from oasisagent.config import (
 
 @dataclass(frozen=True)
 class TypeMeta:
-    """Metadata for a stored config type."""
+    """Metadata for a stored config type.
+
+    ``module_path`` and ``class_name`` locate the runtime class for
+    types that can be instantiated directly from a DB row (adapters,
+    handlers, notification channels).  Infrastructure singletons
+    (LLM endpoints, guardrails, etc.) leave these empty.
+    """
 
     model: type[BaseModel]
     secret_fields: frozenset[str] = field(default_factory=frozenset)
+    module_path: str = ""
+    class_name: str = ""
 
 
 # ---------------------------------------------------------------------------
@@ -73,71 +81,106 @@ CONNECTOR_TYPES: dict[str, TypeMeta] = {
     "mqtt": TypeMeta(
         model=MqttIngestionConfig,
         secret_fields=frozenset({"password"}),
+        module_path="oasisagent.ingestion.mqtt",
+        class_name="MqttAdapter",
     ),
     "ha_websocket": TypeMeta(
         model=HaWebSocketConfig,
         secret_fields=frozenset({"token"}),
+        module_path="oasisagent.ingestion.ha_websocket",
+        class_name="HaWebSocketAdapter",
     ),
     "ha_log_poller": TypeMeta(
         model=HaLogPollerConfig,
         secret_fields=frozenset({"token"}),
+        module_path="oasisagent.ingestion.ha_log_poller",
+        class_name="HaLogPollerAdapter",
     ),
     "webhook_receiver": TypeMeta(
         model=WebhookSourceConfig,
         secret_fields=frozenset({"auth_secret"}),
+        # No adapter class — handled by the FastAPI webhook route.
     ),
     "http_poller": TypeMeta(
         model=HttpPollerTargetConfig,
         secret_fields=frozenset({"auth_password", "auth_value"}),
+        module_path="oasisagent.ingestion.http_poller",
+        class_name="HttpPollerAdapter",
     ),
     "unifi": TypeMeta(
         model=UnifiAdapterConfig,
         secret_fields=frozenset({"password"}),
+        module_path="oasisagent.ingestion.unifi",
+        class_name="UnifiAdapter",
     ),
     "cloudflare": TypeMeta(
         model=CloudflareAdapterConfig,
         secret_fields=frozenset({"api_token"}),
+        module_path="oasisagent.ingestion.cloudflare",
+        class_name="CloudflareAdapter",
     ),
     "uptime_kuma": TypeMeta(
         model=UptimeKumaAdapterConfig,
         secret_fields=frozenset({"api_key"}),
+        module_path="oasisagent.ingestion.uptime_kuma",
+        class_name="UptimeKumaAdapter",
     ),
     "frigate": TypeMeta(
         model=FrigateAdapterConfig,
+        module_path="oasisagent.ingestion.frigate",
+        class_name="FrigateAdapter",
     ),
     "npm": TypeMeta(
         model=NpmAdapterConfig,
         secret_fields=frozenset({"password"}),
+        module_path="oasisagent.ingestion.npm",
+        class_name="NpmAdapter",
     ),
     "servarr": TypeMeta(
         model=ServarrAdapterConfig,
         secret_fields=frozenset({"api_key"}),
+        module_path="oasisagent.ingestion.servarr",
+        class_name="ServarrAdapter",
     ),
     "qbittorrent": TypeMeta(
         model=QBittorrentAdapterConfig,
         secret_fields=frozenset({"password"}),
+        module_path="oasisagent.ingestion.qbittorrent",
+        class_name="QBittorrentAdapter",
     ),
     "plex": TypeMeta(
         model=PlexAdapterConfig,
         secret_fields=frozenset({"token"}),
+        module_path="oasisagent.ingestion.plex",
+        class_name="PlexAdapter",
     ),
     "tautulli": TypeMeta(
         model=TautulliAdapterConfig,
         secret_fields=frozenset({"api_key"}),
+        module_path="oasisagent.ingestion.tautulli",
+        class_name="TautulliAdapter",
     ),
     "tdarr": TypeMeta(
         model=TdarrAdapterConfig,
+        module_path="oasisagent.ingestion.tdarr",
+        class_name="TdarrAdapter",
     ),
     "n8n": TypeMeta(
         model=N8nAdapterConfig,
         secret_fields=frozenset({"api_key"}),
+        module_path="oasisagent.ingestion.n8n",
+        class_name="N8nAdapter",
     ),
     "overseerr": TypeMeta(
         model=OverseerrAdapterConfig,
         secret_fields=frozenset({"api_key"}),
+        module_path="oasisagent.ingestion.overseerr",
+        class_name="OverseerrAdapter",
     ),
     "vaultwarden": TypeMeta(
         model=VaultwardenAdapterConfig,
+        module_path="oasisagent.ingestion.vaultwarden",
+        class_name="VaultwardenAdapter",
     ),
 }
 
@@ -147,6 +190,7 @@ CONNECTOR_TYPES: dict[str, TypeMeta] = {
 # ---------------------------------------------------------------------------
 
 CORE_SERVICE_TYPES: dict[str, TypeMeta] = {
+    # --- Infrastructure singletons (no module_path — built by _build_infrastructure) ---
     "llm_triage": TypeMeta(
         model=LlmEndpointConfig,
         secret_fields=frozenset({"api_key"}),
@@ -157,29 +201,6 @@ CORE_SERVICE_TYPES: dict[str, TypeMeta] = {
     ),
     "llm_options": TypeMeta(
         model=LlmOptionsConfig,
-    ),
-    "ha_handler": TypeMeta(
-        model=HaHandlerConfig,
-        secret_fields=frozenset({"token"}),
-    ),
-    "docker_handler": TypeMeta(
-        model=DockerHandlerConfig,
-    ),
-    "portainer_handler": TypeMeta(
-        model=PortainerHandlerConfig,
-        secret_fields=frozenset({"api_key"}),
-    ),
-    "proxmox_handler": TypeMeta(
-        model=ProxmoxHandlerConfig,
-        secret_fields=frozenset({"token_value"}),
-    ),
-    "unifi_handler": TypeMeta(
-        model=UnifiHandlerConfig,
-        secret_fields=frozenset({"password"}),
-    ),
-    "cloudflare_handler": TypeMeta(
-        model=CloudflareHandlerConfig,
-        secret_fields=frozenset({"api_token"}),
     ),
     "influxdb": TypeMeta(
         model=InfluxDbConfig,
@@ -194,6 +215,42 @@ CORE_SERVICE_TYPES: dict[str, TypeMeta] = {
     "scanner": TypeMeta(
         model=ScannerConfig,
     ),
+    # --- Handlers (instantiable from DB rows) ---
+    "ha_handler": TypeMeta(
+        model=HaHandlerConfig,
+        secret_fields=frozenset({"token"}),
+        module_path="oasisagent.handlers.homeassistant",
+        class_name="HomeAssistantHandler",
+    ),
+    "docker_handler": TypeMeta(
+        model=DockerHandlerConfig,
+        module_path="oasisagent.handlers.docker",
+        class_name="DockerHandler",
+    ),
+    "portainer_handler": TypeMeta(
+        model=PortainerHandlerConfig,
+        secret_fields=frozenset({"api_key"}),
+        module_path="oasisagent.handlers.portainer",
+        class_name="PortainerHandler",
+    ),
+    "proxmox_handler": TypeMeta(
+        model=ProxmoxHandlerConfig,
+        secret_fields=frozenset({"token_value"}),
+        module_path="oasisagent.handlers.proxmox",
+        class_name="ProxmoxHandler",
+    ),
+    "unifi_handler": TypeMeta(
+        model=UnifiHandlerConfig,
+        secret_fields=frozenset({"password"}),
+        module_path="oasisagent.handlers.unifi",
+        class_name="UnifiHandler",
+    ),
+    "cloudflare_handler": TypeMeta(
+        model=CloudflareHandlerConfig,
+        secret_fields=frozenset({"api_token"}),
+        module_path="oasisagent.handlers.cloudflare",
+        class_name="CloudflareHandler",
+    ),
 }
 
 
@@ -205,25 +262,37 @@ NOTIFICATION_TYPES: dict[str, TypeMeta] = {
     "mqtt_notification": TypeMeta(
         model=MqttNotificationConfig,
         secret_fields=frozenset({"password"}),
+        module_path="oasisagent.notifications.mqtt",
+        class_name="MqttNotificationChannel",
     ),
     "email": TypeMeta(
         model=EmailNotificationConfig,
         secret_fields=frozenset({"password"}),
+        module_path="oasisagent.notifications.email",
+        class_name="EmailNotificationChannel",
     ),
     "webhook": TypeMeta(
         model=WebhookNotificationConfig,
+        module_path="oasisagent.notifications.webhook",
+        class_name="WebhookNotificationChannel",
     ),
     "telegram": TypeMeta(
         model=TelegramNotificationConfig,
         secret_fields=frozenset({"bot_token"}),
+        module_path="oasisagent.notifications.telegram",
+        class_name="TelegramChannel",
     ),
     "discord": TypeMeta(
         model=DiscordNotificationConfig,
         secret_fields=frozenset({"webhook_url"}),
+        module_path="oasisagent.notifications.discord",
+        class_name="DiscordNotificationChannel",
     ),
     "slack": TypeMeta(
         model=SlackNotificationConfig,
         secret_fields=frozenset({"webhook_url"}),
+        module_path="oasisagent.notifications.slack",
+        class_name="SlackNotificationChannel",
     ),
 }
 

--- a/oasisagent/orchestrator.py
+++ b/oasisagent/orchestrator.py
@@ -167,7 +167,8 @@ class Orchestrator:
         self._config_store = config_store
         self._shutting_down = False
 
-        # Components — populated by _build_components()
+        # Components — populated by _build_infrastructure() + _build_db_components()
+        # (or _build_components_from_config() as fallback)
         self._queue: EventQueue | None = None
         self._correlator: EventCorrelator | None = None
         self._registry: KnownFixRegistry | None = None
@@ -236,12 +237,23 @@ class Orchestrator:
 
         Call this from FastAPI lifespan startup. Does NOT install signal
         handlers — under uvicorn, signal handling belongs to uvicorn.
+
+        Two-phase startup:
+        1. ``_build_infrastructure()`` — sync singletons from config
+        2. ``_build_db_components()`` — async, queries SQLite tables
+           OR ``_build_components_from_config()`` — sync fallback
         """
-        self._build_components()
+        # Phase A: infrastructure singletons (always from config)
+        self._build_infrastructure()
+
+        # Phase B: user-configurable components (DB or config fallback)
+        if self._config_store is not None:
+            await self._build_db_components()
+        else:
+            self._build_components_from_config()
 
         # Upgrade pending queue, notification store, and stats from SQLite
-        # when available. Must happen after _build_components and before
-        # _start_components.
+        # when available. Must happen after components and before start.
         if self._db is not None:
             self._pending_queue = await PendingQueue.from_db(self._db)
 
@@ -570,13 +582,6 @@ class Orchestrator:
             )
             return False
 
-        # Reload full config from database
-        try:
-            new_config = await store.load_config()
-        except Exception:
-            logger.exception("Failed to reload config for service restart")
-            return False
-
         # Stop the old handler
         old_handler = self._handlers.get(handler_name)
         if old_handler is not None:
@@ -590,10 +595,10 @@ class Orchestrator:
             logger.info("Service %d disabled, removed handler", service_id)
             return True
 
-        # Build a new handler from the refreshed config
-        new_handler = self._build_handler(handler_name, new_config)
+        # Build a new handler directly from the database row config
+        new_handler = self._build_handler_from_row(db_type, row["config"])
         if new_handler is None:
-            logger.info("Service %d not enabled in config after reload", service_id)
+            logger.info("Service %d: handler type %s not buildable", service_id, db_type)
             return True
 
         # Start the new handler
@@ -635,13 +640,6 @@ class Orchestrator:
             logger.error("Cannot restart notification: no dispatcher")
             return False
 
-        # Reload full config from database
-        try:
-            new_config = await store.load_config()
-        except Exception:
-            logger.exception("Failed to reload config for notification restart")
-            return False
-
         # Find the channel name that maps to this DB type
         channel_name: str | None = None
         for cname, ctype in self._CHANNEL_NAME_TO_TYPE.items():
@@ -673,10 +671,12 @@ class Orchestrator:
             logger.info("Notification %d disabled, removed channel", notification_id)
             return True
 
-        # Build a new channel from the refreshed config
-        new_channel = self._build_notification_channel(db_type, new_config)
+        # Build a new channel directly from the database row config
+        new_channel = self._build_notification_from_row(db_type, row["config"])
         if new_channel is None:
-            logger.info("Notification %d not enabled in config after reload", notification_id)
+            logger.info(
+                "Notification %d: type %s not buildable", notification_id, db_type,
+            )
             return True
 
         # Start and add the new channel
@@ -697,10 +697,14 @@ class Orchestrator:
     ) -> IngestAdapter | None:
         """Build an adapter directly from a database row's config dict.
 
-        This is used by restart_connector to construct adapters from
-        UI-created connectors that aren't in the YAML config file.
+        Uses the registry's ``module_path`` / ``class_name`` to locate the
+        adapter class — no hardcoded mapping needed.  Returns ``None`` for
+        types that have no adapter class (webhook_receiver, http_poller
+        when handled via aggregation).
         """
         assert self._queue is not None
+        import importlib
+
         from oasisagent.db.registry import get_type_meta
 
         try:
@@ -708,37 +712,66 @@ class Orchestrator:
         except ValueError:
             return None
 
+        if not meta.module_path:
+            return None
+
         # Validate the config through the Pydantic model
         adapter_config = meta.model(**{**row_config, "enabled": True})
 
-        # Map db_type → adapter class
-        adapter_map: dict[str, tuple[str, str]] = {
-            "mqtt": ("oasisagent.ingestion.mqtt", "MqttAdapter"),
-            "ha_websocket": ("oasisagent.ingestion.ha_websocket", "HaWebSocketAdapter"),
-            "ha_log_poller": ("oasisagent.ingestion.ha_log_poller", "HaLogPollerAdapter"),
-            "uptime_kuma": ("oasisagent.ingestion.uptime_kuma", "UptimeKumaAdapter"),
-            "unifi": ("oasisagent.ingestion.unifi", "UnifiAdapter"),
-            "cloudflare": ("oasisagent.ingestion.cloudflare", "CloudflareAdapter"),
-            "npm": ("oasisagent.ingestion.npm", "NpmAdapter"),
-            "frigate": ("oasisagent.ingestion.frigate", "FrigateAdapter"),
-            "n8n": ("oasisagent.ingestion.n8n", "N8nAdapter"),
-            "vaultwarden": ("oasisagent.ingestion.vaultwarden", "VaultwardenAdapter"),
-            "overseerr": ("oasisagent.ingestion.overseerr", "OverseerrAdapter"),
-            "qbittorrent": ("oasisagent.ingestion.qbittorrent", "QBittorrentAdapter"),
-            "plex": ("oasisagent.ingestion.plex", "PlexAdapter"),
-            "tautulli": ("oasisagent.ingestion.tautulli", "TautulliAdapter"),
-            "tdarr": ("oasisagent.ingestion.tdarr", "TdarrAdapter"),
-            "servarr": ("oasisagent.ingestion.servarr", "ServarrAdapter"),
-        }
+        module = importlib.import_module(meta.module_path)
+        cls = getattr(module, meta.class_name)
+        return cls(adapter_config, self._queue)
 
-        entry = adapter_map.get(db_type)
-        if entry is None:
+    def _build_handler_from_row(
+        self, db_type: str, row_config: dict[str, Any],
+    ) -> Handler | None:
+        """Build a handler directly from a database row's config dict.
+
+        Uses the registry's ``module_path`` / ``class_name``.  Returns
+        ``None`` for non-handler service types (LLM, guardrails, etc.)
+        which have empty ``module_path``.
+        """
+        import importlib
+
+        from oasisagent.db.registry import get_type_meta
+
+        try:
+            meta = get_type_meta("core_services", db_type)
+        except ValueError:
             return None
 
+        if not meta.module_path:
+            return None
+
+        config = meta.model(**{**row_config, "enabled": True})
+        module = importlib.import_module(meta.module_path)
+        cls = getattr(module, meta.class_name)
+        return cls(config)
+
+    def _build_notification_from_row(
+        self, db_type: str, row_config: dict[str, Any],
+    ) -> NotificationChannel | None:
+        """Build a notification channel directly from a database row's config.
+
+        Uses the registry's ``module_path`` / ``class_name``.  Returns
+        ``None`` for unknown types.
+        """
         import importlib
-        module = importlib.import_module(entry[0])
-        cls = getattr(module, entry[1])
-        return cls(adapter_config, self._queue)
+
+        from oasisagent.db.registry import get_type_meta
+
+        try:
+            meta = get_type_meta("notification_channels", db_type)
+        except ValueError:
+            return None
+
+        if not meta.module_path:
+            return None
+
+        config = meta.model(**{**row_config, "enabled": True})
+        module = importlib.import_module(meta.module_path)
+        cls = getattr(module, meta.class_name)
+        return cls(config)
 
     def _build_adapter(
         self, db_type: str, config: OasisAgentConfig,
@@ -872,8 +905,13 @@ class Orchestrator:
     # Component construction
     # -------------------------------------------------------------------
 
-    def _build_components(self) -> None:
-        """Instantiate all components from config. No I/O — just wiring."""
+    def _build_infrastructure(self) -> None:
+        """Instantiate system singletons from config. No I/O — just wiring.
+
+        These are infrastructure components that are NOT configurable
+        per-component via the UI. They are always built from
+        ``self._config`` (the OasisAgentConfig from ``store.load_config()``).
+        """
         cfg = self._config
 
         # 1. Event queue
@@ -895,24 +933,22 @@ class Orchestrator:
         else:
             logger.warning("Known fixes directory not found: %s", fixes_dir)
 
-        # 3. Circuit breaker
+        # 4. Circuit breaker
         self._circuit_breaker = CircuitBreaker(cfg.guardrails.circuit_breaker)
 
-        # 4. Guardrails engine
+        # 5. Guardrails engine
         self._guardrails = GuardrailsEngine(cfg.guardrails)
 
-        # 5. LLM client (stateless)
+        # 6. LLM client (stateless)
         self._llm_client = LLMClient(cfg.llm)
 
-        # 6. Triage service
+        # 7. Triage service
         self._triage_service = TriageService(self._llm_client)
 
-        # 7. Reasoning service (T2)
-        # TODO: Wire entity_context fetching (handler.get_context()) into the
-        # T2 pipeline once §16.2 entity context enrichment is implemented.
+        # 8. Reasoning service (T2)
         self._reasoning_service = ReasoningService(self._llm_client)
 
-        # 8. Decision engine
+        # 9. Decision engine
         self._decision_engine = DecisionEngine(
             registry=self._registry,
             guardrails=self._guardrails,
@@ -920,7 +956,39 @@ class Orchestrator:
             reasoning_service=self._reasoning_service,
         )
 
-        # 9. Handlers
+        # 10. Audit writer
+        self._audit = AuditWriter(cfg.audit)
+
+        # 11. Pending action queue (in-memory; upgraded to persistent in start())
+        self._pending_queue = PendingQueue()
+
+        # 12. Metrics server (Prometheus)
+        if cfg.agent.metrics_port > 0:
+            from oasisagent import metrics as metrics_mod
+
+            self._metrics_server = MetricsServer(cfg.agent.metrics_port)
+            metrics_mod.set_callback_sources(self._queue, self._pending_queue)
+
+    def _build_components(self) -> None:
+        """Build all components from config (backward-compat for tests).
+
+        Equivalent to ``_build_infrastructure()`` +
+        ``_build_components_from_config()``.
+        """
+        self._build_infrastructure()
+        self._build_components_from_config()
+
+    def _build_components_from_config(self) -> None:
+        """Build user-configurable components from OasisAgentConfig.
+
+        This is the sync fallback for standalone mode (no DB / tests).
+        Only builds adapters, handlers, and notifications — infrastructure
+        singletons must already be built by ``_build_infrastructure()``.
+        """
+        cfg = self._config
+        assert self._queue is not None
+
+        # --- Handlers ---
         if cfg.handlers.homeassistant.enabled:
             ha = HomeAssistantHandler(cfg.handlers.homeassistant)
             self._handlers[ha.name()] = ha
@@ -948,11 +1016,8 @@ class Orchestrator:
             cf_h = CloudflareHandler(cfg.handlers.cloudflare)
             self._handlers[cf_h.name()] = cf_h
 
-        # 10. Audit writer
-        self._audit = AuditWriter(cfg.audit)
-
-        # 11. Notification channels
-        channels = []
+        # --- Notification channels ---
+        channels: list[NotificationChannel] = []
         if cfg.notifications.mqtt.enabled:
             channels.append(MqttNotificationChannel(cfg.notifications.mqtt))
         if cfg.notifications.email.enabled:
@@ -977,12 +1042,7 @@ class Orchestrator:
             channels.append(SlackNotificationChannel(cfg.notifications.slack))
         self._dispatcher = NotificationDispatcher(channels)
 
-        # 12. Pending action queue (for RECOMMEND-tier actions)
-        # Initialized as in-memory here; upgraded to persistent in start()
-        # when a database connection is available.
-        self._pending_queue = PendingQueue()
-
-        # 13. Approval listener (subscribes to MQTT approve/reject topics)
+        # --- Approval listener ---
         if cfg.ingestion.mqtt.enabled:
             self._approval_listener = ApprovalListener(
                 config=cfg.ingestion.mqtt,
@@ -990,7 +1050,7 @@ class Orchestrator:
                 on_reject=self._handle_rejection,
             )
 
-        # 14. Ingestion adapters
+        # --- Ingestion adapters ---
         if cfg.ingestion.mqtt.enabled:
             self._adapters.append(MqttAdapter(cfg.ingestion.mqtt, self._queue))
         if cfg.ingestion.ha_websocket.enabled:
@@ -1026,65 +1086,304 @@ class Orchestrator:
                 UptimeKumaAdapter(cfg.ingestion.uptime_kuma, self._queue)
             )
 
-        # 14b. Scanner adapters (each scanner is its own adapter)
-        if cfg.scanner.enabled:
-            adaptive_kw = {
-                "adaptive_enabled": cfg.scanner.adaptive_enabled,
-                "adaptive_fast_factor": cfg.scanner.adaptive_fast_factor,
-                "adaptive_recovery_scans": cfg.scanner.adaptive_recovery_scans,
-            }
-            if cfg.scanner.certificate_expiry.enabled:
+        # --- Scanners ---
+        self._build_scanners_from_config(cfg)
+
+    def _build_scanners_from_config(self, cfg: OasisAgentConfig) -> None:
+        """Build scanner adapters from config (config-driven fallback)."""
+        assert self._queue is not None
+        if not cfg.scanner.enabled:
+            return
+
+        adaptive_kw = {
+            "adaptive_enabled": cfg.scanner.adaptive_enabled,
+            "adaptive_fast_factor": cfg.scanner.adaptive_fast_factor,
+            "adaptive_recovery_scans": cfg.scanner.adaptive_recovery_scans,
+        }
+        if cfg.scanner.certificate_expiry.enabled:
+            from oasisagent.scanner.cert_expiry import CertExpiryScannerAdapter
+
+            interval = cfg.scanner.certificate_expiry.interval or cfg.scanner.interval
+            self._adapters.append(CertExpiryScannerAdapter(
+                cfg.scanner.certificate_expiry, self._queue, interval,
+                **adaptive_kw,
+            ))
+        if cfg.scanner.disk_space.enabled:
+            from oasisagent.scanner.disk_space import DiskSpaceScannerAdapter
+
+            interval = cfg.scanner.disk_space.interval or cfg.scanner.interval
+            self._adapters.append(DiskSpaceScannerAdapter(
+                cfg.scanner.disk_space, self._queue, interval,
+                **adaptive_kw,
+            ))
+        if cfg.scanner.ha_health.enabled and cfg.handlers.homeassistant.enabled:
+            from oasisagent.scanner.ha_health import HaHealthScannerAdapter
+
+            interval = cfg.scanner.ha_health.interval or cfg.scanner.interval
+            self._adapters.append(HaHealthScannerAdapter(
+                cfg.scanner.ha_health, self._queue, interval,
+                ha_config=cfg.handlers.homeassistant,
+                **adaptive_kw,
+            ))
+        if cfg.scanner.docker_health.enabled and cfg.handlers.docker.enabled:
+            from oasisagent.scanner.docker_health import DockerHealthScannerAdapter
+
+            interval = cfg.scanner.docker_health.interval or cfg.scanner.interval
+            self._adapters.append(DockerHealthScannerAdapter(
+                cfg.scanner.docker_health, self._queue, interval,
+                docker_config=cfg.handlers.docker,
+                **adaptive_kw,
+            ))
+        if cfg.scanner.backup_freshness.enabled:
+            from oasisagent.scanner.backup_freshness import (
+                BackupFreshnessScannerAdapter,
+            )
+
+            interval = (
+                cfg.scanner.backup_freshness.interval or cfg.scanner.interval
+            )
+            self._adapters.append(BackupFreshnessScannerAdapter(
+                cfg.scanner.backup_freshness, self._queue, interval,
+            ))
+
+    async def _build_db_components(self) -> None:
+        """Build all user-configurable components from SQLite tables.
+
+        Queries ``connectors``, ``core_services``, and
+        ``notification_channels`` tables directly. Per-row try/except so
+        one bad config row never blocks others from starting.
+        """
+        store = self._config_store
+        assert store is not None
+        assert self._queue is not None
+
+        from oasisagent.db.registry import get_type_meta
+
+        # === Pass 1: Connectors ===
+        connector_rows = await store.list_connectors()
+        http_poller_configs: list[dict[str, Any]] = []
+
+        for row in connector_rows:
+            if not row["enabled"]:
+                continue
+            if row["type"] == "http_poller":
+                http_poller_configs.append(row["config"])
+                continue
+            try:
+                adapter = self._build_adapter_from_row(row["type"], row["config"])
+                if adapter is not None:
+                    self._adapters.append(adapter)
+            except Exception:
+                logger.exception(
+                    "Failed to build adapter %s (id=%d)", row["type"], row["id"],
+                )
+
+        # HTTP poller is many-to-one: all rows become one adapter
+        if http_poller_configs:
+            try:
+                from oasisagent.config import HttpPollerTargetConfig
+
+                targets = [
+                    HttpPollerTargetConfig(**{**cfg, "enabled": True})
+                    for cfg in http_poller_configs
+                ]
+                self._adapters.append(HttpPollerAdapter(targets, self._queue))
+            except Exception:
+                logger.exception("Failed to build http_poller adapter")
+
+        # === Pass 2: Handlers (before scanners) ===
+        service_rows = await store.list_services()
+        handler_db_types = set(self._HANDLER_NAME_TO_TYPE.values())
+
+        for row in service_rows:
+            if not row["enabled"] or row["type"] not in handler_db_types:
+                continue
+            try:
+                handler = self._build_handler_from_row(row["type"], row["config"])
+                if handler is not None:
+                    self._handlers[handler.name()] = handler
+            except Exception:
+                logger.exception(
+                    "Failed to build handler %s (id=%d)", row["type"], row["id"],
+                )
+
+        # === Pass 3: Scanners (after handlers — needs handler configs) ===
+        await self._build_scanners_from_db(service_rows)
+
+        # === Pass 4: Notification channels ===
+        notification_rows = await store.list_notifications()
+        channels: list[NotificationChannel] = []
+        for row in notification_rows:
+            if not row["enabled"]:
+                continue
+            try:
+                channel = self._build_notification_from_row(
+                    row["type"], row["config"],
+                )
+                if channel is not None:
+                    channels.append(channel)
+            except Exception:
+                logger.exception(
+                    "Failed to build notification %s (id=%d)",
+                    row["type"], row["id"],
+                )
+        self._dispatcher = NotificationDispatcher(channels)
+
+        # === Pass 5: Approval listener ===
+        mqtt_rows = [
+            r for r in connector_rows
+            if r["type"] == "mqtt" and r["enabled"]
+        ]
+        if len(mqtt_rows) > 1:
+            logger.warning(
+                "Multiple MQTT connectors enabled (%d) — using first for approval listener",
+                len(mqtt_rows),
+            )
+        if mqtt_rows:
+            try:
+                meta = get_type_meta("connectors", "mqtt")
+                mqtt_config = meta.model(**{**mqtt_rows[0]["config"], "enabled": True})
+                self._approval_listener = ApprovalListener(
+                    config=mqtt_config,
+                    on_approve=self._handle_approval,
+                    on_reject=self._handle_rejection,
+                )
+            except Exception:
+                logger.exception("Failed to build approval listener from MQTT row")
+
+    async def _build_scanners_from_db(
+        self, service_rows: list[dict[str, Any]],
+    ) -> None:
+        """Build scanner adapters from the 'scanner' service row.
+
+        Scanners need handler configs for cross-references (ha_health needs
+        ha_handler config, docker_health needs docker_handler config), so
+        this runs after handlers are built (Pass 3).
+        """
+        assert self._queue is not None
+
+        from oasisagent.config import (
+            DockerHandlerConfig,
+            HaHandlerConfig,
+            ScannerConfig,
+        )
+
+        # Find the scanner service row
+        scanner_row = None
+        for row in service_rows:
+            if row["type"] == "scanner" and row["enabled"]:
+                scanner_row = row
+                break
+        if scanner_row is None:
+            return
+
+        try:
+            scanner_cfg = ScannerConfig(**{**scanner_row["config"], "enabled": True})
+        except Exception:
+            logger.exception("Failed to parse scanner config (id=%d)", scanner_row["id"])
+            return
+
+        adaptive_kw = {
+            "adaptive_enabled": scanner_cfg.adaptive_enabled,
+            "adaptive_fast_factor": scanner_cfg.adaptive_fast_factor,
+            "adaptive_recovery_scans": scanner_cfg.adaptive_recovery_scans,
+        }
+
+        if scanner_cfg.certificate_expiry.enabled:
+            try:
                 from oasisagent.scanner.cert_expiry import CertExpiryScannerAdapter
 
-                interval = cfg.scanner.certificate_expiry.interval or cfg.scanner.interval
+                interval = scanner_cfg.certificate_expiry.interval or scanner_cfg.interval
                 self._adapters.append(CertExpiryScannerAdapter(
-                    cfg.scanner.certificate_expiry, self._queue, interval,
+                    scanner_cfg.certificate_expiry, self._queue, interval,
                     **adaptive_kw,
                 ))
-            if cfg.scanner.disk_space.enabled:
+            except Exception:
+                logger.exception("Failed to build cert_expiry scanner")
+
+        if scanner_cfg.disk_space.enabled:
+            try:
                 from oasisagent.scanner.disk_space import DiskSpaceScannerAdapter
 
-                interval = cfg.scanner.disk_space.interval or cfg.scanner.interval
+                interval = scanner_cfg.disk_space.interval or scanner_cfg.interval
                 self._adapters.append(DiskSpaceScannerAdapter(
-                    cfg.scanner.disk_space, self._queue, interval,
+                    scanner_cfg.disk_space, self._queue, interval,
                     **adaptive_kw,
                 ))
-            if cfg.scanner.ha_health.enabled and cfg.handlers.homeassistant.enabled:
-                from oasisagent.scanner.ha_health import HaHealthScannerAdapter
+            except Exception:
+                logger.exception("Failed to build disk_space scanner")
 
-                interval = cfg.scanner.ha_health.interval or cfg.scanner.interval
-                self._adapters.append(HaHealthScannerAdapter(
-                    cfg.scanner.ha_health, self._queue, interval,
-                    ha_config=cfg.handlers.homeassistant,
-                    **adaptive_kw,
-                ))
-            if cfg.scanner.docker_health.enabled and cfg.handlers.docker.enabled:
-                from oasisagent.scanner.docker_health import DockerHealthScannerAdapter
+        # ha_health needs the ha_handler config
+        if scanner_cfg.ha_health.enabled:
+            ha_config = self._find_handler_config(service_rows, "ha_handler", HaHandlerConfig)
+            if ha_config is not None:
+                try:
+                    from oasisagent.scanner.ha_health import HaHealthScannerAdapter
 
-                interval = cfg.scanner.docker_health.interval or cfg.scanner.interval
-                self._adapters.append(DockerHealthScannerAdapter(
-                    cfg.scanner.docker_health, self._queue, interval,
-                    docker_config=cfg.handlers.docker,
-                    **adaptive_kw,
-                ))
-            if cfg.scanner.backup_freshness.enabled:
+                    interval = scanner_cfg.ha_health.interval or scanner_cfg.interval
+                    self._adapters.append(HaHealthScannerAdapter(
+                        scanner_cfg.ha_health, self._queue, interval,
+                        ha_config=ha_config,
+                        **adaptive_kw,
+                    ))
+                except Exception:
+                    logger.exception("Failed to build ha_health scanner")
+            else:
+                logger.warning(
+                    "ha_health scanner enabled but no enabled ha_handler found — skipping",
+                )
+
+        # docker_health needs the docker_handler config
+        if scanner_cfg.docker_health.enabled:
+            docker_config = self._find_handler_config(
+                service_rows, "docker_handler", DockerHandlerConfig,
+            )
+            if docker_config is not None:
+                try:
+                    from oasisagent.scanner.docker_health import DockerHealthScannerAdapter
+
+                    interval = scanner_cfg.docker_health.interval or scanner_cfg.interval
+                    self._adapters.append(DockerHealthScannerAdapter(
+                        scanner_cfg.docker_health, self._queue, interval,
+                        docker_config=docker_config,
+                        **adaptive_kw,
+                    ))
+                except Exception:
+                    logger.exception("Failed to build docker_health scanner")
+            else:
+                logger.warning(
+                    "docker_health scanner enabled but no enabled docker_handler found — skipping",
+                )
+
+        if scanner_cfg.backup_freshness.enabled:
+            try:
                 from oasisagent.scanner.backup_freshness import (
                     BackupFreshnessScannerAdapter,
                 )
 
                 interval = (
-                    cfg.scanner.backup_freshness.interval or cfg.scanner.interval
+                    scanner_cfg.backup_freshness.interval or scanner_cfg.interval
                 )
                 self._adapters.append(BackupFreshnessScannerAdapter(
-                    cfg.scanner.backup_freshness, self._queue, interval,
+                    scanner_cfg.backup_freshness, self._queue, interval,
                 ))
+            except Exception:
+                logger.exception("Failed to build backup_freshness scanner")
 
-        # 15. Metrics server (Prometheus)
-        if cfg.agent.metrics_port > 0:
-            from oasisagent import metrics as metrics_mod
-
-            self._metrics_server = MetricsServer(cfg.agent.metrics_port)
-            metrics_mod.set_callback_sources(self._queue, self._pending_queue)
+    @staticmethod
+    def _find_handler_config(
+        service_rows: list[dict[str, Any]],
+        handler_type: str,
+        config_cls: type,
+    ) -> object | None:
+        """Find an enabled handler row and return its validated config."""
+        for row in service_rows:
+            if row["type"] == handler_type and row["enabled"]:
+                try:
+                    return config_cls(**{**row["config"], "enabled": True})
+                except Exception:
+                    return None
+        return None
 
     # -------------------------------------------------------------------
     # Component lifecycle

--- a/tests/test_orchestrator_db_build.py
+++ b/tests/test_orchestrator_db_build.py
@@ -1,0 +1,531 @@
+"""Tests for DB-first component building in the Orchestrator.
+
+Covers ``_build_infrastructure()``, ``_build_db_components()``,
+``_build_components_from_config()`` fallback, and the from_row builder
+methods.
+"""
+
+from __future__ import annotations
+
+import logging
+from typing import Any
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from oasisagent.config import (
+    AgentConfig,
+    AuditConfig,
+    GuardrailsConfig,
+    HaHandlerConfig,
+    HandlersConfig,
+    HaWebSocketConfig,
+    InfluxDbConfig,
+    IngestionConfig,
+    LlmConfig,
+    LlmEndpointConfig,
+    MqttIngestionConfig,
+    MqttNotificationConfig,
+    NotificationsConfig,
+    OasisAgentConfig,
+)
+from oasisagent.db.registry import CONNECTOR_TYPES, CORE_SERVICE_TYPES, NOTIFICATION_TYPES
+from oasisagent.orchestrator import Orchestrator
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _make_config(**agent_overrides: Any) -> OasisAgentConfig:
+    """Create a minimal config for testing. All external services disabled."""
+    agent_defaults: dict[str, Any] = {
+        "event_queue_size": 100,
+        "shutdown_timeout": 2,
+        "event_ttl": 300,
+        "known_fixes_dir": "/nonexistent",
+    }
+    agent_defaults.update(agent_overrides)
+    return OasisAgentConfig(
+        agent=AgentConfig(**agent_defaults),
+        ingestion=IngestionConfig(
+            mqtt=MqttIngestionConfig(enabled=False),
+            ha_websocket=HaWebSocketConfig(enabled=False),
+        ),
+        llm=LlmConfig(
+            triage=LlmEndpointConfig(
+                base_url="http://localhost:11434/v1", model="test", api_key="test",
+            ),
+            reasoning=LlmEndpointConfig(
+                base_url="http://localhost:11434/v1", model="test", api_key="test",
+            ),
+        ),
+        handlers=HandlersConfig(homeassistant=HaHandlerConfig(enabled=False)),
+        guardrails=GuardrailsConfig(),
+        audit=AuditConfig(influxdb=InfluxDbConfig(enabled=False)),
+        notifications=NotificationsConfig(mqtt=MqttNotificationConfig(enabled=False)),
+    )
+
+
+def _mock_store(
+    *,
+    connectors: list[dict[str, Any]] | None = None,
+    services: list[dict[str, Any]] | None = None,
+    notifications: list[dict[str, Any]] | None = None,
+) -> MagicMock:
+    """Create a mock ConfigStore with list_* methods."""
+    store = MagicMock()
+    store.list_connectors = AsyncMock(return_value=connectors or [])
+    store.list_services = AsyncMock(return_value=services or [])
+    store.list_notifications = AsyncMock(return_value=notifications or [])
+    return store
+
+
+def _connector_row(
+    row_id: int, db_type: str, config: dict[str, Any],
+    *, enabled: bool = True, name: str = "",
+) -> dict[str, Any]:
+    return {
+        "id": row_id, "type": db_type,
+        "name": name or db_type,
+        "enabled": enabled, "config": config,
+        "created_at": "2026-01-01", "updated_at": "2026-01-01",
+    }
+
+
+def _service_row(
+    row_id: int, db_type: str, config: dict[str, Any],
+    *, enabled: bool = True, name: str = "",
+) -> dict[str, Any]:
+    return {
+        "id": row_id, "type": db_type,
+        "name": name or db_type,
+        "enabled": enabled, "config": config,
+        "created_at": "2026-01-01", "updated_at": "2026-01-01",
+    }
+
+
+def _notification_row(
+    row_id: int, db_type: str, config: dict[str, Any],
+    *, enabled: bool = True, name: str = "",
+) -> dict[str, Any]:
+    return {
+        "id": row_id, "type": db_type,
+        "name": name or db_type,
+        "enabled": enabled, "config": config,
+        "created_at": "2026-01-01", "updated_at": "2026-01-01",
+    }
+
+
+# ---------------------------------------------------------------------------
+# Happy path
+# ---------------------------------------------------------------------------
+
+
+class TestBuildInfrastructure:
+    def test_creates_all_singletons(self) -> None:
+        orch = Orchestrator(_make_config())
+        orch._build_infrastructure()
+
+        assert orch._queue is not None
+        assert orch._correlator is not None
+        assert orch._registry is not None
+        assert orch._circuit_breaker is not None
+        assert orch._guardrails is not None
+        assert orch._llm_client is not None
+        assert orch._triage_service is not None
+        assert orch._reasoning_service is not None
+        assert orch._decision_engine is not None
+        assert orch._audit is not None
+        assert orch._pending_queue is not None
+
+    def test_does_not_build_user_components(self) -> None:
+        orch = Orchestrator(_make_config())
+        orch._build_infrastructure()
+
+        assert orch._handlers == {}
+        assert orch._adapters == []
+        assert orch._dispatcher is None
+
+
+class TestBuildDbComponents:
+    async def test_builds_adapters_from_rows(self) -> None:
+        mock_adapter = MagicMock()
+        store = _mock_store(
+            connectors=[
+                _connector_row(1, "mqtt", {
+                    "host": "localhost", "port": 1883, "topics": ["test/#"],
+                }),
+            ],
+        )
+        orch = Orchestrator(_make_config(), config_store=store)
+        orch._build_infrastructure()
+
+        with patch.object(orch, "_build_adapter_from_row", return_value=mock_adapter):
+            await orch._build_db_components()
+
+        assert mock_adapter in orch._adapters
+
+    async def test_builds_handlers_from_rows(self) -> None:
+        mock_handler = MagicMock()
+        mock_handler.name.return_value = "homeassistant"
+        store = _mock_store(
+            services=[
+                _service_row(1, "ha_handler", {
+                    "url": "http://ha:8123", "token": "test",
+                }),
+            ],
+        )
+        orch = Orchestrator(_make_config(), config_store=store)
+        orch._build_infrastructure()
+
+        with patch.object(orch, "_build_handler_from_row", return_value=mock_handler):
+            await orch._build_db_components()
+
+        assert orch._handlers["homeassistant"] is mock_handler
+
+    async def test_builds_notifications_from_rows(self) -> None:
+        mock_channel = MagicMock()
+        store = _mock_store(
+            notifications=[
+                _notification_row(1, "email", {
+                    "smtp_host": "mail.test", "smtp_port": 587,
+                    "from_address": "a@b.c", "to_addresses": ["x@y.z"],
+                    "username": "u", "password": "p",
+                }),
+            ],
+        )
+        orch = Orchestrator(_make_config(), config_store=store)
+        orch._build_infrastructure()
+
+        with patch.object(orch, "_build_notification_from_row", return_value=mock_channel):
+            await orch._build_db_components()
+
+        assert orch._dispatcher is not None
+        assert mock_channel in orch._dispatcher.channels
+
+    async def test_builds_dispatcher_even_with_no_channels(self) -> None:
+        store = _mock_store()
+        orch = Orchestrator(_make_config(), config_store=store)
+        orch._build_infrastructure()
+        await orch._build_db_components()
+
+        assert orch._dispatcher is not None
+        assert orch._dispatcher.channels == []
+
+
+class TestStartupSequence:
+    async def test_infrastructure_then_db(self) -> None:
+        """start() calls infrastructure then db_components when store exists."""
+        store = _mock_store()
+        orch = Orchestrator(_make_config(), config_store=store)
+
+        call_order: list[str] = []
+        orig_infra = orch._build_infrastructure
+
+        def tracked_infra() -> None:
+            call_order.append("infrastructure")
+            orig_infra()
+
+        async def tracked_db() -> None:
+            call_order.append("db_components")
+            # Ensure dispatcher is created so _start_components works
+            from oasisagent.notifications.dispatcher import NotificationDispatcher
+            orch._dispatcher = NotificationDispatcher([])
+
+        with (
+            patch.object(orch, "_build_infrastructure", side_effect=tracked_infra),
+            patch.object(orch, "_build_db_components", side_effect=tracked_db),
+            patch.object(orch, "_start_components", new_callable=AsyncMock),
+        ):
+            await orch.start()
+
+        assert call_order == ["infrastructure", "db_components"]
+
+    async def test_fallback_to_config_when_no_store(self) -> None:
+        orch = Orchestrator(_make_config())
+
+        call_order: list[str] = []
+        orig_infra = orch._build_infrastructure
+
+        def tracked_infra() -> None:
+            call_order.append("infrastructure")
+            orig_infra()
+
+        def tracked_config() -> None:
+            call_order.append("config")
+            # Need dispatcher for _start_components
+            from oasisagent.notifications.dispatcher import NotificationDispatcher
+            orch._dispatcher = NotificationDispatcher([])
+
+        with (
+            patch.object(orch, "_build_infrastructure", side_effect=tracked_infra),
+            patch.object(orch, "_build_components_from_config", side_effect=tracked_config),
+            patch.object(orch, "_start_components", new_callable=AsyncMock),
+        ):
+            await orch.start()
+
+        assert call_order == ["infrastructure", "config"]
+
+
+class TestFromRowBuilders:
+    def test_adapter_from_row_uses_registry(self) -> None:
+        orch = Orchestrator(_make_config())
+        orch._build_infrastructure()
+
+        adapter = orch._build_adapter_from_row("mqtt", {
+            "broker": "mqtt://localhost:1883",
+        })
+        assert adapter is not None
+        assert adapter.name == "mqtt"
+
+    def test_handler_from_row_uses_registry(self) -> None:
+        orch = Orchestrator(_make_config())
+        orch._build_infrastructure()
+
+        handler = orch._build_handler_from_row("ha_handler", {
+            "url": "http://ha:8123", "token": "test-token",
+        })
+        assert handler is not None
+        assert handler.name() == "homeassistant"
+
+    def test_notification_from_row_uses_registry(self) -> None:
+        orch = Orchestrator(_make_config())
+
+        channel = orch._build_notification_from_row("mqtt_notification", {
+            "broker": "mqtt://localhost:1883",
+            "topic_prefix": "oasis/notifications",
+        })
+        assert channel is not None
+        assert channel.name() == "mqtt"
+
+
+# ---------------------------------------------------------------------------
+# Edge cases
+# ---------------------------------------------------------------------------
+
+
+class TestBadRowIsolation:
+    async def test_bad_adapter_row_does_not_block_others(self) -> None:
+        good_adapter = MagicMock()
+        good_adapter.name.return_value = "good"
+
+        def side_effect(db_type: str, config: dict[str, Any]) -> MagicMock | None:
+            if db_type == "bad_type":
+                raise ValueError("bad config")
+            return good_adapter
+
+        store = _mock_store(
+            connectors=[
+                _connector_row(1, "bad_type", {}),
+                _connector_row(2, "mqtt", {"host": "localhost"}),
+            ],
+        )
+        orch = Orchestrator(_make_config(), config_store=store)
+        orch._build_infrastructure()
+
+        with patch.object(orch, "_build_adapter_from_row", side_effect=side_effect):
+            await orch._build_db_components()
+
+        assert good_adapter in orch._adapters
+
+    async def test_bad_handler_row_does_not_block_others(self) -> None:
+        good_handler = MagicMock()
+        good_handler.name.return_value = "docker"
+
+        call_count = 0
+
+        def side_effect(db_type: str, config: dict[str, Any]) -> MagicMock | None:
+            nonlocal call_count
+            call_count += 1
+            if db_type == "ha_handler":
+                raise ValueError("bad ha config")
+            return good_handler
+
+        store = _mock_store(
+            services=[
+                _service_row(1, "ha_handler", {}),
+                _service_row(2, "docker_handler", {}),
+            ],
+        )
+        orch = Orchestrator(_make_config(), config_store=store)
+        orch._build_infrastructure()
+
+        with patch.object(orch, "_build_handler_from_row", side_effect=side_effect):
+            await orch._build_db_components()
+
+        assert orch._handlers.get("docker") is good_handler
+
+
+class TestHttpPollerAggregation:
+    async def test_three_rows_one_adapter(self) -> None:
+        store = _mock_store(
+            connectors=[
+                _connector_row(1, "http_poller", {
+                    "url": "http://svc1/health", "system": "svc1",
+                    "interval": 60,
+                }),
+                _connector_row(2, "http_poller", {
+                    "url": "http://svc2/health", "system": "svc2",
+                    "interval": 60,
+                }),
+                _connector_row(3, "http_poller", {
+                    "url": "http://svc3/health", "system": "svc3",
+                    "interval": 60,
+                }),
+            ],
+        )
+        orch = Orchestrator(_make_config(), config_store=store)
+        orch._build_infrastructure()
+        await orch._build_db_components()
+
+        # Should be exactly one HttpPollerAdapter with 3 targets
+        from oasisagent.ingestion.http_poller import HttpPollerAdapter
+        http_adapters = [a for a in orch._adapters if isinstance(a, HttpPollerAdapter)]
+        assert len(http_adapters) == 1
+        assert len(http_adapters[0]._targets) == 3
+
+
+class TestScannerHandlerCrossRef:
+    async def test_missing_handler_skips_scanner(self, caplog: pytest.LogCaptureFixture) -> None:
+        store = _mock_store(
+            services=[
+                _service_row(1, "scanner", {
+                    "interval": 900,
+                    "ha_health": {"enabled": True, "interval": 900},
+                }),
+                # No ha_handler row!
+            ],
+        )
+        orch = Orchestrator(_make_config(), config_store=store)
+        orch._build_infrastructure()
+
+        with caplog.at_level(logging.WARNING):
+            await orch._build_db_components()
+
+        assert "no enabled ha_handler found" in caplog.text.lower()
+        # No ha_health scanner should be built
+        scanner_adapters = [a for a in orch._adapters if a.name.startswith("scanner.")]
+        assert len(scanner_adapters) == 0
+
+
+class TestEmptyDb:
+    async def test_empty_tables_no_crash(self) -> None:
+        store = _mock_store()
+        orch = Orchestrator(_make_config(), config_store=store)
+        orch._build_infrastructure()
+        await orch._build_db_components()
+
+        assert orch._adapters == []
+        assert orch._handlers == {}
+        assert orch._dispatcher is not None
+        assert orch._dispatcher.channels == []
+
+    async def test_all_rows_disabled_no_components(self) -> None:
+        store = _mock_store(
+            connectors=[
+                _connector_row(1, "mqtt", {}, enabled=False),
+            ],
+            services=[
+                _service_row(1, "ha_handler", {}, enabled=False),
+            ],
+            notifications=[
+                _notification_row(1, "email", {}, enabled=False),
+            ],
+        )
+        orch = Orchestrator(_make_config(), config_store=store)
+        orch._build_infrastructure()
+        await orch._build_db_components()
+
+        assert orch._adapters == []
+        assert orch._handlers == {}
+        assert orch._dispatcher.channels == []
+
+
+class TestMultipleMqttConnectors:
+    async def test_first_used_for_approval_warning_logged(
+        self, caplog: pytest.LogCaptureFixture,
+    ) -> None:
+        store = _mock_store(
+            connectors=[
+                _connector_row(1, "mqtt", {
+                    "broker": "mqtt://broker1:1883",
+                }),
+                _connector_row(2, "mqtt", {
+                    "broker": "mqtt://broker2:1883",
+                }),
+            ],
+        )
+        orch = Orchestrator(_make_config(), config_store=store)
+        orch._build_infrastructure()
+
+        with caplog.at_level(logging.WARNING):
+            await orch._build_db_components()
+
+        assert "multiple mqtt connectors" in caplog.text.lower()
+        assert orch._approval_listener is not None
+
+
+class TestUnknownTypes:
+    def test_unknown_adapter_type_returns_none(self) -> None:
+        orch = Orchestrator(_make_config())
+        orch._build_infrastructure()
+
+        result = orch._build_adapter_from_row("totally_fake_type", {})
+        assert result is None
+
+    def test_handler_from_row_non_handler_type_returns_none(self) -> None:
+        orch = Orchestrator(_make_config())
+
+        result = orch._build_handler_from_row("llm_triage", {
+            "base_url": "http://x", "model": "y", "api_key": "z",
+        })
+        assert result is None
+
+    def test_notification_from_row_unknown_type_returns_none(self) -> None:
+        orch = Orchestrator(_make_config())
+
+        result = orch._build_notification_from_row("nonexistent", {})
+        assert result is None
+
+    def test_webhook_receiver_adapter_returns_none(self) -> None:
+        """webhook_receiver has no adapter class — returns None."""
+        orch = Orchestrator(_make_config())
+        orch._build_infrastructure()
+
+        result = orch._build_adapter_from_row("webhook_receiver", {})
+        assert result is None
+
+
+class TestRegistryModulePaths:
+    def test_all_handler_types_have_module_path(self) -> None:
+        handler_types = {
+            "ha_handler", "docker_handler", "portainer_handler",
+            "proxmox_handler", "unifi_handler", "cloudflare_handler",
+        }
+        for db_type in handler_types:
+            meta = CORE_SERVICE_TYPES[db_type]
+            assert meta.module_path, f"{db_type} missing module_path"
+            assert meta.class_name, f"{db_type} missing class_name"
+
+    def test_infrastructure_types_have_no_module_path(self) -> None:
+        infra_types = {
+            "llm_triage", "llm_reasoning", "llm_options",
+            "influxdb", "guardrails", "circuit_breaker", "scanner",
+        }
+        for db_type in infra_types:
+            meta = CORE_SERVICE_TYPES[db_type]
+            assert meta.module_path == "", f"{db_type} should not have module_path"
+
+    def test_all_notification_types_have_module_path(self) -> None:
+        for db_type, meta in NOTIFICATION_TYPES.items():
+            assert meta.module_path, f"{db_type} missing module_path"
+            assert meta.class_name, f"{db_type} missing class_name"
+
+    def test_connector_types_with_adapters_have_module_path(self) -> None:
+        for db_type, meta in CONNECTOR_TYPES.items():
+            if db_type == "webhook_receiver":
+                assert meta.module_path == ""
+                continue
+            assert meta.module_path, f"{db_type} missing module_path"
+            assert meta.class_name, f"{db_type} missing class_name"

--- a/tests/test_orchestrator_restart.py
+++ b/tests/test_orchestrator_restart.py
@@ -213,7 +213,7 @@ class TestRestartService:
         orch._handlers["homeassistant"] = old_handler
 
         new_handler = _mock_handler("homeassistant")
-        with patch.object(orch, "_build_handler", return_value=new_handler):
+        with patch.object(orch, "_build_handler_from_row", return_value=new_handler):
             result = await orch.restart_service(1)
 
         assert result is True


### PR DESCRIPTION
## Summary

Closes #210.

- **Split `_build_components()`** into `_build_infrastructure()` (sync singletons: queue, correlator, LLM, decision engine, etc.) and `async _build_db_components()` (queries SQLite `connectors`, `core_services`, `notification_channels` tables). `_build_components_from_config()` is a sync fallback when no config store is available (standalone/tests).
- **Extended `TypeMeta`** in `registry.py` with `module_path` and `class_name` fields. Populated for all 18 connector types, 6 handler types, and 6 notification types. Infrastructure types (LLM, guardrails, etc.) and webhook_receiver have empty paths.
- **Added `_build_handler_from_row()` and `_build_notification_from_row()`** that use the registry for class loading via importlib -- no more hardcoded if/elif maps.
- **Refactored `_build_adapter_from_row()`** to use registry `module_path`/`class_name` instead of the 16-entry `adapter_map` dict.
- **Updated `restart_service()` and `restart_notification()`** to use from_row builders -- no more `store.load_config()` round-trip on every restart.
- **DB build order**: connectors (http_poller aggregated) -> handlers -> scanners (cross-ref handler configs) -> notifications -> approval listener (first MQTT, warn if >1).
- **Per-row try/except** so one bad config row never blocks others from starting.
- **Backward-compat `_build_components()`** wrapper kept for existing test callers.
- **26 new tests** covering happy path, fault isolation, HTTP poller aggregation, scanner cross-refs, empty DB, disabled rows, multiple MQTT, unknown types, and registry completeness.

## Test plan

- [x] `pytest --tb=short` -- 2541 tests passing (26 new)
- [x] `ruff check` -- lint clean
- [ ] Deploy -> all UI-created connectors show Connected on startup without manual Restart
- [ ] Restart button still works for individual components
- [ ] Standalone mode (no DB) still works for tests
- [ ] Create a new connector via UI -> auto-starts after next deploy

🤖 Generated with [Claude Code](https://claude.com/claude-code)