### PR TITLE
Fix Add Node modal and add container type to service map

### DIFF
--- a/oasisagent/ui/static/service_map.js
+++ b/oasisagent/ui/static/service_map.js
@@ -24,6 +24,7 @@
     host: "#6b7280",
     proxy: "#f97316",
     monitor: "#a855f7",
+    container: "#06b6d4",
   };
 
   var DEFAULT_COLOR = "#94a3b8";
@@ -452,6 +453,7 @@
       '    <select name="entity_type" class="block w-full rounded border-gray-300 text-sm py-1.5 px-2">' +
       '      <option value="service"' + (d.type === "service" ? " selected" : "") + ">Service</option>" +
       '      <option value="host"' + (d.type === "host" ? " selected" : "") + ">Host</option>" +
+      '      <option value="container"' + (d.type === "container" ? " selected" : "") + ">Container</option>" +
       '      <option value="network_device"' + (d.type === "network_device" ? " selected" : "") + ">Network Device</option>" +
       '      <option value="proxy"' + (d.type === "proxy" ? " selected" : "") + ">Proxy</option>" +
       '      <option value="monitor"' + (d.type === "monitor" ? " selected" : "") + ">Monitor</option>" +

--- a/oasisagent/ui/templates/service_map/index.html
+++ b/oasisagent/ui/templates/service_map/index.html
@@ -109,6 +109,10 @@
                 <span class="w-3 h-3 rounded-full inline-block" style="background: #a855f7;"></span>
                 Monitor
             </span>
+            <span class="flex items-center gap-1">
+                <span class="w-3 h-3 rounded-full inline-block" style="background: #06b6d4;"></span>
+                Container
+            </span>
             <span class="ml-4 flex items-center gap-1">
                 <span class="w-3 h-3 rounded-full inline-block border-2 border-dashed border-gray-400 bg-transparent"></span>
                 Manual
@@ -122,7 +126,7 @@
 </div>
 
 <!-- Add Node Modal -->
-<div id="add-node-modal" class="fixed inset-0 bg-black bg-opacity-50 z-50 hidden items-center justify-center"
+<div id="add-node-modal" class="fixed inset-0 bg-black bg-opacity-50 z-50 flex items-center justify-center"
      x-data="{ show: false }" x-show="show" x-transition x-cloak
      @open-add-node.window="show = true" @click.self="show = false" @keydown.escape.window="show = false">
     <div class="bg-white rounded-lg shadow-xl p-6 w-96" @click.stop>
@@ -143,6 +147,7 @@
                 <select name="entity_type" class="block w-full rounded border-gray-300 text-sm py-1.5 px-2">
                     <option value="service">Service</option>
                     <option value="host">Host</option>
+                    <option value="container">Container</option>
                     <option value="network_device">Network Device</option>
                     <option value="proxy">Proxy</option>
                     <option value="monitor">Monitor</option>


### PR DESCRIPTION
## Summary
- **Fix: Add Node modal never opens** — The modal div had `class="hidden"` which applies CSS `display: none`, overriding Alpine.js `x-show` (Alpine removes inline styles but can't override class-based display). Replaced `hidden` with `flex` so `x-show` + `x-cloak` correctly control visibility.
- **Add "container" entity type** — Portainer adapter discovers `container` type nodes but the service map had no color, legend entry, or dropdown option for them. Added cyan (#06b6d4) to `TYPE_COLORS`, legend bar, and both add/edit type dropdowns.

### Topology completeness note
The service map currently shows only disconnected "service" nodes because most adapters (Plex, Tdarr, Sonarr, etc.) can only discover themselves — they poll via HTTP and have no knowledge of their host infrastructure. Rich topology (hosts, network devices, proxies, containers, edges) comes from infrastructure adapters: Proxmox, UniFi, NPM, and now Portainer. When those are connected and healthy, the map will show the full stack with connections.

## Test plan
- [x] 2748 tests passing, 0 regressions
- [x] 22 service map tests pass
- [ ] Manual: click Add Node → modal opens, create a node → appears on map
- [ ] Manual: Portainer containers appear as cyan dots with "container" label in legend
- [ ] Manual: edit a node → Container option available in type dropdown


🤖 Generated with [Claude Code](https://claude.com/claude-code)