### PR TITLE
Add verify_ssl option to Frigate adapter for self-signed certificates

### DIFF
--- a/oasisagent/clients/frigate.py
+++ b/oasisagent/clients/frigate.py
@@ -21,14 +21,20 @@ logger = logging.getLogger(__name__)
 class FrigateClient:
     """Async HTTP client for Frigate NVR API."""
 
-    def __init__(self, url: str, timeout: int = 10) -> None:
+    def __init__(
+        self, url: str, timeout: int = 10, *, verify_ssl: bool = True,
+    ) -> None:
         self._base_url = url.rstrip("/")
         self._timeout = aiohttp.ClientTimeout(total=timeout)
+        self._verify_ssl = verify_ssl
         self._session: aiohttp.ClientSession | None = None
 
     async def start(self) -> None:
         """Create the HTTP session and verify connectivity."""
-        self._session = aiohttp.ClientSession(timeout=self._timeout)
+        connector = aiohttp.TCPConnector(ssl=self._verify_ssl)
+        self._session = aiohttp.ClientSession(
+            timeout=self._timeout, connector=connector,
+        )
         # Verify connectivity with a stats call
         async with self._session.get(f"{self._base_url}/api/stats") as resp:
             resp.raise_for_status()

--- a/oasisagent/config.py
+++ b/oasisagent/config.py
@@ -454,6 +454,7 @@ class FrigateAdapterConfig(BaseModel):
     poll_events: bool = False
     detector_fps_threshold: float = 5.0
     detection_spike_threshold: int = 20
+    verify_ssl: bool = False
     timeout: int = 10
 
 

--- a/oasisagent/ingestion/frigate.py
+++ b/oasisagent/ingestion/frigate.py
@@ -43,6 +43,7 @@ class FrigateAdapter(IngestAdapter):
         self._client = FrigateClient(
             url=config.url,
             timeout=config.timeout,
+            verify_ssl=config.verify_ssl,
         )
         self._stopping = False
         self._task: asyncio.Task[None] | None = None

--- a/oasisagent/ui/form_specs.py
+++ b/oasisagent/ui/form_specs.py
@@ -605,7 +605,7 @@ FORM_SPECS: dict[str, list[FieldSpec]] = {
     "frigate": [
         FieldSpec(
             "url", "Frigate URL", "text",
-            help_text="e.g. http://192.168.1.130:8971",
+            help_text="e.g. https://192.168.1.130:8971",
             required=True,
         ),
         FieldSpec(
@@ -640,6 +640,12 @@ FORM_SPECS: dict[str, list[FieldSpec]] = {
             ),
             default=20, min_val=1,
             group="Thresholds",
+        ),
+        FieldSpec(
+            "verify_ssl", "Verify SSL Certificate",
+            "checkbox",
+            help_text="Disable for self-signed certificates",
+            default=False,
         ),
         FieldSpec(
             "timeout", "Request Timeout (seconds)",


### PR DESCRIPTION
## Summary

- Frigate NVR serves HTTPS only on port 8971 with a self-signed certificate
- Adapter was failing with `SSLCertVerificationError` on every connection attempt
- Added `verify_ssl: bool = False` to `FrigateAdapterConfig` (defaults to disabled, matching UniFi/Proxmox/Portainer pattern)
- `FrigateClient` passes `ssl=verify_ssl` to `aiohttp.TCPConnector`
- UI form spec updated with verify_ssl checkbox and HTTPS URL hint

## Test plan

- [x] 36 Frigate tests pass
- [x] ruff clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)