### PR TITLE
Fix UniFi events 403: detect cascading auth failure in auto-disable

### DIFF
--- a/oasisagent/ingestion/unifi.py
+++ b/oasisagent/ingestion/unifi.py
@@ -765,14 +765,15 @@ class UnifiAdapter(IngestAdapter):
     def _is_unsupported(exc: Exception) -> bool:
         """Return True if the exception indicates an unsupported endpoint.
 
-        Matches 404 (not found) and 403 (forbidden) — both indicate the
-        endpoint is unavailable on this firmware or for this API user.
-        Transient 403s from session expiry are handled by the client's
-        automatic re-auth, so a 403 reaching here means the endpoint
-        itself is inaccessible.
+        Matches three cases:
+        1. ``aiohttp.ClientResponseError`` with status 403 or 404 — the
+           endpoint returned an error directly.
+        2. ``ConnectionError`` from re-auth failure — the endpoint returned
+           403, the client tried to re-authenticate, and re-auth also failed.
+           This cascading failure indicates the endpoint itself is forbidden,
+           not that credentials are wrong (other endpoints work fine).
         """
-        return (
-            isinstance(exc, aiohttp.ClientResponseError)
-            and exc.status in (403, 404)
-        )
+        if isinstance(exc, aiohttp.ClientResponseError) and exc.status in (403, 404):
+            return True
+        return isinstance(exc, ConnectionError) and "login failed (HTTP 403)" in str(exc)
 

--- a/tests/test_ingestion/test_unifi.py
+++ b/tests/test_ingestion/test_unifi.py
@@ -1721,8 +1721,16 @@ class TestAutoDisable404:
         )
         exc_other = RuntimeError("connection lost")
 
+        # ConnectionError from cascading re-auth failure
+        exc_login_403 = ConnectionError(
+            'UniFi login failed (HTTP 403): {"error":{"code":403,"message":"Forbidden"}}',
+        )
+        exc_login_other = ConnectionError("UniFi login failed (HTTP 401): unauthorized")
+
         assert UnifiAdapter._is_unsupported(exc_404) is True
         assert UnifiAdapter._is_unsupported(exc_403) is True
+        assert UnifiAdapter._is_unsupported(exc_login_403) is True
+        assert UnifiAdapter._is_unsupported(exc_login_other) is False
         assert UnifiAdapter._is_unsupported(exc_500) is False
         assert UnifiAdapter._is_unsupported(exc_other) is False
 


### PR DESCRIPTION
## Summary

- `stat/event` POST returns 403 → client retries auth → auth fails with `ConnectionError("UniFi login failed (HTTP 403)")` → cascading failure
- `_is_unsupported()` only matched `aiohttp.ClientResponseError`, so this `ConnectionError` never triggered auto-disable
- Now also matches `ConnectionError` containing `"login failed (HTTP 403)"` — the cascading auth failure from an unsupported endpoint
- After 3 consecutive failures, the events endpoint will auto-disable with a warning log

## Root cause

The UniFi client's `request()` method sees a 403 from the POST and assumes session expired → calls `_authenticate()` → re-auth itself gets 403 (session poisoned by bad POST) → raises `ConnectionError`, not `ClientResponseError`. The auto-disable check was only looking for `ClientResponseError`.

## Test plan

- [x] `test_is_unsupported_detection` updated: verifies `ConnectionError("login failed (HTTP 403)")` matches, `ConnectionError("login failed (HTTP 401)")` does not
- [x] All 96 UniFi tests pass
- [x] ruff clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)