### PR TITLE
Fix Portainer handler passing entity prefix as container ID

### DIFF
--- a/oasisagent/handlers/portainer.py
+++ b/oasisagent/handlers/portainer.py
@@ -179,7 +179,7 @@ class PortainerHandler(Handler):
         container_id = (
             result.details.get("container_id")
             or action.params.get("container_id")
-            or event.entity_id
+            or self._extract_container_id(event.entity_id)
         )
 
         expected = ("exited", "stopped") if action.operation == "stop_container" else ("running",)
@@ -196,7 +196,7 @@ class PortainerHandler(Handler):
         """
         self._ensure_started()
         context: dict[str, Any] = {}
-        container_id = event.entity_id
+        container_id = self._extract_container_id(event.entity_id)
         prefix = self._docker_prefix_for(event)
 
         try:
@@ -278,7 +278,10 @@ class PortainerHandler(Handler):
         self, event: Event, action: RecommendedAction,
     ) -> ActionResult:
         """Restart a container via Portainer-proxied Docker API."""
-        container_id = action.params.get("container_id") or event.entity_id
+        container_id = (
+            action.params.get("container_id")
+            or self._extract_container_id(event.entity_id)
+        )
         if not container_id:
             return ActionResult(
                 status=ActionStatus.FAILURE,
@@ -302,7 +305,10 @@ class PortainerHandler(Handler):
         self, event: Event, action: RecommendedAction,
     ) -> ActionResult:
         """Stop a container via Portainer-proxied Docker API."""
-        container_id = action.params.get("container_id") or event.entity_id
+        container_id = (
+            action.params.get("container_id")
+            or self._extract_container_id(event.entity_id)
+        )
         if not container_id:
             return ActionResult(
                 status=ActionStatus.FAILURE,
@@ -332,7 +338,10 @@ class PortainerHandler(Handler):
         self, event: Event, action: RecommendedAction,
     ) -> ActionResult:
         """Start a container via Portainer-proxied Docker API."""
-        container_id = action.params.get("container_id") or event.entity_id
+        container_id = (
+            action.params.get("container_id")
+            or self._extract_container_id(event.entity_id)
+        )
         if not container_id:
             return ActionResult(
                 status=ActionStatus.FAILURE,
@@ -356,7 +365,10 @@ class PortainerHandler(Handler):
         self, event: Event, action: RecommendedAction,
     ) -> ActionResult:
         """Fetch container logs via Portainer-proxied Docker API."""
-        container_id = action.params.get("container_id") or event.entity_id
+        container_id = (
+            action.params.get("container_id")
+            or self._extract_container_id(event.entity_id)
+        )
         if not container_id:
             return ActionResult(
                 status=ActionStatus.FAILURE,
@@ -382,7 +394,10 @@ class PortainerHandler(Handler):
         self, event: Event, action: RecommendedAction,
     ) -> ActionResult:
         """Fetch container stats via Portainer-proxied Docker API."""
-        container_id = action.params.get("container_id") or event.entity_id
+        container_id = (
+            action.params.get("container_id")
+            or self._extract_container_id(event.entity_id)
+        )
         if not container_id:
             return ActionResult(
                 status=ActionStatus.FAILURE,
@@ -407,7 +422,10 @@ class PortainerHandler(Handler):
         self, event: Event, action: RecommendedAction,
     ) -> ActionResult:
         """Inspect a container via Portainer-proxied Docker API."""
-        container_id = action.params.get("container_id") or event.entity_id
+        container_id = (
+            action.params.get("container_id")
+            or self._extract_container_id(event.entity_id)
+        )
         if not container_id:
             return ActionResult(
                 status=ActionStatus.FAILURE,
@@ -452,6 +470,16 @@ class PortainerHandler(Handler):
     # -------------------------------------------------------------------
     # Internal helpers
     # -------------------------------------------------------------------
+
+    @staticmethod
+    def _extract_container_id(entity_id: str) -> str:
+        """Strip ``portainer:endpoint/`` prefix from entity_id.
+
+        Adapter entity_ids use format ``portainer:{endpoint}/{container}``.
+        The Docker API expects just the container name or ID.
+        Returns the input unchanged if there's no ``/`` separator.
+        """
+        return entity_id.rsplit("/", 1)[-1] if "/" in entity_id else entity_id
 
     def _ensure_started(self) -> None:
         """Raise if the handler hasn't been started."""

--- a/tests/test_handlers/test_portainer.py
+++ b/tests/test_handlers/test_portainer.py
@@ -669,6 +669,58 @@ class TestVerify:
 # ---------------------------------------------------------------------------
 
 
+class TestExtractContainerId:
+    """Test _extract_container_id strips portainer:endpoint/ prefix."""
+
+    def test_prefixed_entity_id(self) -> None:
+        result = PortainerHandler._extract_container_id(
+            "portainer:Swarm (mix of nodes)/mediastack_radarr1.1.abc123",
+        )
+        assert result == "mediastack_radarr1.1.abc123"
+
+    def test_simple_prefix(self) -> None:
+        result = PortainerHandler._extract_container_id(
+            "portainer:local/my_container",
+        )
+        assert result == "my_container"
+
+    def test_bare_container_name(self) -> None:
+        result = PortainerHandler._extract_container_id("my_container")
+        assert result == "my_container"
+
+    def test_empty_string(self) -> None:
+        result = PortainerHandler._extract_container_id("")
+        assert result == ""
+
+    def test_container_id_with_no_slash(self) -> None:
+        result = PortainerHandler._extract_container_id("portainer:abc123")
+        assert result == "portainer:abc123"
+
+    @pytest.mark.asyncio
+    async def test_restart_uses_extracted_id(self) -> None:
+        """Regression: restart_container must strip entity prefix."""
+        handler = PortainerHandler(_make_config())
+        handler._session = AsyncMock()
+
+        mock_resp = AsyncMock()
+        mock_resp.raise_for_status = MagicMock()
+        mock_resp.__aenter__ = AsyncMock(return_value=mock_resp)
+        mock_resp.__aexit__ = AsyncMock(return_value=False)
+        handler._session.post = MagicMock(return_value=mock_resp)
+
+        event = _make_event(
+            entity_id="portainer:Swarm (nodes)/mediastack_radarr1.1.xyz",
+        )
+        action = _make_action(operation="restart_container", params={})
+
+        result = await handler._op_restart_container(event, action)
+
+        assert result.status == ActionStatus.SUCCESS
+        call_url = handler._session.post.call_args[0][0]
+        assert "mediastack_radarr1.1.xyz" in call_url
+        assert "Swarm" not in call_url
+
+
 class TestDockerPrefixRouting:
     """Test multi-endpoint routing via _docker_prefix_for()."""
 


### PR DESCRIPTION
## Summary
- Adds `_extract_container_id()` helper that strips `portainer:endpoint/` prefix from entity_id using `rsplit("/", 1)[-1]`
- Applied to all 8 callsites: 6 operation methods (`restart`, `stop`, `start`, `get_logs`, `get_stats`, `inspect`), `verify()`, and `get_context()`
- `_op_list_containers` and `_op_notify` don't use container_id — not affected
- `get_context_for_entity()` already had correct parsing — this fixes the remaining paths
- Docker handler checked: uses bare container names, not affected

Closes #236

## Test plan
- [x] `ruff check .` — clean
- [x] 6 new tests: prefixed ID, simple prefix, bare name, empty string, no-slash, regression (restart with prefix)
- [x] 52 Portainer handler tests passing

🤖 Generated with [Claude Code](https://claude.com/claude-code)