### PR TITLE
Fix connector create 500 on float-formatted form values

### DIFF
--- a/oasisagent/ui/form_specs.py
+++ b/oasisagent/ui/form_specs.py
@@ -961,12 +961,12 @@ FORM_SPECS: dict[str, list[FieldSpec]] = {
         ),
         FieldSpec(
             "cpu_threshold", "CPU Alert Threshold (%)",
-            "number", default=90.0, min_val=0, max_val=100,
+            "float", default=90.0, min_val=0, max_val=100,
             group="Thresholds",
         ),
         FieldSpec(
             "memory_threshold", "Memory Alert Threshold (%)",
-            "number", default=90.0, min_val=0, max_val=100,
+            "float", default=90.0, min_val=0, max_val=100,
             group="Thresholds",
         ),
     ],

--- a/oasisagent/ui/routes/connectors.py
+++ b/oasisagent/ui/routes/connectors.py
@@ -97,7 +97,7 @@ def _parse_form_config(
                 if spec.default is not None:
                     config[spec.name] = spec.default
                 continue
-            config[spec.name] = int(value)
+            config[spec.name] = int(float(value))
             continue
 
         if spec.input_type == "float":
@@ -262,9 +262,9 @@ def _build_ui_crud(
             raise HTTPException(status_code=422, detail=f"Unknown type: {type_name}")
 
         specs = get_form_specs(type_name)
-        config = _parse_form_config(form_data, specs, is_edit=False)
 
         try:
+            config = _parse_form_config(form_data, specs, is_edit=False)
             await getattr(store, create_method)(type_name, name, config)
         except (ValueError, ValidationError) as exc:
             errors = (
@@ -387,12 +387,11 @@ def _build_ui_crud(
         type_name = existing["type"]
         name = str(form_data.get("name", existing["name"])).strip()
         specs = get_form_specs(type_name)
-        config = _parse_form_config(form_data, specs, is_edit=True)
-
-        # Build the update payload
-        updates: dict[str, Any] = {"name": name, "config": config}
 
         try:
+            config = _parse_form_config(form_data, specs, is_edit=True)
+            # Build the update payload
+            updates: dict[str, Any] = {"name": name, "config": config}
             result = await getattr(store, update_method)(row_id, updates)
         except (ValueError, ValidationError) as exc:
             errors = (


### PR DESCRIPTION
## Summary
- **Root cause**: Proxmox form specs defined `cpu_threshold` and `memory_threshold` as `input_type="number"` with float defaults (`90.0`). The browser renders `<input type="number" value="90.0">` and submits the string `"90.0"`. `_parse_form_config` calls `int("90.0")` which raises `ValueError` — and this call was **outside** the try/except block, causing an unhandled 500 Internal Server Error.
- **Fix 1**: Change Proxmox threshold fields from `"number"` to `"float"` input type (matches UniFi and Portainer which already use `"float"` for the same fields)
- **Fix 2**: Harden `_parse_form_config` to use `int(float(value))` for `"number"` fields as defense in depth
- **Fix 3**: Move `_parse_form_config` call inside the try/except in both create and update handlers so future parsing errors render as form validation errors instead of 500s

## Test plan
- [x] `ruff check` clean
- [x] 2748 tests passing, 0 regressions
- [x] 320 CRUD + form spec tests pass
- [ ] Manual: create Proxmox VE connector with default thresholds (90.0) → succeeds, redirects to list


🤖 Generated with [Claude Code](https://claude.com/claude-code)