### PR TITLE
Fix UniFi topology, add periodic pruning and service-container linking

### DIFF
--- a/oasisagent/db/topology_store.py
+++ b/oasisagent/db/topology_store.py
@@ -194,12 +194,12 @@ class TopologyStore:
 
     async def prune_stale_nodes(
         self, max_age_seconds: int, entity_type: str | None = None,
-    ) -> int:
+    ) -> list[str]:
         """Delete auto-discovered nodes not seen within *max_age_seconds*.
 
         Also deletes all edges referencing pruned nodes.
         Manually edited nodes are never pruned.
-        Returns count of nodes deleted.
+        Returns list of pruned entity IDs.
         """
         cutoff = datetime.now(UTC).isoformat()
         # Nodes with NULL last_seen are considered stale
@@ -218,7 +218,7 @@ class TopologyStore:
             params,
         )
         if not rows:
-            return 0
+            return []
 
         ids = [r[0] for r in rows]
         placeholders = ",".join("?" for _ in ids)
@@ -230,12 +230,12 @@ class TopologyStore:
             ids + ids,
         )
         # Delete the nodes
-        cursor = await self._db.execute(
+        await self._db.execute(
             f"DELETE FROM topology_nodes WHERE entity_id IN ({placeholders})",
             ids,
         )
         await self._db.commit()
-        return cursor.rowcount
+        return ids
 
     # -------------------------------------------------------------------
     # Helpers

--- a/oasisagent/engine/service_graph.py
+++ b/oasisagent/engine/service_graph.py
@@ -130,6 +130,35 @@ class ServiceGraph:
 
         return diffs
 
+    async def remove_pruned(
+        self,
+        pruned_ids: list[str],
+        store: TopologyStore,
+    ) -> list[TopologyDiff]:
+        """Remove pruned nodes from the in-memory graph.
+
+        Called after ``TopologyStore.prune_stale_nodes()`` deletes from
+        SQLite. Removes nodes from ``_nodes``, reloads edges from the
+        store (pruning already deleted referencing edges), and rebuilds
+        all four indexes.
+        """
+        diffs: list[TopologyDiff] = []
+        for entity_id in pruned_ids:
+            node = self._nodes.pop(entity_id, None)
+            if node:
+                diffs.append(TopologyDiff(
+                    action="pruned",
+                    entity_type="node",
+                    entity_id=entity_id,
+                    details=f"{node.entity_type}: {node.display_name}",
+                ))
+
+        if diffs:
+            self._edges = await store.list_edges()
+            self._rebuild_indexes()
+
+        return diffs
+
     def detect_stale(
         self, max_missed_cycles: int = 3, cycle_seconds: int = 300,
     ) -> list[TopologyDiff]:
@@ -259,7 +288,7 @@ class ServiceGraph:
         for edge in self._edges:
             if edge.edge_type in (
                 "depends_on", "proxies_to", "runs_on", "connects_via",
-                "forwards_to", "resolves_via",
+                "forwards_to", "resolves_via", "runs_in",
             ):
                 self._entity_to_deps.setdefault(edge.from_entity, []).append(
                     edge.to_entity

--- a/oasisagent/ingestion/npm.py
+++ b/oasisagent/ingestion/npm.py
@@ -403,8 +403,8 @@ class NpmAdapter(IngestAdapter):
 
         try:
             data = await self._client.get("/api/nginx/proxy-hosts")
-        except Exception:
-            logger.debug("NPM topology discovery failed (API unreachable)")
+        except Exception as exc:
+            logger.warning("NPM topology discovery failed: %s", exc)
             return [], []
 
         hosts: list[dict[str, Any]] = data if isinstance(data, list) else []

--- a/oasisagent/ingestion/unifi.py
+++ b/oasisagent/ingestion/unifi.py
@@ -791,10 +791,10 @@ class UnifiAdapter(IngestAdapter):
         now = datetime.now(UTC)
 
         try:
-            resp = await self._client.get("/api/s/{site}/stat/device")
+            resp = await self._client.get("stat/device")
             devices: list[dict[str, Any]] = resp.get("data", [])
-        except Exception:
-            logger.debug("UniFi topology discovery failed (API unreachable)")
+        except Exception as exc:
+            logger.warning("UniFi topology discovery failed: %s", exc)
             return [], []
 
         for dev in devices:

--- a/oasisagent/models.py
+++ b/oasisagent/models.py
@@ -394,7 +394,7 @@ class TopologyDiff(BaseModel):
 
     model_config = ConfigDict(extra="forbid")
 
-    action: Literal["added", "updated", "stale"]
+    action: Literal["added", "updated", "stale", "pruned"]
     entity_type: Literal["node", "edge"]
     entity_id: str  # node entity_id or "from->to" for edges
     details: str = ""

--- a/oasisagent/orchestrator.py
+++ b/oasisagent/orchestrator.py
@@ -1594,6 +1594,79 @@ class Orchestrator:
 
         return edges
 
+    @staticmethod
+    def _synthesize_service_container_edges(
+        nodes: list[object],
+    ) -> list[object]:
+        """Create ``runs_in`` edges linking service nodes to containers.
+
+        When an adapter discovers a service node (e.g. ``plex:plex``)
+        and Portainer discovers a container whose name contains that
+        service name, link them with a ``runs_in`` edge.
+
+        Uses word-boundary matching against container ``display_name``
+        and Docker ``image`` metadata to avoid false positives.
+        """
+        import re
+
+        from oasisagent.models import TopologyEdge
+
+        services = [n for n in nodes if n.entity_type == "service"]
+        containers = [n for n in nodes if n.entity_type == "container"]
+
+        if not services or not containers:
+            return []
+
+        now = datetime.now(UTC)
+        edges: list[TopologyEdge] = []
+
+        for svc in services:
+            # Extract match key from entity_id (e.g. "plex" from "plex:plex")
+            key = svc.entity_id.split(":")[-1] if ":" in svc.entity_id else ""
+            if not key:
+                continue
+
+            # For servarr adapters, also try the bare app type
+            # e.g. "servarr_sonarr" → also try "sonarr"
+            keys = [key]
+            if "_" in key:
+                keys.append(key.split("_", 1)[-1])
+
+            # Build word-boundary patterns (space included for
+            # matching inside "display_name image" combined text)
+            patterns = [re.compile(r"(?:^|[_.\-/ ])" + re.escape(k)
+                                   + r"(?:$|[_.\-/\d: ])", re.IGNORECASE)
+                        for k in keys]
+
+            best_match = None
+            for ct in containers:
+                # Search in display_name and image metadata
+                search_text = ct.display_name or ""
+                image = (ct.metadata or {}).get("image", "")
+                if isinstance(image, str):
+                    search_text += " " + image
+
+                for pat in patterns:
+                    if pat.search(search_text):
+                        # Prefer same-IP match
+                        if svc.host_ip and ct.host_ip == svc.host_ip:
+                            best_match = ct
+                            break
+                        if best_match is None:
+                            best_match = ct
+                        break
+
+            if best_match is not None:
+                edges.append(TopologyEdge(
+                    from_entity=svc.entity_id,
+                    to_entity=best_match.entity_id,
+                    edge_type="runs_in",
+                    source="auto:service_synthesis",
+                    last_seen=now,
+                ))
+
+        return edges
+
     async def _run_topology_discovery(self) -> None:
         """Periodically discover topology from all adapters.
 
@@ -1615,14 +1688,14 @@ class Orchestrator:
 
         # Prune stale container/stack nodes not seen in 2 discovery cycles
         stale_age = interval * 2
-        pruned = await self._topology_store.prune_stale_nodes(
+        pruned_ids = await self._topology_store.prune_stale_nodes(
             max_age_seconds=stale_age, entity_type="container",
         )
-        pruned += await self._topology_store.prune_stale_nodes(
+        pruned_ids += await self._topology_store.prune_stale_nodes(
             max_age_seconds=stale_age, entity_type="stack",
         )
-        if pruned:
-            logger.info("Pruned %d stale topology nodes", pruned)
+        if pruned_ids:
+            logger.info("Pruned %d stale topology nodes on startup", len(pruned_ids))
 
         # Wait for adapters to establish connections
         await asyncio.sleep(30)
@@ -1636,15 +1709,23 @@ class Orchestrator:
                         nodes, edges = await adapter.discover_topology()
                         all_nodes.extend(nodes)
                         all_edges.extend(edges)
-                    except Exception:
-                        logger.debug(
-                            "Topology discovery failed for %s", adapter.name
+                    except Exception as exc:
+                        logger.warning(
+                            "Topology discovery failed for %s: %s",
+                            adapter.name, exc,
                         )
 
                 # Cross-adapter IP synthesis: link nodes from different
                 # adapters that share a host_ip
                 ip_synth_edges = self._synthesize_ip_edges(all_nodes)
                 all_edges.extend(ip_synth_edges)
+
+                # Service-container synthesis: link adapter service nodes
+                # to Portainer containers by name matching
+                svc_synth_edges = self._synthesize_service_container_edges(
+                    all_nodes,
+                )
+                all_edges.extend(svc_synth_edges)
 
                 if all_nodes or all_edges:
                     diffs = await self._service_graph.merge_discovered(
@@ -1657,6 +1738,22 @@ class Orchestrator:
                             len(all_nodes),
                             len(all_edges),
                         )
+
+                # Prune stale container/stack nodes not seen in 2 cycles
+                stale_age = interval * 2
+                pruned_ids = await self._topology_store.prune_stale_nodes(
+                    max_age_seconds=stale_age, entity_type="container",
+                )
+                pruned_ids += await self._topology_store.prune_stale_nodes(
+                    max_age_seconds=stale_age, entity_type="stack",
+                )
+                if pruned_ids:
+                    await self._service_graph.remove_pruned(
+                        pruned_ids, self._topology_store,
+                    )
+                    logger.info(
+                        "Pruned %d stale topology nodes", len(pruned_ids),
+                    )
 
             except asyncio.CancelledError:
                 return

--- a/oasisagent/ui/static/service_map.js
+++ b/oasisagent/ui/static/service_map.js
@@ -41,6 +41,7 @@
     connects_via: "#6b7280",
     member_of: "#14b8a6",
     hosted_by: "#6b7280",
+    runs_in: "#22c55e",
   };
 
   var DEFAULT_COLOR = "#94a3b8";

--- a/tests/test_orchestrator.py
+++ b/tests/test_orchestrator.py
@@ -1092,3 +1092,131 @@ class TestIPSynthesis:
 
         # Same adapter — no synthesis needed
         assert len(edges) == 0
+
+
+class TestServiceContainerSynthesis:
+    """Tests for service-to-container name matching."""
+
+    def test_links_plex_service_to_container(self) -> None:
+        from oasisagent.models import TopologyNode
+        from oasisagent.orchestrator import Orchestrator
+
+        nodes = [
+            TopologyNode(
+                entity_id="plex:plex", entity_type="service",
+                display_name="Plex", source="auto:plex",
+            ),
+            TopologyNode(
+                entity_id="portainer:Swarm/mediastack_plex.1.abc123",
+                entity_type="container",
+                display_name="mediastack_plex.1.abc123",
+                source="auto:portainer",
+                metadata={"image": "plexinc/pms-docker"},
+            ),
+        ]
+
+        edges = Orchestrator._synthesize_service_container_edges(nodes)
+
+        assert len(edges) == 1
+        assert edges[0].from_entity == "plex:plex"
+        assert edges[0].to_entity == "portainer:Swarm/mediastack_plex.1.abc123"
+        assert edges[0].edge_type == "runs_in"
+
+    def test_links_servarr_to_sonarr_container(self) -> None:
+        from oasisagent.models import TopologyNode
+        from oasisagent.orchestrator import Orchestrator
+
+        nodes = [
+            TopologyNode(
+                entity_id="servarr_sonarr:servarr_sonarr",
+                entity_type="service",
+                display_name="Sonarr", source="auto:servarr",
+            ),
+            TopologyNode(
+                entity_id="portainer:Swarm/mediastack_sonarr1.1.xyz",
+                entity_type="container",
+                display_name="mediastack_sonarr1.1.xyz",
+                source="auto:portainer",
+                metadata={"image": "linuxserver/sonarr"},
+            ),
+        ]
+
+        edges = Orchestrator._synthesize_service_container_edges(nodes)
+
+        assert len(edges) == 1
+        assert edges[0].to_entity == "portainer:Swarm/mediastack_sonarr1.1.xyz"
+
+    def test_no_match_returns_empty(self) -> None:
+        from oasisagent.models import TopologyNode
+        from oasisagent.orchestrator import Orchestrator
+
+        nodes = [
+            TopologyNode(
+                entity_id="custom:myapp", entity_type="service",
+                display_name="My App", source="auto:custom",
+            ),
+            TopologyNode(
+                entity_id="portainer:Swarm/nginx.1.abc",
+                entity_type="container",
+                display_name="nginx.1.abc",
+                source="auto:portainer",
+            ),
+        ]
+
+        edges = Orchestrator._synthesize_service_container_edges(nodes)
+
+        assert len(edges) == 0
+
+    def test_image_fallback_match(self) -> None:
+        from oasisagent.models import TopologyNode
+        from oasisagent.orchestrator import Orchestrator
+
+        nodes = [
+            TopologyNode(
+                entity_id="vaultwarden:vaultwarden",
+                entity_type="service",
+                display_name="Vaultwarden", source="auto:vaultwarden",
+            ),
+            TopologyNode(
+                entity_id="portainer:Swarm/bitwarden.1.xyz",
+                entity_type="container",
+                display_name="bitwarden.1.xyz",
+                source="auto:portainer",
+                metadata={"image": "vaultwarden/server:latest"},
+            ),
+        ]
+
+        edges = Orchestrator._synthesize_service_container_edges(nodes)
+
+        assert len(edges) == 1
+        assert edges[0].to_entity == "portainer:Swarm/bitwarden.1.xyz"
+
+    def test_prefers_same_ip(self) -> None:
+        from oasisagent.models import TopologyNode
+        from oasisagent.orchestrator import Orchestrator
+
+        nodes = [
+            TopologyNode(
+                entity_id="plex:plex", entity_type="service",
+                display_name="Plex", host_ip="10.0.0.1",
+                source="auto:plex",
+            ),
+            TopologyNode(
+                entity_id="portainer:host-a/plex.1.aaa",
+                entity_type="container",
+                display_name="plex.1.aaa", host_ip="10.0.0.2",
+                source="auto:portainer",
+            ),
+            TopologyNode(
+                entity_id="portainer:host-b/plex.1.bbb",
+                entity_type="container",
+                display_name="plex.1.bbb", host_ip="10.0.0.1",
+                source="auto:portainer",
+            ),
+        ]
+
+        edges = Orchestrator._synthesize_service_container_edges(nodes)
+
+        assert len(edges) == 1
+        # Should prefer the container on the same IP
+        assert edges[0].to_entity == "portainer:host-b/plex.1.bbb"


### PR DESCRIPTION
## Summary

Three topology improvements in one PR:

- **#251 — UniFi topology bug**: `discover_topology()` used `"/api/s/{site}/stat/device"` (literal string, double path prefix). Fixed to `"stat/device"` matching the working `_poll_devices()`. All discovery error logs upgraded from DEBUG to WARNING.
- **#249 — Periodic pruning**: `prune_stale_nodes()` now runs every discovery cycle (not just startup). Returns `list[str]` of pruned IDs. New `ServiceGraph.remove_pruned()` syncs in-memory graph (all 4 data structures). Added `"pruned"` to `TopologyDiff.action`.
- **#250 — Service-container linking**: New `_synthesize_service_container_edges()` matches service nodes (Plex, Sonarr, Vaultwarden, etc.) to Portainer containers via word-boundary regex on display_name + image metadata. Creates `runs_in` edges. IP tiebreaker for multi-host.

Closes #249, closes #250, closes #251

## Test plan

- [x] `ruff check .` — clean
- [x] 3026 tests passing (+5 new: service linking, image fallback, IP tiebreaker, no-match, servarr compound names)
- [ ] Deploy — verify UniFi network devices appear in service map
- [ ] Verify stale nodes get pruned each discovery cycle (check logs)
- [ ] Verify service nodes (Plex, Sonarr, etc.) connect to their containers via green `runs_in` edges


🤖 Generated with [Claude Code](https://claude.com/claude-code)